### PR TITLE
fix: stabilize FAME metadata and Farcaster loading

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -39,6 +39,12 @@ module.exports = {
         hostname: "gateway.irys.xyz",
       },
       {
+        hostname: "arweave.net",
+      },
+      {
+        hostname: "**.arweave.net",
+      },
+      {
         hostname: "onchaingas.vercel.app",
       },
       {

--- a/src/app/fame/creator/[address]/CreatorPortal.tsx
+++ b/src/app/fame/creator/[address]/CreatorPortal.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useAccount } from "@/hooks/useAccount";
 import { useRouter } from "next/navigation";
 import { useHasCreatorRole } from "./useHasCreatorRole";
@@ -30,11 +30,12 @@ export function CreatorPortal({
   const roles = useHasCreatorRole(address);
   const [selectedTokenId, setSelectedTokenId] = useState<bigint | null>(null);
 
-  // Redirect if not connected or not the correct address
-  if (!connectedAddress || connectedAddress !== address) {
-    router.push("/fame/creator");
-    return null;
-  }
+  useEffect(() => {
+    // Redirect if not connected or not the correct address
+    if (!connectedAddress || connectedAddress !== address) {
+      router.push("/fame/creator");
+    }
+  }, [connectedAddress, address, router]);
 
   // Redirect if user has no relevant roles
   const hasAnyRole = !!(

--- a/src/app/fame/creator/[address]/SelectableGrid.tsx
+++ b/src/app/fame/creator/[address]/SelectableGrid.tsx
@@ -5,6 +5,11 @@ import { readContract } from "viem/actions";
 import { creatorArtistMagicAddress } from "@/features/fame/contract";
 import { base } from "viem/chains";
 import { creatorArtistMagicAbi } from "@/wagmi";
+import {
+  FAME_METADATA_FALLBACK_IMAGE,
+  fameMetadataFetchUrls,
+  imageFromFameMetadata,
+} from "@/service/fameMetadata";
 
 export const SelectableGrid = ({
   tokenIds,
@@ -25,20 +30,39 @@ export const SelectableGrid = ({
 }) => {
   const client = useClient();
   const [images, setImages] = useState<Record<number, string>>({});
+  const fetchMetadataImage = useCallback(async (uri: string) => {
+    let lastError: unknown = null;
+    for (const fetchUrl of fameMetadataFetchUrls(uri)) {
+      try {
+        const response = await fetch(fetchUrl);
+        if (!response.ok) {
+          throw new Error(
+            `Metadata request failed with ${response.status} ${response.statusText}`,
+          );
+        }
+
+        return imageFromFameMetadata(await response.json());
+      } catch (error) {
+        lastError = error;
+      }
+    }
+
+    throw lastError instanceof Error
+      ? lastError
+      : new Error("Failed to fetch metadata image");
+  }, []);
   const fetchImage = useCallback(
     async (tokenId: bigint) => {
-      const tokenIdIndex = Number(tokenId);
       if (!client) throw new Error("Client not available");
-      const response = await readContract(client, {
+      const uri = await readContract(client, {
         address: creatorArtistMagicAddress(base.id),
         abi: creatorArtistMagicAbi,
         functionName: "tokenURI",
         args: [tokenId],
-      }).then((uri) => fetch(uri));
-      const { image } = await response.json();
-      return image;
+      });
+      return fetchMetadataImage(uri);
     },
-    [client],
+    [client, fetchMetadataImage],
   );
 
   useEffect(() => {
@@ -52,7 +76,16 @@ export const SelectableGrid = ({
         (tokenId) => !poolIds.has(Number(tokenId)),
       );
       const imagePromises = idsToFetch.map(async (tokenId) => {
-        const image = await fetchImage(tokenId);
+        let image: string;
+        try {
+          image = await fetchImage(tokenId);
+        } catch (error) {
+          console.warn(
+            `Failed to fetch metadata for token ${tokenId.toString()}:`,
+            error,
+          );
+          image = FAME_METADATA_FALLBACK_IMAGE;
+        }
         return { tokenId: Number(tokenId), image };
       });
       const results = await Promise.all(imagePromises);
@@ -66,10 +99,10 @@ export const SelectableGrid = ({
     setImages((prev) => {
       const updatedImages = { ...prev };
       burnPool?.forEach(({ tokenId, uri }) => {
-        updatedImages[Number(tokenId)] = uri;
+        updatedImages[Number(tokenId)] = uri || FAME_METADATA_FALLBACK_IMAGE;
       });
       mintPool?.forEach(({ tokenId, uri }) => {
-        updatedImages[Number(tokenId)] = uri;
+        updatedImages[Number(tokenId)] = uri || FAME_METADATA_FALLBACK_IMAGE;
       });
       return updatedImages;
     });
@@ -81,7 +114,7 @@ export const SelectableGrid = ({
         <SelectableToken
           key={tokenId.toString()}
           tokenId={tokenId}
-          imageUrl={images[Number(tokenId)] || ""}
+          imageUrl={images[Number(tokenId)] || FAME_METADATA_FALLBACK_IMAGE}
           onTokenSelected={onTokenSelected}
           onTokenUnselected={onTokenUnselected}
           isSelected={selectedTokenIds.includes(tokenId)}

--- a/src/context/Wagmi.tsx
+++ b/src/context/Wagmi.tsx
@@ -7,10 +7,10 @@ import {
   createConfig,
   cookieStorage,
   createStorage,
+  type CreateConnectorFn,
 } from "wagmi";
-import { farcasterMiniApp as miniAppConnector } from "@farcaster/miniapp-wagmi-connector";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { FC, PropsWithChildren, useMemo } from "react";
+import { FC, PropsWithChildren, useEffect, useMemo, useState } from "react";
 import { SiweMessage } from "siwe";
 import {
   ConnectKitProvider,
@@ -110,6 +110,10 @@ const siweConfig = {
 
 const queryClient = new QueryClient();
 
+type MiniAppConnectorModule = {
+  farcasterMiniApp: () => CreateConnectorFn;
+};
+
 export const Web3Provider: FC<
   PropsWithChildren<{
     siwe?: boolean;
@@ -117,12 +121,38 @@ export const Web3Provider: FC<
     chains: readonly [Chain, ...Chain[]];
   }>
 > = ({ children, siwe = false, transports, chains }) => {
+  const [miniAppConnector, setMiniAppConnector] =
+    useState<CreateConnectorFn | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadMiniAppConnector = async () => {
+      try {
+        const { farcasterMiniApp }: MiniAppConnectorModule = await import(
+          "@farcaster/miniapp-wagmi-connector"
+        );
+        const connector = farcasterMiniApp();
+        if (cancelled) return;
+
+        setMiniAppConnector(() => connector);
+      } catch {
+        if (cancelled) return;
+      }
+    };
+
+    loadMiniAppConnector();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const config = useMemo(() => {
     const connectors =
       typeof window === "undefined"
         ? []
         : [
-            miniAppConnector(),
+            ...(miniAppConnector ? [miniAppConnector] : []),
             ...getDefaultConnectors({
               app: {
                 name: defaultConfig.appName,
@@ -146,7 +176,7 @@ export const Web3Provider: FC<
         dataSuffix: BASE_BUILDER_DATA_SUFFIX,
       }),
     );
-  }, [chains, transports]);
+  }, [chains, transports, miniAppConnector]);
   // const initialState = cookieToInitialState(config, headers().get("cookie"));
   return (
     <WagmiProvider config={config}>

--- a/src/context/default.tsx
+++ b/src/context/default.tsx
@@ -2,6 +2,7 @@
 import { FC, PropsWithChildren, useEffect, useMemo } from "react";
 import * as Sentry from "@sentry/nextjs";
 import CssBaseline from "@mui/material/CssBaseline";
+import GlobalStyles from "@mui/material/GlobalStyles";
 import { ThemeProvider } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { createAppTheme } from "@/theme";
@@ -49,7 +50,9 @@ export const DefaultProvider: FC<
   sepolia,
   baseSepolia,
 }) => {
-  const prefersDarkMode = useMediaQuery("(prefers-color-scheme: dark)");
+  const prefersDarkMode = useMediaQuery("(prefers-color-scheme: dark)", {
+    defaultMatches: true,
+  });
   const theme = useMemo(
     () => createAppTheme(prefersDarkMode ? "dark" : "light"),
     [prefersDarkMode],
@@ -133,6 +136,19 @@ export const DefaultProvider: FC<
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
+      <GlobalStyles
+        styles={(theme) => ({
+          html: {
+            backgroundColor: `${theme.palette.background.default} !important`,
+            color: `${theme.palette.text.primary} !important`,
+            colorScheme: theme.palette.mode,
+          },
+          body: {
+            backgroundColor: `${theme.palette.background.default} !important`,
+            color: `${theme.palette.text.primary} !important`,
+          },
+        })}
+      />
       <Web3Provider siwe={siwe} chains={chains} transports={transports}>
         <NotificationsProvider>
           <Config>{children}</Config>

--- a/src/features/fame/layout.tsx
+++ b/src/features/fame/layout.tsx
@@ -33,7 +33,6 @@ import {
 import Button from "@mui/material/Button";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
-import CardActionArea from "@mui/material/CardActionArea";
 import { fameFromNetwork, fameSaleAddress } from "@/features/fame/contract";
 import { FameFAQ } from "@/features/presale/components/FameFAQ";
 import {
@@ -218,6 +217,8 @@ const Content: FC<{
   const isTinyScreen = useMediaQuery(theme.breakpoints.down("sm"));
   const imageWidth = isSmallScreen ? 200 : 400;
   const imageHeight = Math.floor(imageWidth * 2);
+  const fameTokenAddress = fameFromNetwork(8453);
+  const fameNftAddress = "0xbb5ed04dd7b207592429eb8d599d103ccad646c4";
   const eyesRef = useRef<HTMLImageElement>(null);
   const eyesContainer = useParallax<HTMLDivElement>({
     onProgressChange: (progress) => {
@@ -229,7 +230,11 @@ const Content: FC<{
   });
 
   return (
-    <Grid2 container spacing={2} sx={{ mt: 4, mx: 4, pt: 2 }}>
+    <Grid2
+      container
+      spacing={2}
+      sx={{ mt: 4, mx: 4, pt: 2, color: "text.primary" }}
+    >
       <Grid2
         xs={12}
         display="flex"
@@ -413,208 +418,196 @@ const Content: FC<{
       </Grid2>
       <Grid2 xs={12} marginBottom={4}>
         <Box
-          component="div"
+          component="section"
           sx={{
             position: "relative",
             left: "50%",
             width: "100vw",
-            backgroundColor: "white",
             transform: "translateX(-50%)",
-            zIndex: 1, // Ensure it's above other content
+            zIndex: 1,
+            borderTop: (theme) => `1px solid ${theme.palette.divider}`,
+            borderBottom: (theme) => `1px solid ${theme.palette.divider}`,
+            py: { xs: 3, md: 4 },
           }}
         >
-          <Grid2
-            container
-            justifyContent="flex-start"
-            alignItems="center"
-            spacing="4"
-            color="black"
+          <Box
+            component="div"
+            sx={{
+              maxWidth: 1120,
+              mx: "auto",
+              px: { xs: 2, sm: 4 },
+              display: "grid",
+              gap: 3,
+            }}
           >
-            <Grid2 xs={4} sm={2} px={2}>
+            <Box
+              component="div"
+              sx={{
+                display: "grid",
+                gridTemplateColumns: { xs: "1fr", sm: "120px minmax(0, 1fr)" },
+                columnGap: 3,
+                rowGap: 1.5,
+                alignItems: "center",
+              }}
+            >
               <Typography
-                variant="h5"
-                textAlign="start"
-                fontSize={isSmallScreen ? "16px" : "24px"}
+                variant="overline"
+                color="text.secondary"
+                fontWeight={700}
               >
                 chain
               </Typography>
-            </Grid2>
-            <Grid2 xs={8} sm={10} px={2}>
               <Typography
-                variant="h5"
-                mt={0.05}
-                fontSize={isSmallScreen ? "16px" : "24px"}
+                variant="body1"
+                fontWeight={700}
+                textTransform="uppercase"
               >
                 base
               </Typography>
-            </Grid2>
 
-            <Grid2 xs={12} sm={2} px={2}>
               <Typography
-                variant="h5"
-                textAlign="start"
-                fontSize={isSmallScreen ? "16px" : "24px"}
+                variant="overline"
+                color="text.secondary"
+                fontWeight={700}
               >
                 erc20
               </Typography>
-            </Grid2>
-            <Grid2 xs={12} sm={10} pl={1}>
-              <CopyToClipboard text={fameFromNetwork(8453)}>
+              <CopyToClipboard text={fameTokenAddress}>
                 {(handleClick) => (
                   <CopyButton
+                    sx={{
+                      p: 0,
+                      minWidth: 0,
+                      color: "text.primary",
+                      "&:hover": { backgroundColor: "transparent" },
+                    }}
                     endIcon={
                       <ContentCopyIcon
                         sx={{
-                          color: "black",
+                          color: "primary.main",
+                          fontSize: 18,
                         }}
                       />
                     }
                     onClick={handleClick}
                   >
                     <Typography
-                      variant="h5"
-                      mt={0.05}
-                      color="black"
-                      fontSize={isSmallScreen ? "16px" : "24px"}
+                      component="span"
+                      fontFamily="monospace"
+                      fontSize={isSmallScreen ? "0.8rem" : "1rem"}
+                      sx={{ overflowWrap: "anywhere" }}
                     >
-                      {fameFromNetwork(8453)}
+                      {fameTokenAddress}
                     </Typography>
                   </CopyButton>
                 )}
               </CopyToClipboard>
-            </Grid2>
-            <Grid2 xs={12} sm={2} px={2}>
+
               <Typography
-                variant="h5"
-                textAlign="start"
-                fontSize={isSmallScreen ? "16px" : "24px"}
+                variant="overline"
+                color="text.secondary"
+                fontWeight={700}
               >
                 erc721
               </Typography>
-            </Grid2>
-            <Grid2 xs={12} sm={10} pl={1}>
-              <CopyToClipboard
-                text={"0xbb5ed04dd7b207592429eb8d599d103ccad646c4"}
-              >
+              <CopyToClipboard text={fameNftAddress}>
                 {(handleClick) => (
                   <CopyButton
+                    sx={{
+                      p: 0,
+                      minWidth: 0,
+                      color: "text.primary",
+                      "&:hover": { backgroundColor: "transparent" },
+                    }}
                     endIcon={
                       <ContentCopyIcon
                         sx={{
-                          color: "black",
+                          color: "primary.main",
+                          fontSize: 18,
                         }}
                       />
                     }
                     onClick={handleClick}
                   >
                     <Typography
-                      variant="h5"
-                      mt={0.05}
-                      color="black"
-                      fontSize={isSmallScreen ? "16px" : "24px"}
+                      component="span"
+                      fontFamily="monospace"
+                      fontSize={isSmallScreen ? "0.8rem" : "1rem"}
+                      sx={{ overflowWrap: "anywhere" }}
                     >
-                      0xbb5ed04dd7b207592429eb8d599d103ccad646c4
+                      {fameNftAddress}
                     </Typography>
                   </CopyButton>
                 )}
               </CopyToClipboard>
-            </Grid2>
-            <Grid2 xs={12} p={4}>
-              <Card
-                variant="outlined"
+            </Box>
+
+            <Box
+              component="nav"
+              aria-label="FAME resources"
+              sx={{
+                display: "flex",
+                flexWrap: "wrap",
+                alignItems: "baseline",
+                justifyContent: "center",
+                gap: { xs: 2, sm: 4 },
+                pt: 2,
+                borderTop: (theme) => `1px solid ${theme.palette.divider}`,
+              }}
+            >
+              <Box
+                component="span"
                 sx={{
-                  borderColor: "primary.main",
-                  borderWidth: 2,
+                  display: "inline-flex",
+                  alignItems: "baseline",
+                  gap: 1,
+                  flexWrap: "wrap",
+                  justifyContent: "center",
                 }}
               >
-                <CardActionArea href="/fame/swap" aria-label="Open FAME swap">
-                  <CardContent
-                    sx={{
-                      minHeight: "180px",
-                      display: "flex",
-                      flexDirection: "column",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      gap: 1,
-                    }}
-                  >
-                    <Typography
-                      variant={isTinyScreen ? "h5" : "h4"}
-                      textAlign="center"
-                      textTransform="uppercase"
-                      fontWeight={700}
-                    >
-                      Swap FAME
-                    </Typography>
-                    <Typography
-                      variant={isTinyScreen ? "body2" : "h6"}
-                      textAlign="center"
-                      color="text.secondary"
-                    >
-                      using FAME preferred pools
-                    </Typography>
-                  </CardContent>
-                </CardActionArea>
-              </Card>
-            </Grid2>
-            <Grid2 xs={12} sm={4} p={4}>
-              <Card>
-                <CardActionArea
-                  href="https://dexscreener.com/search?q=0xf307e242BfE1EC1fF01a4Cef2fdaa81b10A52418"
-                  target="_blank"
-                  rel="noreferrer noopener"
+                <WrappedLink
+                  href="/fame/swap"
+                  underline="hover"
+                  sx={{
+                    fontWeight: 800,
+                    letterSpacing: "0.08em",
+                    textTransform: "uppercase",
+                  }}
                 >
-                  <CardContent
-                    sx={{
-                      height: "220px",
-                      display: "flex",
-                      alignItems: "center",
-                    }}
-                  >
-                    <Typography
-                      variant={isTinyScreen ? "body1" : "h5"}
-                      textAlign="center"
-                      textTransform="uppercase"
-                      sx={{
-                        width: "100%",
-                      }}
-                    >
-                      dexscreener
-                    </Typography>
-                  </CardContent>
-                </CardActionArea>
-              </Card>
-            </Grid2>
-
-            <Grid2 xs={12} sm={4} p={4}>
-              <Card>
-                <CardActionArea
-                  href="https://opensea.io/collection/fameladysociety"
-                  target="_blank"
-                  rel="noreferrer noopener"
-                >
-                  <CardContent
-                    sx={{
-                      height: "220px",
-                      display: "flex",
-                      alignItems: "center",
-                    }}
-                  >
-                    <Typography
-                      variant={isTinyScreen ? "body1" : "h5"}
-                      textAlign="center"
-                      textTransform="uppercase"
-                      sx={{
-                        width: "100%",
-                      }}
-                    >
-                      opensea
-                    </Typography>
-                  </CardContent>
-                </CardActionArea>
-              </Card>
-            </Grid2>
-          </Grid2>
+                  Swap FAME
+                </WrappedLink>
+                <Typography variant="body2" color="text.secondary">
+                  using preferred pools
+                </Typography>
+              </Box>
+              <WrappedLink
+                href="https://dexscreener.com/search?q=0xf307e242BfE1EC1fF01a4Cef2fdaa81b10A52418"
+                target="_blank"
+                rel="noreferrer noopener"
+                underline="hover"
+                sx={{
+                  fontWeight: 700,
+                  letterSpacing: "0.08em",
+                  textTransform: "uppercase",
+                }}
+              >
+                Dexscreener
+              </WrappedLink>
+              <WrappedLink
+                href="https://opensea.io/collection/fameladysociety"
+                target="_blank"
+                rel="noreferrer noopener"
+                underline="hover"
+                sx={{
+                  fontWeight: 700,
+                  letterSpacing: "0.08em",
+                  textTransform: "uppercase",
+                }}
+              >
+                OpenSea
+              </WrappedLink>
+            </Box>
+          </Box>
         </Box>
       </Grid2>
       {burnPool.length > 0 && (

--- a/src/hooks/useAccount.ts
+++ b/src/hooks/useAccount.ts
@@ -2,10 +2,18 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useConnection } from "wagmi";
-import { sdk } from "@farcaster/miniapp-sdk";
 import { type SIWESession, useSIWE } from "connectkit";
 
 const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+
+type MiniAppContext = unknown;
+type FarcasterMiniAppSdk = {
+  actions: {
+    ready: () => Promise<void>;
+  };
+  context: Promise<MiniAppContext>;
+  isInMiniApp: () => Promise<boolean>;
+};
 
 type StatusState = "ready" | "loading" | "success" | "rejected" | "error";
 
@@ -33,9 +41,8 @@ export function useAccount() {
   } = useConnection();
   const [isMiniApp, setIsMiniApp] = useState(false);
   const { isSignedIn, signIn: signInSIWE } = useSIWE() as HookProps;
-  const [miniAppContext, setMiniAppContext] = useState<Awaited<
-    Awaited<(typeof sdk)["context"]>
-  > | null>(null);
+  const [miniAppContext, setMiniAppContext] =
+    useState<MiniAppContext | null>(null);
 
   const signIn = useCallback(async () => {
     if (isSignedIn) return true;
@@ -46,17 +53,24 @@ export function useAccount() {
   useEffect(() => {
     let cancelled = false;
     const loadMiniApp = async () => {
-      if (typeof window === "undefined") return;
+      try {
+        const { sdk }: { sdk: FarcasterMiniAppSdk } = await import(
+          "@farcaster/miniapp-sdk"
+        );
+        const isInMiniApp = await sdk.isInMiniApp();
+        if (cancelled || !isInMiniApp) return;
 
-      if (cancelled) return;
-      sdk.actions.ready().then(() => {
+        await sdk.actions.ready();
         if (cancelled) return;
+
         setIsMiniApp(true);
-        sdk.context.then((context) => {
-          if (cancelled) return;
-          setMiniAppContext(context);
-        });
-      });
+        const context = await sdk.context;
+        if (cancelled) return;
+
+        setMiniAppContext(context);
+      } catch {
+        if (cancelled) return;
+      }
     };
     loadMiniApp();
     return () => {

--- a/src/layouts/Main.tsx
+++ b/src/layouts/Main.tsx
@@ -36,6 +36,8 @@ export const Main: FC<
         component="main"
         sx={{
           backgroundColor: "background.default",
+          color: "text.primary",
+          minHeight: "100vh",
         }}
       >
         <AppBar

--- a/src/routes/Customize.tsx
+++ b/src/routes/Customize.tsx
@@ -8,26 +8,35 @@ import { Main } from "@/layouts/Main";
 import { SiteMenu } from "@/features/appbar/components/SiteMenu";
 import { LinksMenuItems } from "@/features/appbar/components/LinksMenuItems";
 import { SelectPage } from "@/features/customize/SelectPage";
-import { FC, useMemo } from "react";
+import { FC, useEffect, useMemo } from "react";
 import { useAccount } from "@/hooks/useAccount";
 import { UnsupportedNetwork } from "@/features/wrap/UnsupportedNetwork";
 import { useRouter } from "next/navigation";
 import { useLadies } from "@/features/customize/hooks/useLadies";
-import {  mainnet, sepolia } from "viem/chains";
+import { mainnet, sepolia } from "viem/chains";
 
-const Content: FC<{  network: "mainnet" | "sepolia", prefix?: string }> = ({
+const Content: FC<{ network: "mainnet" | "sepolia"; prefix?: string }> = ({
   prefix = "",
   network,
 }) => {
   const { replace } = useRouter();
   const { chain } = useAccount();
-  if (chain && chain?.name.toLowerCase() !== network) {
-    const name = chain.id === 1 ? "mainnet" : chain.name.toLowerCase();
-    replace(`/${name}/customize`);
-  }
 
-  const { isLoading, data } = useLadies({ chainId: (chain?.id ?? 1) as typeof mainnet.id | typeof sepolia.id  });
-  const tokens = useMemo(() => data?.map((tokenId) => ({ tokenId, url: `${prefix}/${tokenId}` })) ?? [], [data, prefix]);
+  useEffect(() => {
+    if (chain && chain?.name.toLowerCase() !== network) {
+      const name = chain.id === 1 ? "mainnet" : chain.name.toLowerCase();
+      replace(`/${name}/customize`);
+    }
+  }, [chain, replace, network]);
+
+  const { isLoading, data } = useLadies({
+    chainId: (chain?.id ?? 1) as typeof mainnet.id | typeof sepolia.id,
+  });
+  const tokens = useMemo(
+    () =>
+      data?.map((tokenId) => ({ tokenId, url: `${prefix}/${tokenId}` })) ?? [],
+    [data, prefix],
+  );
 
   if (chain && ![1, 11155111].includes(chain?.id)) {
     return <UnsupportedNetwork />;

--- a/src/service/fame.ts
+++ b/src/service/fame.ts
@@ -12,7 +12,11 @@ import {
   creatorArtistMagicAddress,
   fameFromNetwork,
 } from "@/features/fame/contract";
-import { IMetadata } from "@/utils/metadata";
+import {
+  FAME_METADATA_FALLBACK_IMAGE,
+  fameMetadataFetchUrls,
+  imageFromFameMetadata,
+} from "./fameMetadata";
 
 export async function getArtPoolRange() {
   const [startIndex, endIndex, nextIndex] = await Promise.all([
@@ -93,30 +97,47 @@ export async function getFamePools() {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
     try {
-      const response = await fetch(url, { signal: controller.signal });
+      return await fetch(url, { signal: controller.signal });
+    } finally {
       clearTimeout(timeoutId);
-      return response;
-    } catch (error) {
-      clearTimeout(timeoutId);
-      throw error;
     }
+  };
+
+  const fetchMetadataImage = async (uri: string): Promise<string> => {
+    let lastError: unknown = null;
+    for (const fetchUrl of fameMetadataFetchUrls(uri)) {
+      try {
+        const response = await fetchWithTimeout(fetchUrl);
+        if (!response.ok) {
+          throw new Error(
+            `Metadata request failed with ${response.status} ${response.statusText}`,
+          );
+        }
+
+        return imageFromFameMetadata(await response.json());
+      } catch (error) {
+        lastError = error;
+      }
+    }
+
+    throw lastError instanceof Error
+      ? lastError
+      : new Error("Failed to fetch metadata image");
   };
 
   return {
     burnPool: await Promise.all(
       uris.map(async ({ uri, tokenId }) => {
         try {
-          const response = await fetchWithTimeout(uri);
-          const metadata: IMetadata = await response.json();
           return {
             tokenId,
-            image: metadata.image,
+            image: await fetchMetadataImage(uri),
           };
         } catch (error) {
           console.warn(`Failed to fetch metadata for token ${tokenId}:`, error);
           return {
             tokenId,
-            image: "",
+            image: FAME_METADATA_FALLBACK_IMAGE,
           };
         }
       }),
@@ -124,17 +145,15 @@ export async function getFamePools() {
     mintPool: await Promise.all(
       mintPoolUris.map(async ({ uri, tokenId }) => {
         try {
-          const response = await fetchWithTimeout(uri);
-          const metadata: IMetadata = await response.json();
           return {
             tokenId,
-            image: metadata.image,
+            image: await fetchMetadataImage(uri),
           };
         } catch (error) {
           console.warn(`Failed to fetch metadata for token ${tokenId}:`, error);
           return {
             tokenId,
-            image: "",
+            image: FAME_METADATA_FALLBACK_IMAGE,
           };
         }
       }),

--- a/src/service/fameMetadata.test.ts
+++ b/src/service/fameMetadata.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  fameMetadataFetchUrls,
+  imageFromFameMetadata,
+  irysGatewayToArweaveUrl,
+  normalizeFameImageUrl,
+} from "./fameMetadata";
+
+describe("fame metadata URL handling", () => {
+  it("converts Irys gateway URLs to Arweave gateway URLs", () => {
+    assert.equal(
+      irysGatewayToArweaveUrl(
+        "https://gateway.irys.xyz/txid/path/to/metadata.json",
+      ),
+      "https://arweave.net/txid/path/to/metadata.json",
+    );
+  });
+
+  it("fetches Irys metadata through Arweave before trying the original gateway", () => {
+    assert.deepEqual(
+      fameMetadataFetchUrls("https://gateway.irys.xyz/txid/metadata.json"),
+      [
+        "https://arweave.net/txid/metadata.json",
+        "https://gateway.irys.xyz/txid/metadata.json",
+      ],
+    );
+  });
+
+  it("leaves non-Irys and local image URLs unchanged", () => {
+    assert.equal(
+      normalizeFameImageUrl("https://www.fameladysociety.com/image.png"),
+      "https://www.fameladysociety.com/image.png",
+    );
+    assert.equal(
+      normalizeFameImageUrl("/images/fame/gold-leaf-square.png"),
+      "/images/fame/gold-leaf-square.png",
+    );
+  });
+
+  it("extracts and normalizes the metadata image field", () => {
+    assert.equal(
+      imageFromFameMetadata({
+        image: "https://gateway.irys.xyz/imageTx",
+      }),
+      "https://arweave.net/imageTx",
+    );
+  });
+
+  it("rejects metadata without a usable image", () => {
+    assert.throws(
+      () => imageFromFameMetadata({ image: "" }),
+      /FAME metadata image must be a non-empty string/,
+    );
+    assert.throws(
+      () => imageFromFameMetadata({ name: "FAME Society" }),
+      /FAME metadata is missing an image field/,
+    );
+  });
+});

--- a/src/service/fameMetadata.ts
+++ b/src/service/fameMetadata.ts
@@ -1,0 +1,45 @@
+export const FAME_METADATA_FALLBACK_IMAGE =
+  "/images/fame/gold-leaf-square.png";
+
+export function irysGatewayToArweaveUrl(rawUrl: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== "https:" || url.hostname !== "gateway.irys.xyz") {
+    return null;
+  }
+
+  return `https://arweave.net${url.pathname}${url.search}`;
+}
+
+export function fameMetadataFetchUrls(uri: string): string[] {
+  const arweaveUrl = irysGatewayToArweaveUrl(uri);
+  if (!arweaveUrl) return [uri];
+
+  return [arweaveUrl, uri];
+}
+
+export function normalizeFameImageUrl(image: string): string {
+  return irysGatewayToArweaveUrl(image) ?? image;
+}
+
+export function imageFromFameMetadata(metadata: unknown): string {
+  if (
+    metadata === null ||
+    typeof metadata !== "object" ||
+    !("image" in metadata)
+  ) {
+    throw new Error("FAME metadata is missing an image field");
+  }
+
+  const { image } = metadata;
+  if (typeof image !== "string" || image.length === 0) {
+    throw new Error("FAME metadata image must be a non-empty string");
+  }
+
+  return normalizeFameImageUrl(image);
+}


### PR DESCRIPTION
## Summary

FAME pages now avoid broken token images when Irys metadata or image URLs need Arweave access, creator routes no longer crash when Farcaster mini-app packages fail during client module evaluation, and shared dark-mode pages inherit readable document colors without white viewport bars. The customize route also defers network-mismatch redirects until after render, addressing follow-up exceptions exposed by recent Next/React updates.

Metadata loading now validates image fields, tries Arweave for Irys gateway URLs before falling back to the original URL, and uses a local FAME fallback image instead of rendering empty `src` values. Farcaster SDK and wagmi connector loading now happen at runtime with guarded dynamic imports, which keeps normal desktop loads alive while still allowing mini-app clients to attach when supported. The creator portal redirect and customize network redirect now both run as effects instead of during render.

The `/fame` content shell now uses theme text colors, and the old white contract/resources strip has been simplified into a theme-aware inline section with no card tiles. Shared `DefaultProvider` and `Main` document styling now keep `/fame/swap`, `/lore`, and other themed pages from falling back to black text or light document bars in dark mode.

## Test Plan

- `./node_modules/.bin/eslint src/hooks/useAccount.ts src/context/Wagmi.tsx src/service/fame.ts src/app/fame/creator/[address]/SelectableGrid.tsx`
- `./node_modules/.bin/eslint src/features/fame/layout.tsx`
- `./node_modules/.bin/eslint src/context/default.tsx src/layouts/Main.tsx src/features/fame/layout.tsx`
- `./node_modules/.bin/eslint src/routes/Customize.tsx`
- `/home/user/.bun/bin/bun test src/service/fameMetadata.test.ts`
- Browser loaded `/fame` and `/fame/creator` without the BigInt crash
- Browser verified `/fame` in dark color scheme with readable below-fold text
- Browser verified `/fame/swap` and `/lore` in dark color scheme with dark `html`/`body` backgrounds and readable themed text

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
