### PR TITLE
fix: restore home menu contrast in dark mode

### DIFF
--- a/src/features/appbar/components/HomeMenu.tsx
+++ b/src/features/appbar/components/HomeMenu.tsx
@@ -1,4 +1,5 @@
 import { FC, PropsWithChildren, useEffect, useState } from "react";
+import { useTheme } from "@mui/material/styles";
 
 interface IProps {
   handleClose: () => void;
@@ -14,6 +15,7 @@ export const HomeMenu: FC<PropsWithChildren<IProps>> = ({
   children,
 }) => {
   const open = Boolean(anchorEl);
+  const theme = useTheme();
   const [position, setPosition] = useState({ left: MENU_MARGIN, top: 64 });
 
   useEffect(() => {
@@ -70,9 +72,11 @@ export const HomeMenu: FC<PropsWithChildren<IProps>> = ({
     >
       <div className="absolute inset-0 bg-black/30" />
       <div
-        className="fixed rounded bg-white py-2 shadow-xl"
+        className="fixed rounded py-2 shadow-xl"
         onClick={(event) => event.stopPropagation()}
         style={{
+          backgroundColor: theme.palette.background.paper,
+          color: theme.palette.text.primary,
           left: position.left,
           maxWidth: `calc(100vw - ${MENU_MARGIN * 2}px)`,
           top: position.top,


### PR DESCRIPTION
## Summary

The home page drawer menu is readable again for visitors using dark mode. Its floating panel now follows the active MUI theme surface and text colors instead of forcing a white background under dark-mode text.

## Verification

- `eslint .` passed with 0 errors and 3 pre-existing warnings outside this change.
- Verified `/` in a dark color scheme with Playwright: the menu panel rendered with a dark surface (`rgb(18, 18, 18)`) and white text.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
