### PR TITLE
fix(fame): compact swap quote responses

### DIFF
--- a/docs/plans/2026-05-19-001-refactor-fame-swap-quote-response-plan.md
+++ b/docs/plans/2026-05-19-001-refactor-fame-swap-quote-response-plan.md
@@ -1,0 +1,286 @@
+---
+title: "refactor: Compact FAME swap quote responses"
+type: refactor
+status: completed
+date: 2026-05-19
+---
+
+# refactor: Compact FAME Swap Quote Responses
+
+## Summary
+
+Compact the default `/api/fame/swap/quote` response so the frontend receives only the status, UI display fields, and executable route data it needs. Keep bulky quote diagnostics available through an explicit `includeDebug` request flag, preserving the current safety boundary around protocol evidence, helper secrets, RPC URLs, and calldata-like data.
+
+---
+
+## Problem Frame
+
+The FAME swap quote API can return roughly 63 KB for ordinary quote requests because debug-oriented fields ride along with the normal frontend payload. The existing wire contract already strips some route-lab-only protocol evidence, but top-level transaction request objects, optimizer summaries, rejection arrays, and warning/debug details still inflate the public response even when the widget does not need them.
+
+---
+
+## Requirements
+
+- R1. Default quote responses must include only the data needed for status display, route UI, quote freshness, and client-side contract request construction.
+- R2. Debug-oriented fields must be omitted by default and exposed only when the request body includes `includeDebug: true`.
+- R3. Ready responses must remain executable by the existing frontend, including protected simulation and final router calls.
+- R4. Non-ready responses must remain structurally non-executable by default.
+- R5. The serializer and deserializer must continue to fail closed for malformed ready routes and handle every `FameSwapQuote.status` exhaustively.
+- R6. The change must not alter route selection, liquidity quoting, transaction encoding, router ABI behavior, or solver behavior.
+
+---
+
+## Scope Boundaries
+
+- Do not implement the quote API response refactor in this planning task.
+- Do not remove the executable `route` from default ready responses; the client uses it for protected simulation and final swap calls.
+- Do not add query-string debug toggles; the opt-in is the POST body flag `includeDebug`.
+- Do not add new public exposure for `protocolEvidence`, `activeLiquidity`, helper service tokens, RPC URLs, raw calldata, or signer/private material.
+- Do not change the solver, live adapters, indexed pool-state helper semantics, route graph, or wallet execution flow except where tests need to assert the compact wire contract.
+
+### Deferred to Follow-Up Work
+
+- Route diagnostics UI redesign: if the default compact payload leaves the collapsed diagnostics panel less detailed, improve that panel separately after the wire payload is slimmed.
+- Additional payload compression or transport-level caching: this plan focuses on response shape, not HTTP compression, edge caching, or solver caching.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/app/api/fame/swap/quote/handler.ts` parses request bodies, validates quote inputs, runs readiness/quote execution, and currently calls `serializeFameSwapQuoteResponse(quote)` without options.
+- `src/features/fame-swap/solver/quoteWire.ts` owns the shared JSON-safe serializer/deserializer and currently includes top-level `approval`, `swap`, `rejectedCandidates`, `optimizerSummary`, and `warnings` in normal ready responses.
+- `src/features/fame-swap/hooks/useFameSwapQuote.ts` sends the normal frontend POST body and deserializes the API response into the internal `FameSwapQuote` shape.
+- `src/features/fame-swap/transactions.ts` already reconstructs approval and swap contract requests from a ready quote's route, so top-level serialized `approval` and `swap` are redundant for the frontend.
+- `src/features/fame-swap/components/RouteDiagnostics.tsx` reads `optimizerSummary` and `rejectedCandidates` when present, so compact default deserialization should tolerate their absence.
+
+### Institutional Learnings
+
+- `docs/plans/2026-05-14-003-fame-swap-quote-wire-contract-plan.md` established the shared quote wire boundary, canonical hash fields, and fail-closed deserialization for ready responses.
+- `docs/solutions/architecture-patterns/fame-swap-indexed-pool-state-quote-helper-2026-05-19.md` reinforces that public quote responses must preserve indexed context while avoiding helper credentials and protocol evidence leaks.
+- `docs/solutions/performance-issues/fame-swap-quote-solver-timeouts-native-wrap-routing-2026-05-15.md` notes that public quote diagnostics should be stripped of internal route-lab/protocol evidence while keeping executable quote correctness intact.
+
+### External References
+
+- Not used. The repo has a direct local wire-contract pattern and the task is a project-specific API-shape refactor.
+
+---
+
+## Key Technical Decisions
+
+- Keep `route` in the compact ready response: protected simulation, route hash validation, and final contract request construction depend on the decoded route.
+- Remove top-level `approval` and `swap` from default ready responses: they duplicate client-reconstructed data and include ABI-heavy contract request objects.
+- Move debug opt-in data under a single `debug` object: this makes the normal payload easy to audit and prevents debug fields from creeping back into the public response.
+- Parse debug-backed fields in the deserializer as optional enrichment: the frontend should continue to build a usable quote when `debug` is absent.
+- Keep all existing sanitization and public fee-breakdown stripping: `includeDebug` is for operational quote diagnostics, not raw route-lab/private evidence.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should the debug flag be a query string or body field? Use the POST body field `includeDebug`, matching the existing request parser boundary.
+- Can the API omit `approval` and `swap` safely? Yes; `fameSwapTransactionRequests` reconstructs these from the ready quote locally.
+- Can the default response omit `rejectedCandidates` and `optimizerSummary`? Yes; these are diagnostics, and consumers already need to tolerate absent summaries.
+
+### Deferred to Implementation
+
+- Exact compact-response size target: implementation should measure representative ready quotes and assert a meaningful reduction without making the test brittle to unrelated route-size changes.
+- Exact debug object shape: keep it small and typed, but allow the implementing agent to choose names that best fit the existing quote-wire helpers.
+
+---
+
+## Implementation Units
+
+### U1. Prepare Baseline and Parse Debug Opt-In
+
+**Goal:** Start implementation from the merged `origin/main` state and teach the quote API request parser about the optional debug flag.
+
+**Requirements:** R2, R6
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `src/app/api/fame/swap/quote/handler.ts`
+- Test: `src/app/api/fame/swap/quote/route.test.ts`
+
+**Approach:**
+- Before implementation, sync the workspace to `origin/main` and discard tracked feature-branch changes while leaving untracked local files alone unless they block the work.
+- Extend the parsed quote body with `includeDebug?: boolean`.
+- Accept only an actual boolean value for the flag; omitted or non-boolean values should behave like `false` rather than creating a new validation failure for normal quote requests.
+- Pass the parsed flag into `serializeFameSwapQuoteResponse`.
+- Keep all existing request validation, slippage/deadline normalization, readiness lookup, rate limiting, and dependency-injection seams unchanged.
+
+**Patterns to follow:**
+- `parseQuoteBody` in `src/app/api/fame/swap/quote/handler.ts` for simple explicit body parsing.
+- Existing deterministic API tests in `src/app/api/fame/swap/quote/route.test.ts`.
+
+**Test scenarios:**
+- Happy path: a normal POST body without `includeDebug` serializes through the compact default path.
+- Happy path: a POST body with `includeDebug: true` serializes with a `debug` object.
+- Edge case: `includeDebug: false` behaves exactly like omission.
+- Edge case: non-boolean `includeDebug` does not break otherwise valid quote requests and is treated as false.
+- Integration: injected `quoteForRequest` still receives normalized quote request data, and only the serializer option changes.
+
+**Verification:**
+- API route tests prove the flag controls response shape without changing quote execution inputs.
+
+---
+
+### U2. Compact the Shared Quote Wire Serializer
+
+**Goal:** Make default serialized quote responses small and frontend-oriented while keeping debug fields available under explicit opt-in.
+
+**Requirements:** R1, R2, R4, R5
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `src/features/fame-swap/solver/quoteWire.ts`
+- Test: `src/features/fame-swap/solver/quoteWire.test.ts`
+
+**Approach:**
+- Add serializer options for `includeDebug`.
+- For ready quotes, keep the compact public fields needed by the UI and transaction path: status, token/request amounts, message/status flags, route artifact/source, router address, output/minimum/fee/slippage/expiry fields, canonical hashes and `routeHash`, executable `route`, `callValue`, public fee breakdown, quote context, fee ppm, capabilities, pool ids, and route display.
+- Remove default top-level `approval`, `swap`, `rejectedCandidates`, `optimizerSummary`, and raw warnings/debug detail.
+- When debug is enabled, include a `debug` object with omitted diagnostics such as reconstructed transaction requests, rejected candidates, optimizer summary, and warnings.
+- For non-ready quotes, keep only status, token/request amounts, message, diagnostic visibility, and status-specific user-facing fields by default; put rejected candidates and other operational detail under `debug`.
+- Keep `publicFeeBreakdown` stripping protocol evidence for both default and debug paths.
+- Preserve exhaustive status handling with `assertNever` and the handled-status map.
+
+**Patterns to follow:**
+- Existing `serializeFameSwapQuoteResponse`, `publicFeeBreakdown`, and `toJsonSafe` helpers in `src/features/fame-swap/solver/quoteWire.ts`.
+- Existing tests that assert no `protocolEvidence` or `activeLiquidity` leaks.
+
+**Test scenarios:**
+- Happy path: default ready serialization includes the route/hash/output/UI fields and omits `approval`, `swap`, `rejectedCandidates`, `optimizerSummary`, `warnings`, and `debug`.
+- Happy path: debug ready serialization includes a `debug` object containing the omitted diagnostics.
+- Happy path: default non-ready serialization includes status-specific user-facing fields and no executable transaction data.
+- Happy path: debug non-ready serialization places rejected candidates under `debug`.
+- Edge case: a quote containing optimizer evidence still does not serialize raw optimizer evidence, allocation trials, protocol evidence, or active liquidity.
+- Integration: representative ready payload size is materially smaller than the debug payload and below the prior bulky response class.
+
+**Verification:**
+- Quote-wire tests document both compact default and debug opt-in contracts.
+
+---
+
+### U3. Accept Compact Responses in the Client Deserializer
+
+**Goal:** Ensure the frontend can deserialize compact API responses into the existing internal `FameSwapQuote` shape and rebuild contract requests locally.
+
+**Requirements:** R1, R3, R4, R5
+
+**Dependencies:** U2
+
+**Files:**
+- Modify: `src/features/fame-swap/solver/quoteWire.ts`
+- Modify: `src/features/fame-swap/hooks/useFameSwapQuote.ts`
+- Test: `src/features/fame-swap/hooks/useFameSwapQuote.test.ts`
+- Test: `src/features/fame-swap/transactions.test.ts`
+
+**Approach:**
+- Keep `fetchFameSwapRemoteQuote` unchanged for normal frontend calls; it should not send `includeDebug`.
+- Update deserialization to read `rejectedCandidates`, `optimizerSummary`, and warnings from `debug` when present and default them to empty or absent when not present.
+- Continue reconstructing `approval` from the input token and decoded route, and `callValue` from either serialized `callValue` or native route amount.
+- Preserve ready-response route hash validation against `materializedRouteHash`.
+- Ensure non-ready compact responses still become non-executable internal quote variants with empty rejected-candidate arrays where the type requires them.
+
+**Patterns to follow:**
+- Existing `deserializeFameSwapQuoteResponse` fail-closed behavior in `src/features/fame-swap/solver/quoteWire.ts`.
+- Existing `fameSwapTransactionRequests` reconstruction in `src/features/fame-swap/transactions.ts`.
+
+**Test scenarios:**
+- Happy path: compact ready API response deserializes into a ready quote with route amount, approval amount, route hash, fee data, and route display intact.
+- Happy path: `fameSwapTransactionRequests` rebuilds approval and swap contract requests from a compact-deserialized quote.
+- Happy path: debug ready API response restores rejected candidates and optimizer summary into the internal quote.
+- Edge case: compact ready response without debug yields empty rejected candidates and no optimizer summary.
+- Error path: malformed route/hash mismatch still returns `quote_adapter_failure`.
+- Error path: compact non-ready response does not gain `route`, `approval`, or `swap`.
+
+**Verification:**
+- Hook and transaction tests prove normal frontend fetches remain executable without requesting debug data.
+
+---
+
+### U4. Update API and UI Regression Coverage
+
+**Goal:** Lock the behavior across the API route, hook, widget, and route-view layers so the compact response does not break normal swap UX.
+
+**Requirements:** R1, R2, R3, R4, R6
+
+**Dependencies:** U1, U2, U3
+
+**Files:**
+- Modify: `src/app/api/fame/swap/quote/route.test.ts`
+- Modify: `src/features/fame-swap/hooks/useFameSwapQuote.test.ts`
+- Modify: `src/features/fame-swap/solver/quoteWire.test.ts`
+- Test: `src/features/fame-swap/components/FameSwapWidget.test.ts`
+- Test: `src/features/fame-swap/ui/quoteView.test.ts`
+- Test: `src/features/fame-swap/ui/routeGraph.test.ts`
+
+**Approach:**
+- Update ready-path API tests that currently expect top-level `approval` and `swap`; they should assert those fields are absent by default and available only under `debug`.
+- Update non-ready API tests to assert rejected candidates move under `debug` when requested and are absent from the default public payload.
+- Keep existing tests that assert no `executeRoute`, `approve`, or calldata-like fields exist for non-ready responses.
+- Add or adjust UI-facing tests only where compact deserialization changes expectations around diagnostics summaries.
+- Preserve tests around public fee breakdown stripping and indexed quote context.
+
+**Patterns to follow:**
+- Existing API ready/non-ready tests in `src/app/api/fame/swap/quote/route.test.ts`.
+- Existing route-view and route-graph tests that assert display data is available from ready quotes.
+
+**Test scenarios:**
+- Integration: default API ready response is compact, still deserializes, and still builds local transaction requests.
+- Integration: debug API ready response carries diagnostics without leaking protocol evidence or active liquidity.
+- Integration: route map and quote panel still render from compact-deserialized ready quote fields.
+- Integration: non-ready compact response keeps swap actions disabled and structurally non-executable.
+- Error path: live quote adapter failure response hides rejected candidates by default but exposes sanitized candidates in debug mode.
+
+**Verification:**
+- Focused quote-wire/API/hook/transaction tests and affected widget/view tests pass.
+- Static checks do not report new unsafe casts, `any`, or lint violations.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** The API route, shared wire module, remote quote hook, transaction request builder, diagnostics panel, and route-map display all consume the ready quote shape.
+- **Error propagation:** Quote execution failures should still return non-ready quote statuses; debug data changes where details are serialized, not the failure classification.
+- **State lifecycle risks:** React Query cache keys and quote refresh behavior should not change because the normal request body remains unchanged.
+- **API surface parity:** The public API response changes by removing default fields; tests must document compact default shape and debug opt-in shape.
+- **Integration coverage:** Unit tests alone are not enough; at least one API-to-deserializer-to-transaction-request path must be covered.
+- **Unchanged invariants:** Route hash validation, non-ready non-executability, public fee-breakdown redaction, indexed quote-context preservation, and exhaustive status handling remain intact.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Removing top-level `approval` and `swap` breaks an unnoticed frontend consumer | Prove the hook and transaction builder reconstruct requests from compact ready responses; search for direct top-level response consumers before editing. |
+| Diagnostics UI becomes less informative on normal frontend quotes | Treat detailed diagnostics as debug-only for this change; leave UI redesign as follow-up work. |
+| Debug mode accidentally reintroduces sensitive evidence | Keep debug construction explicit and reuse public redaction helpers; add negative assertions for protocol evidence, active liquidity, URLs, calldata-like data, and secrets. |
+| Payload-size assertion becomes brittle | Assert relative reduction or broad threshold from a representative quote rather than exact byte counts. |
+| Resetting to `origin/main` drops the plan file before implementation | Preserve or reapply this plan after the baseline reset if implementation begins from a freshly reset branch. |
+
+---
+
+## Documentation / Operational Notes
+
+- The plan itself documents the API response change; no user-facing documentation is required unless external consumers besides the app are discovered during implementation.
+- If implementation starts immediately after this plan is recorded, account for the existing dirty `.gitignore` and untracked `.codex` state before resetting to the merged mainline branch.
+
+---
+
+## Sources & References
+
+- Related plan: `docs/plans/2026-05-14-003-fame-swap-quote-wire-contract-plan.md`
+- Related learning: `docs/solutions/architecture-patterns/fame-swap-indexed-pool-state-quote-helper-2026-05-19.md`
+- Related learning: `docs/solutions/performance-issues/fame-swap-quote-solver-timeouts-native-wrap-routing-2026-05-15.md`
+- Related code: `src/app/api/fame/swap/quote/handler.ts`
+- Related code: `src/features/fame-swap/solver/quoteWire.ts`
+- Related code: `src/features/fame-swap/hooks/useFameSwapQuote.ts`
+- Related code: `src/features/fame-swap/transactions.ts`

--- a/src/app/api/fame/swap/quote/handler.ts
+++ b/src/app/api/fame/swap/quote/handler.ts
@@ -17,6 +17,7 @@ import { serializeFameSwapQuoteResponse } from "@/features/fame-swap/solver/quot
 import type { FameAsyncQuoteAdapter } from "@/features/fame-swap/solver/quotes/adapters";
 import {
   createIndexedPoolStateClient,
+  type FameIndexedPoolStateBatchResponse,
   type FameIndexedPoolStateClient,
 } from "@/features/fame-swap/solver/quotes/indexedPoolStateClient";
 import { createIndexedReserveQuoteAdapter } from "@/features/fame-swap/solver/quotes/indexedReserveAdapter";
@@ -57,6 +58,7 @@ interface ParsedQuoteBody {
   routerAddress?: Address;
   slippageBps?: number;
   deadlineMinutes?: number;
+  includeDebug: boolean;
 }
 
 interface FameSwapQuotePostDependencies {
@@ -70,6 +72,38 @@ interface FameSwapQuotePostDependencies {
     request: FameSwapQuoteRequest & { readiness: FameSwapReadiness },
   ) => FameAsyncQuoteAdapter | Promise<FameAsyncQuoteAdapter>;
   indexedPoolStateClient?: FameIndexedPoolStateClient | null;
+}
+
+type IndexedPoolStateHelperReason =
+  | "not_configured"
+  | "adapter_context_unavailable"
+  | "unsupported_adapter_context"
+  | "unsafe_block_number"
+  | "no_registered_pools"
+  | "wrapped"
+  | "source_registry_mismatch"
+  | "http_error"
+  | "timeout"
+  | "invalid_response"
+  | "request_failed";
+
+interface IndexedPoolStateHelperDebug {
+  configured: boolean;
+  attempted: boolean;
+  reason: IndexedPoolStateHelperReason;
+  currentBlock?: number;
+  poolCount?: number;
+  sourceRegistryMatched?: boolean;
+  httpStatus?: number;
+  statusCounts?: Record<
+    FameIndexedPoolStateBatchResponse["pools"][number]["status"],
+    number
+  >;
+}
+
+interface IndexedQuoteAdapterResult {
+  adapter: FameAsyncQuoteAdapter;
+  debug: IndexedPoolStateHelperDebug;
 }
 
 const readinessCache = new Map<
@@ -190,6 +224,7 @@ function parseQuoteBody(value: unknown): ParsedQuoteBody | string {
       Number.isFinite(body.deadlineMinutes)
         ? body.deadlineMinutes
         : undefined,
+    includeDebug: body.includeDebug === true,
   };
 }
 
@@ -285,7 +320,7 @@ function indexedPoolStateClientFromEnv(): FameIndexedPoolStateClient | null {
 }
 
 function indexedPoolStateFailureReason(error: unknown): {
-  reason: string;
+  reason: IndexedPoolStateHelperReason;
   httpStatus?: number;
 } {
   const message = error instanceof Error ? error.message : String(error);
@@ -339,32 +374,88 @@ function logIndexedPoolStateHelperUnavailable(options: {
   );
 }
 
+function indexedPoolStateStatusCounts(
+  indexedState: FameIndexedPoolStateBatchResponse,
+): IndexedPoolStateHelperDebug["statusCounts"] {
+  return indexedState.pools.reduce(
+    (counts, pool) => ({
+      ...counts,
+      [pool.status]: counts[pool.status] + 1,
+    }),
+    {
+      fresh: 0,
+      stale: 0,
+      unknown: 0,
+      unsupported: 0,
+    },
+  );
+}
+
 async function maybeWrapIndexedQuoteAdapter(options: {
   adapter: FameAsyncQuoteAdapter;
   tokenIn: Address;
   tokenOut: Address;
   poolStateClient: FameIndexedPoolStateClient | null;
-}): Promise<FameAsyncQuoteAdapter> {
+}): Promise<IndexedQuoteAdapterResult> {
   const context = options.adapter.quoteContext;
-  if (
-    !options.poolStateClient ||
-    !context ||
-    (context.source !== "live" && context.source !== "fork")
-  ) {
-    return options.adapter;
+  if (!options.poolStateClient) {
+    return {
+      adapter: options.adapter,
+      debug: {
+        configured: false,
+        attempted: false,
+        reason: "not_configured",
+      },
+    };
+  }
+  if (!context) {
+    return {
+      adapter: options.adapter,
+      debug: {
+        configured: true,
+        attempted: false,
+        reason: "adapter_context_unavailable",
+      },
+    };
+  }
+  if (context.source !== "live" && context.source !== "fork") {
+    return {
+      adapter: options.adapter,
+      debug: {
+        configured: true,
+        attempted: false,
+        reason: "unsupported_adapter_context",
+      },
+    };
   }
   if (context.blockNumber > BigInt(Number.MAX_SAFE_INTEGER)) {
-    return options.adapter;
+    return {
+      adapter: options.adapter,
+      debug: {
+        configured: true,
+        attempted: false,
+        reason: "unsafe_block_number",
+      },
+    };
   }
 
   const poolIds = famePoolStateRegistryPoolIdsForPair(
     options.tokenIn,
     options.tokenOut,
   );
-  if (poolIds.length === 0) return options.adapter;
+  if (poolIds.length === 0) {
+    return {
+      adapter: options.adapter,
+      debug: {
+        configured: true,
+        attempted: false,
+        reason: "no_registered_pools",
+      },
+    };
+  }
 
+  const currentBlock = Number(context.blockNumber);
   try {
-    const currentBlock = Number(context.blockNumber);
     const expectedSourceRegistryId = famePoolStateRegistrySourceId();
     const indexedState = await options.poolStateClient.fetchPoolStates({
       currentBlock,
@@ -381,20 +472,55 @@ async function maybeWrapIndexedQuoteAdapter(options: {
         expectedSourceRegistryId,
         actualSourceRegistryId: indexedState.sourceRegistryId,
       });
-      return options.adapter;
+      return {
+        adapter: options.adapter,
+        debug: {
+          configured: true,
+          attempted: true,
+          reason: "source_registry_mismatch",
+          currentBlock,
+          poolCount: poolIds.length,
+          sourceRegistryMatched: false,
+          statusCounts: indexedPoolStateStatusCounts(indexedState),
+        },
+      };
     }
-    return createIndexedReserveQuoteAdapter({
-      indexedState,
-      fallback: options.adapter,
-      expectedSourceRegistryId,
-    });
+    return {
+      adapter: createIndexedReserveQuoteAdapter({
+        indexedState,
+        fallback: options.adapter,
+        expectedSourceRegistryId,
+      }),
+      debug: {
+        configured: true,
+        attempted: true,
+        reason: "wrapped",
+        currentBlock,
+        poolCount: poolIds.length,
+        sourceRegistryMatched: true,
+        statusCounts: indexedPoolStateStatusCounts(indexedState),
+      },
+    };
   } catch (error) {
+    const failure = indexedPoolStateFailureReason(error);
     logIndexedPoolStateHelperUnavailable({
-      ...indexedPoolStateFailureReason(error),
-      currentBlock: Number(context.blockNumber),
+      ...failure,
+      currentBlock,
       poolCount: poolIds.length,
     });
-    return options.adapter;
+    return {
+      adapter: options.adapter,
+      debug: {
+        configured: true,
+        attempted: true,
+        reason: failure.reason,
+        currentBlock,
+        poolCount: poolIds.length,
+        ...(failure.httpStatus === undefined
+          ? {}
+          : { httpStatus: failure.httpStatus }),
+      },
+    };
   }
 }
 
@@ -602,6 +728,7 @@ export async function handleFameSwapQuotePost(
         : undefined,
   };
 
+  let indexedPoolStateDebug: IndexedPoolStateHelperDebug | undefined;
   const quote = await withTimeout(
     (async (): Promise<FameSwapQuote> => {
       const resolveReadiness = deps.readinessForQuote ?? readinessForQuote;
@@ -657,25 +784,28 @@ export async function handleFameSwapQuotePost(
         });
       }
 
-      return readiness.status === "ready"
-        ? quoteFameSwapAsync({
-            ...quoteRequest,
-            optimizerBudgets:
-              optimizerBudgetsForQuoteRequest(requestStartedAtMs),
-            readiness,
-            adapter: await maybeWrapIndexedQuoteAdapter({
-              adapter: await adapterPromise,
-              tokenIn: tokenIn.address,
-              tokenOut: tokenOut.address,
-              poolStateClient: indexedPoolStateClient,
-            }),
-          })
-        : quoteFameSwap({
-            ...quoteRequest,
-            optimizerBudgets:
-              optimizerBudgetsForQuoteRequest(requestStartedAtMs),
-            readiness,
-          });
+      if (readiness.status === "ready") {
+        const indexedAdapter = await maybeWrapIndexedQuoteAdapter({
+          adapter: await adapterPromise,
+          tokenIn: tokenIn.address,
+          tokenOut: tokenOut.address,
+          poolStateClient: indexedPoolStateClient,
+        });
+        indexedPoolStateDebug = indexedAdapter.debug;
+        const quote = await quoteFameSwapAsync({
+          ...quoteRequest,
+          optimizerBudgets: optimizerBudgetsForQuoteRequest(requestStartedAtMs),
+          readiness,
+          adapter: indexedAdapter.adapter,
+        });
+        return quote;
+      }
+
+      return quoteFameSwap({
+        ...quoteRequest,
+        optimizerBudgets: optimizerBudgetsForQuoteRequest(requestStartedAtMs),
+        readiness,
+      });
     })(),
     QUOTE_REQUEST_TIMEOUT_MS,
     `FAME quote request timed out after ${QUOTE_REQUEST_TIMEOUT_MS}ms`,
@@ -698,5 +828,14 @@ export async function handleFameSwapQuotePost(
     };
   });
 
-  return json(serializeFameSwapQuoteResponse(quote));
+  return json(
+    serializeFameSwapQuoteResponse(quote, {
+      includeDebug: parsedBody.includeDebug,
+      debug: indexedPoolStateDebug
+        ? {
+            indexedPoolState: indexedPoolStateDebug,
+          }
+        : undefined,
+    }),
+  );
 }

--- a/src/app/api/fame/swap/quote/route.test.ts
+++ b/src/app/api/fame/swap/quote/route.test.ts
@@ -20,12 +20,14 @@ function request(body: unknown): NextRequest {
   });
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
 function parseWarnEvent(value: string): Record<string, unknown> | null {
   try {
     const parsed: unknown = JSON.parse(value);
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-      ? (parsed as Record<string, unknown>)
-      : null;
+    return isRecord(parsed) ? parsed : null;
   } catch {
     return null;
   }
@@ -181,14 +183,64 @@ describe("/api/fame/swap/quote", () => {
     assert.match(json.fixtureRouteHash, /^0x[a-fA-F0-9]{64}$/);
     assert.match(json.materializedRouteHash, /^0x[a-fA-F0-9]{64}$/);
     assert.equal(json.routeHash, json.materializedRouteHash);
-    assert.equal(json.approval.kind, "approval");
-    assert.equal(json.approval.contract.functionName, "approve");
-    assert.equal(typeof json.approval.amount, "string");
-    assert.equal(json.swap.kind, "swap");
-    assert.equal(json.swap.fixtureRouteHash, json.fixtureRouteHash);
-    assert.equal(json.swap.materializedRouteHash, json.materializedRouteHash);
-    assert.equal(json.swap.contract.functionName, "executeRoute");
+    assert.equal("approval" in json, false);
+    assert.equal("swap" in json, false);
+    assert.equal("rejectedCandidates" in json, false);
+    assert.equal("optimizerSummary" in json, false);
+    assert.equal("warnings" in json, false);
+    assert.equal("debug" in json, false);
     assert.equal(typeof json.routerFeeAmount, "string");
+    assert.doesNotMatch(
+      JSON.stringify(json),
+      /protocolEvidence|activeLiquidity/,
+    );
+  });
+
+  it("serializes ready debug fields only when requested", async () => {
+    const response = await handleFameSwapQuotePost(
+      request({
+        tokenIn: USDC,
+        tokenOut: FAME,
+        amountIn: "1000000",
+        recipient: "0x0000000000000000000000000000000000000abc",
+        includeDebug: true,
+      }),
+      {
+        readinessForQuote: async (routerAddress) => ({
+          status: "ready",
+          routerAddress: routerAddress!,
+          feePpm: 2_222n,
+        }),
+        quoteForRequest: (quoteRequest) =>
+          quoteFameSwap({
+            ...quoteRequest,
+            now: new Date("2026-05-14T00:00:00Z"),
+            adapter: createDeterministicQuoteAdapter(),
+          }),
+      },
+    );
+    const json: unknown = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.ok(isRecord(json));
+    assert.equal(json.status, "ready");
+    assert.equal("approval" in json, false);
+    assert.equal("swap" in json, false);
+    const debug = json.debug;
+    assert.ok(isRecord(debug));
+    const approval = debug.approval;
+    const swap = debug.swap;
+    assert.ok(isRecord(approval));
+    assert.ok(isRecord(swap));
+    const approvalContract = approval.contract;
+    const swapContract = swap.contract;
+    assert.ok(isRecord(approvalContract));
+    assert.ok(isRecord(swapContract));
+    assert.equal(approval.kind, "approval");
+    assert.equal(approvalContract.functionName, "approve");
+    assert.equal(swap.kind, "swap");
+    assert.equal(swapContract.functionName, "executeRoute");
+    assert.ok(Array.isArray(debug.rejectedCandidates));
     assert.doesNotMatch(
       JSON.stringify(json),
       /protocolEvidence|activeLiquidity/,
@@ -231,6 +283,59 @@ describe("/api/fame/swap/quote", () => {
     assert.equal("approval" in json, false);
     assert.equal("swap" in json, false);
     assert.equal("route" in json, false);
+    assert.equal("rejectedCandidates" in json, false);
+    assert.equal("debug" in json, false);
+    assert.doesNotMatch(JSON.stringify(json), /executeRoute|approve|calldata/);
+  });
+
+  it("serializes non-ready rejected candidates only in debug responses", async () => {
+    const response = await handleFameSwapQuotePost(
+      request({
+        tokenIn: USDC,
+        tokenOut: FAME,
+        amountIn: "1000000",
+        recipient: "0x0000000000000000000000000000000000000abc",
+        includeDebug: true,
+      }),
+      {
+        readinessForQuote: async (routerAddress) => ({
+          status: "ready",
+          routerAddress: routerAddress!,
+          feePpm: 2_222n,
+        }),
+        quoteForRequest: (quoteRequest) => ({
+          status: "quote_adapter_failure",
+          tokenIn: quoteRequest.tokenIn,
+          tokenOut: quoteRequest.tokenOut,
+          requestedAmountIn: quoteRequest.amountIn,
+          rejectedCandidates: [
+            {
+              candidateId: "api-runner",
+              reason: "adapter_failure",
+              message: "Base RPC is not configured for live liquidity quotes.",
+            },
+          ],
+          message: "Base RPC is not configured for live liquidity quotes.",
+          diagnosticsVisibleByDefault: true,
+        }),
+      },
+    );
+    const json: unknown = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.ok(isRecord(json));
+    assert.equal(json.status, "quote_adapter_failure");
+    assert.equal("rejectedCandidates" in json, false);
+    const debug = json.debug;
+    assert.ok(isRecord(debug));
+    const rejectedCandidates = debug.rejectedCandidates;
+    assert.ok(Array.isArray(rejectedCandidates));
+    const [firstRejection] = rejectedCandidates;
+    assert.ok(isRecord(firstRejection));
+    assert.equal(firstRejection.candidateId, "api-runner");
+    assert.equal("approval" in json, false);
+    assert.equal("swap" in json, false);
+    assert.equal("route" in json, false);
     assert.doesNotMatch(JSON.stringify(json), /executeRoute|approve|calldata/);
   });
 
@@ -261,8 +366,8 @@ describe("/api/fame/swap/quote", () => {
     assert.equal(response.status, 200);
     assert.equal(json.status, "ready");
     assert.equal(json.route.recipient, FAME_SWAP_PREVIEW_RECIPIENT);
-    assert.equal(json.approval.kind, "approval");
-    assert.equal(json.swap.kind, "swap");
+    assert.equal("approval" in json, false);
+    assert.equal("swap" in json, false);
   });
 
   it("wraps server quotes with indexed pool-state when configured", async () => {
@@ -274,6 +379,7 @@ describe("/api/fame/swap/quote", () => {
         tokenOut: FAME,
         amountIn: "100000000000000",
         recipient: "0x0000000000000000000000000000000000000abc",
+        includeDebug: true,
       }),
       {
         readinessForQuote: async (routerAddress) => ({
@@ -342,13 +448,80 @@ describe("/api/fame/swap/quote", () => {
         },
       },
     );
-    const json = await response.json();
+    const json: unknown = await response.json();
 
     assert.equal(response.status, 200);
+    assert.ok(isRecord(json));
     assert.equal(json.status, "ready");
+    assert.ok(isRecord(json.quoteContext));
     assert.equal(json.quoteContext.source, "indexed");
+    const debug = json.debug;
+    assert.ok(isRecord(debug));
+    const indexedPoolState = debug.indexedPoolState;
+    assert.ok(isRecord(indexedPoolState));
+    assert.equal(indexedPoolState.configured, true);
+    assert.equal(indexedPoolState.attempted, true);
+    assert.equal(indexedPoolState.reason, "wrapped");
+    assert.equal(indexedPoolState.sourceRegistryMatched, true);
+    assert.ok(isRecord(indexedPoolState.statusCounts));
+    assert.equal(indexedPoolState.statusCounts.fresh, 2);
     assert.ok(requestedPoolIds[0]?.includes("uniswap-v2-fame-direct"));
     assert.doesNotMatch(JSON.stringify(json), /unit-token|protocolEvidence/);
+  });
+
+  it("reports when indexed pool-state helper is not configured", async () => {
+    const snapshot = createSnapshotQuoteAdapter();
+    const response = await handleFameSwapQuotePost(
+      request({
+        tokenIn: WETH,
+        tokenOut: FAME,
+        amountIn: "100000000000000",
+        recipient: "0x0000000000000000000000000000000000000abc",
+        includeDebug: true,
+      }),
+      {
+        readinessForQuote: async (routerAddress) => ({
+          status: "ready",
+          routerAddress: routerAddress!,
+          feePpm: 2_222n,
+        }),
+        quoteAdapterForRequest: async () => ({
+          quoteContext: {
+            source: "live",
+            chainId: 8453,
+            blockNumber: 125n,
+          },
+          async quoteEdge(edgeRequest) {
+            const quote = snapshot.quoteEdge(edgeRequest);
+            return quote.status === "quoted"
+              ? {
+                  ...quote,
+                  context: {
+                    source: "live" as const,
+                    chainId: 8453,
+                    blockNumber: 125n,
+                  },
+                }
+              : quote;
+          },
+        }),
+        indexedPoolStateClient: null,
+      },
+    );
+    const json: unknown = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.ok(isRecord(json));
+    assert.equal(json.status, "ready");
+    assert.ok(isRecord(json.quoteContext));
+    assert.equal(json.quoteContext.source, "live");
+    const debug = json.debug;
+    assert.ok(isRecord(debug));
+    const indexedPoolState = debug.indexedPoolState;
+    assert.ok(isRecord(indexedPoolState));
+    assert.equal(indexedPoolState.configured, false);
+    assert.equal(indexedPoolState.attempted, false);
+    assert.equal(indexedPoolState.reason, "not_configured");
   });
 
   it("falls back live and logs when indexed pool-state helper fails", async () => {
@@ -564,14 +737,11 @@ describe("/api/fame/swap/quote", () => {
       assert.equal(json.status, "quote_adapter_failure");
       assert.equal("approval" in json, false);
       assert.equal("swap" in json, false);
-      assert.ok(Array.isArray(json.rejectedCandidates));
+      assert.equal("rejectedCandidates" in json, false);
+      assert.equal("debug" in json, false);
       assert.doesNotMatch(
         JSON.stringify(json),
         /protocolEvidence|activeLiquidity/,
-      );
-      assert.match(
-        json.rejectedCandidates[0]?.message ?? "",
-        /Base RPC is not configured/,
       );
     } finally {
       if (previousRpc === undefined) {

--- a/src/features/fame-swap/hooks/useFameSwapQuote.test.ts
+++ b/src/features/fame-swap/hooks/useFameSwapQuote.test.ts
@@ -191,6 +191,17 @@ describe("useFameSwapQuote", () => {
       assert.ok(request);
 
       assert.equal(parsed.status, "ready");
+      if (parsed.status === "ready") {
+        assert.equal(parsed.approval?.spender, routerAddress);
+        assert.equal(parsed.approval?.amount, sourceQuote.route.amountIn);
+        assert.equal(
+          parsed.materializedRouteHash,
+          sourceQuote.materializedRouteHash,
+        );
+        assert.equal(parsed.callValue, sourceQuote.callValue);
+        assert.deepEqual(parsed.rejectedCandidates, []);
+        assert.equal(parsed.optimizerSummary, undefined);
+      }
       assert.equal(request.url, "/api/fame/swap/quote");
       assert.equal(request.init?.method, "POST");
       assert.equal(request.init?.signal, signal);
@@ -201,6 +212,7 @@ describe("useFameSwapQuote", () => {
       assert.equal(body.recipient, recipient);
       assert.equal(body.slippageBps, 175);
       assert.equal(body.deadlineMinutes, 17);
+      assert.equal("includeDebug" in body, false);
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -328,7 +340,7 @@ describe("useFameSwapQuote", () => {
     }
   });
 
-  it("rebuilds a ready API quote into the shared executable quote shape", () => {
+  it("rebuilds a compact ready API quote into the shared executable quote shape", () => {
     const tokenIn = tokenForAddress(USDC);
     const tokenOut = tokenForAddress(FAME);
     assert.ok(tokenIn);
@@ -367,8 +379,6 @@ describe("useFameSwapQuote", () => {
       expiresAt: sourceQuote.expiresAt.toISOString(),
       routeHash: sourceQuote.materializedRouteHash,
       poolIds: sourceQuote.poolIds,
-      warnings: sourceQuote.warnings,
-      rejectedCandidates: sourceQuote.rejectedCandidates,
       route: sourceQuote.route,
       routeDisplay: sourceQuote.routeDisplay,
     });
@@ -391,6 +401,78 @@ describe("useFameSwapQuote", () => {
       assert.equal(parsed.feePpm, sourceQuote.feePpm);
       assert.equal(parsed.capabilities.splitThenMerge, true);
       assert.equal(parsed.feeBreakdown.legs[0]?.amountIn > 0n, true);
+      assert.deepEqual(parsed.rejectedCandidates, []);
+      assert.equal(parsed.optimizerSummary, undefined);
+    }
+  });
+
+  it("rebuilds optional debug fields when a developer quote response includes them", () => {
+    const tokenIn = tokenForAddress(USDC);
+    const tokenOut = tokenForAddress(FAME);
+    assert.ok(tokenIn);
+    assert.ok(tokenOut);
+    const artifact = routeArtifactById("solver-usdc-split-frxusd-merge-fame");
+    assert.ok(artifact);
+    const sourceQuote = quoteWithReadyReadiness({
+      tokenIn,
+      tokenOut,
+      amountIn: BigInt(artifact.route.amountIn),
+      recipient,
+      routerAddress,
+      now: new Date("2026-05-13T00:00:00Z"),
+      adapter: createDeterministicQuoteAdapter(),
+    });
+    assert.equal(sourceQuote.status, "ready");
+    if (sourceQuote.status !== "ready") return;
+
+    const apiResponse = jsonRoundTrip(
+      serializeFameSwapQuoteResponse(
+        {
+          ...sourceQuote,
+          optimizerSummary: {
+            mode: "select",
+            status: "selected",
+            selectedTemplateId: "debug-template",
+            selectedAllocationBps: 5_000,
+            selectedCandidateId: "debug-candidate",
+            winningMarginBps: 25,
+            trialStatusCounts: {
+              selected: 1,
+              rejected: 1,
+              pruned: 0,
+              budget_exhausted: 0,
+              quote_failed: 0,
+              unsupported_shape: 0,
+              ineligible: 0,
+            },
+            fallbackReason: null,
+            runStats: {
+              logicalQuoteRequests: 2,
+              uniqueExactQuoteReads: 1,
+              exactQuoteCacheHits: 1,
+              trials: 2,
+              templatesConsidered: 1,
+              budgetExhaustions: 0,
+              timeout: false,
+            },
+          },
+        },
+        { includeDebug: true },
+      ),
+    );
+
+    const parsed = deserializeFameSwapQuoteResponse(apiResponse, {
+      tokenIn,
+      tokenOut,
+      amountIn: sourceQuote.requestedAmountIn,
+      config: config(),
+    });
+
+    assert.equal(parsed.status, "ready");
+    if (parsed.status === "ready") {
+      assert.equal(parsed.optimizerSummary?.selectedTemplateId, "debug-template");
+      assert.equal(parsed.optimizerSummary?.selectedAllocationBps, 5_000);
+      assert.ok(parsed.rejectedCandidates.length > 0);
     }
   });
 
@@ -404,13 +486,6 @@ describe("useFameSwapQuote", () => {
       {
         status: "quote_adapter_failure",
         message: "Base RPC is not configured for live liquidity quotes.",
-        rejectedCandidates: [
-          {
-            candidateId: "api-runner",
-            reason: "adapter_failure",
-            message: "Base RPC is not configured for live liquidity quotes.",
-          },
-        ],
       },
       {
         tokenIn,
@@ -423,5 +498,8 @@ describe("useFameSwapQuote", () => {
     assert.equal(parsed.status, "quote_adapter_failure");
     assert.equal("route" in parsed, false);
     assert.equal("approval" in parsed, false);
+    if (parsed.status === "quote_adapter_failure") {
+      assert.deepEqual(parsed.rejectedCandidates, []);
+    }
   });
 });

--- a/src/features/fame-swap/solver/quoteWire.test.ts
+++ b/src/features/fame-swap/solver/quoteWire.test.ts
@@ -9,8 +9,11 @@ import { DEFAULT_FAME_SWAP_SLIPPAGE_BPS } from "./slippage";
 import {
   deserializeFameSwapQuoteResponse,
   FAME_SWAP_QUOTE_WIRE_STATUSES,
+  type SerializeQuoteResponseOptions,
   serializeFameSwapQuoteResponse,
 } from "./quoteWire";
+import type { FameOptimizerEvidence } from "./optimizer/types";
+import type { FameSwapOptimizerSummary } from "./types";
 import { FAME, USDC, tokenForAddress } from "../tokens";
 
 const routerAddress = "0x0000000000000000000000000000000000000009";
@@ -32,7 +35,69 @@ function config(): FameSwapConfig {
   };
 }
 
-function readyWireResponse() {
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function optimizerEvidenceFixture(): FameOptimizerEvidence {
+  return {
+    mode: "select",
+    status: "selected",
+    selectedTemplateId: "secret-template",
+    selectedAllocationBps: 6_250,
+    selectedAllocationVectorBps: null,
+    selectedAlgorithm: "grid",
+    selectedStopReason: "grid_complete",
+    selectedCandidateId: "secret-candidate",
+    objective: {
+      baselineProtectedAmountOut: 1_000n,
+      selectedProtectedAmountOut: 1_012n,
+      winningMarginAmount: 12n,
+      winningMarginBps: 12,
+    },
+    trialStatusCounts: {
+      selected: 1,
+      rejected: 2,
+      pruned: 0,
+      budget_exhausted: 0,
+      quote_failed: 0,
+      unsupported_shape: 0,
+      ineligible: 0,
+    },
+    allocationTrials: [
+      {
+        templateId: "secret-template",
+        allocationBps: 6_250,
+        algorithm: "grid",
+        stopReason: "grid_complete",
+        status: "selected",
+        reason: "raw optimizer trial",
+        candidateId: "secret-candidate",
+        poolIds: ["secret-pool"],
+      },
+    ],
+    templateEligibility: [],
+    quotePlanStats: {
+      logicalQuoteRequests: 1,
+      uniqueExactQuoteReads: 1,
+      exactQuoteCacheHits: 0,
+      inFlightExactQuoteCoalesces: 0,
+      stateReadRequests: 0,
+      uniqueStateReads: 0,
+      stateReadCacheHits: 0,
+      inFlightStateReadCoalesces: 0,
+      underlyingRpcReads: 0,
+      allocationTrials: 1,
+      templatesConsidered: 1,
+      budgetExhaustions: 0,
+      timeout: false,
+      fallbackReason: null,
+    },
+    fallbackReason: null,
+  };
+}
+
+function readyWireResponse(options: SerializeQuoteResponseOptions = {}) {
   const tokenIn = tokenForAddress(USDC);
   const tokenOut = tokenForAddress(FAME);
   assert.ok(tokenIn);
@@ -55,7 +120,7 @@ function readyWireResponse() {
     tokenIn,
     tokenOut,
     quote,
-    wire: serializeFameSwapQuoteResponse(quote),
+    wire: serializeFameSwapQuoteResponse(quote, options),
   };
 }
 
@@ -82,6 +147,12 @@ describe("FAME swap quote wire contract", () => {
     assert.equal(typeof wire.requestedAmountIn, "string");
     assert.equal(typeof wire.routerFeeAmount, "string");
     assert.equal(typeof wire.expiresAt, "string");
+    assert.equal("approval" in wire, false);
+    assert.equal("swap" in wire, false);
+    assert.equal("rejectedCandidates" in wire, false);
+    assert.equal("optimizerSummary" in wire, false);
+    assert.equal("warnings" in wire, false);
+    assert.equal("debug" in wire, false);
     assert.doesNotMatch(
       JSON.stringify(wire),
       /protocolEvidence|activeLiquidity/,
@@ -99,68 +170,77 @@ describe("FAME swap quote wire contract", () => {
       assert.equal(parsed.materializedRouteHash, quote.materializedRouteHash);
       assert.equal(parsed.fixtureRouteHash, quote.fixtureRouteHash);
       assert.equal(parsed.feeBreakdown.legs[0]?.amountIn > 0n, true);
+      assert.deepEqual(parsed.rejectedCandidates, []);
+      assert.equal(parsed.optimizerSummary, undefined);
     }
   });
 
-  it("does not serialize raw optimizer evidence on ready public responses", () => {
+  it("keeps ready response diagnostics behind explicit debug opt-in", () => {
     const { tokenIn, tokenOut, quote } = readyWireResponse();
-    const wire = serializeFameSwapQuoteResponse({
-      ...quote,
-      optimizerSummary: {
-        mode: "select",
-        status: "selected",
-        selectedTemplateId: "public-template",
-        selectedAllocationBps: 6_250,
-        selectedCandidateId: "public-candidate",
-        winningMarginBps: 12,
-        trialStatusCounts: {
-          selected: 1,
-          rejected: 2,
-          pruned: 0,
-          budget_exhausted: 0,
-          quote_failed: 0,
-          unsupported_shape: 0,
-          ineligible: 0,
-        },
-        fallbackReason: null,
-        runStats: {
-          logicalQuoteRequests: 5,
-          uniqueExactQuoteReads: 3,
-          exactQuoteCacheHits: 2,
-          trials: 4,
-          templatesConsidered: 2,
-          budgetExhaustions: 0,
-          timeout: false,
-        },
+    const optimizerSummary: FameSwapOptimizerSummary = {
+      mode: "select",
+      status: "selected",
+      selectedTemplateId: "public-template",
+      selectedAllocationBps: 6_250,
+      selectedCandidateId: "public-candidate",
+      winningMarginBps: 12,
+      trialStatusCounts: {
+        selected: 1,
+        rejected: 2,
+        pruned: 0,
+        budget_exhausted: 0,
+        quote_failed: 0,
+        unsupported_shape: 0,
+        ineligible: 0,
       },
-      optimizerEvidence: {
-        allocationTrials: [
-          {
-            templateId: "secret-template",
-            allocationBps: 6_250,
-            status: "selected",
-            reason: "raw optimizer trial",
-            poolIds: ["secret-pool"],
-          },
-        ],
-        quotePlanStats: {
-          logicalQuoteRequests: 1,
-        },
-      } as never,
+      fallbackReason: null,
+      runStats: {
+        logicalQuoteRequests: 5,
+        uniqueExactQuoteReads: 3,
+        exactQuoteCacheHits: 2,
+        trials: 4,
+        templatesConsidered: 2,
+        budgetExhaustions: 0,
+        timeout: false,
+      },
+    };
+    const sourceQuote = {
+      ...quote,
+      warnings: ["debug quote warning"],
+      optimizerSummary,
+      optimizerEvidence: optimizerEvidenceFixture(),
+    };
+    const wire = serializeFameSwapQuoteResponse(sourceQuote);
+    const debugWire = serializeFameSwapQuoteResponse(sourceQuote, {
+      includeDebug: true,
     });
 
     assert.doesNotMatch(
       JSON.stringify(wire),
-      /optimizerEvidence|allocationTrials|quotePlanStats|secret-template|secret-pool/,
+      /optimizerEvidence|optimizerSummary|allocationTrials|quotePlanStats|secret-template|secret-pool|rejectedCandidates/,
     );
+    assert.equal("warnings" in wire, false);
+    assert.equal("debug" in wire, false);
 
-    assert.equal(
-      (wire.optimizerSummary as { selectedAllocationBps?: number })
-        .selectedAllocationBps,
-      6_250,
+    const readyDebug = debugWire.debug;
+    assert.ok(isRecord(readyDebug));
+    assert.ok(isRecord(readyDebug.optimizerSummary));
+    assert.ok(isRecord(readyDebug.approval));
+    assert.ok(isRecord(readyDebug.swap));
+    assert.deepEqual(readyDebug.warnings, ["debug quote warning"]);
+    assert.equal(readyDebug.optimizerSummary.selectedAllocationBps, 6_250);
+    assert.equal(readyDebug.approval.kind, "approval");
+    assert.equal(readyDebug.swap.kind, "swap");
+    assert.doesNotMatch(
+      JSON.stringify(debugWire),
+      /optimizerEvidence|allocationTrials|quotePlanStats|secret-template|secret-pool|protocolEvidence|activeLiquidity/,
     );
+    const compactBytes = JSON.stringify(wire).length;
+    const debugBytes = JSON.stringify(debugWire).length;
+    assert.ok(compactBytes < 10_000);
+    assert.ok(debugBytes > compactBytes * 3);
 
-    const parsed = deserializeFameSwapQuoteResponse(wire, {
+    const parsed = deserializeFameSwapQuoteResponse(debugWire, {
       tokenIn,
       tokenOut,
       amountIn: quote.requestedAmountIn,
@@ -170,6 +250,7 @@ describe("FAME swap quote wire contract", () => {
     if (parsed.status === "ready") {
       assert.equal(parsed.optimizerSummary?.status, "selected");
       assert.equal(parsed.optimizerSummary?.selectedAllocationBps, 6_250);
+      assert.deepEqual(parsed.warnings, ["debug quote warning"]);
     }
   });
 
@@ -277,6 +358,7 @@ describe("FAME swap quote wire contract", () => {
 
     assert.equal(wire.status, "not_live_ready");
     assert.equal(wire.requestedAmountIn, "5000000");
+    assert.equal("debug" in wire, false);
     assert.equal("approval" in wire, false);
     assert.equal("swap" in wire, false);
     assert.equal("route" in wire, false);
@@ -284,5 +366,51 @@ describe("FAME swap quote wire contract", () => {
       (wire.readiness as { reason?: string } | undefined)?.reason,
       "missing_router",
     );
+  });
+
+  it("keeps non-ready rejected candidates in debug responses only", () => {
+    const tokenIn = tokenForAddress(USDC);
+    const tokenOut = tokenForAddress(FAME);
+    assert.ok(tokenIn);
+    assert.ok(tokenOut);
+    const quote = {
+      status: "quote_adapter_failure" as const,
+      tokenIn,
+      tokenOut,
+      requestedAmountIn: 5_000_000n,
+      rejectedCandidates: [
+        {
+          candidateId: "api-runner",
+          reason: "adapter_failure" as const,
+          message: "Base RPC is not configured for live liquidity quotes.",
+        },
+      ],
+      message: "Base RPC is not configured for live liquidity quotes.",
+      diagnosticsVisibleByDefault: true,
+    };
+    const wire = serializeFameSwapQuoteResponse(quote);
+    const debugWire = serializeFameSwapQuoteResponse(quote, {
+      includeDebug: true,
+    });
+
+    assert.equal("rejectedCandidates" in wire, false);
+    assert.equal("debug" in wire, false);
+    const debug = debugWire.debug;
+    assert.ok(isRecord(debug));
+    assert.ok(Array.isArray(debug.rejectedCandidates));
+    const [firstRejection] = debug.rejectedCandidates;
+    assert.ok(isRecord(firstRejection));
+    assert.equal(firstRejection.candidateId, "api-runner");
+
+    const parsed = deserializeFameSwapQuoteResponse(debugWire, {
+      tokenIn,
+      tokenOut,
+      amountIn: quote.requestedAmountIn,
+      config: config(),
+    });
+    assert.equal(parsed.status, "quote_adapter_failure");
+    if (parsed.status === "quote_adapter_failure") {
+      assert.equal(parsed.rejectedCandidates[0]?.candidateId, "api-runner");
+    }
   });
 });

--- a/src/features/fame-swap/solver/quoteWire.ts
+++ b/src/features/fame-swap/solver/quoteWire.ts
@@ -27,6 +27,11 @@ export interface DeserializeQuoteInput {
   config: FameSwapConfig;
 }
 
+export interface SerializeQuoteResponseOptions {
+  includeDebug?: boolean;
+  debug?: Record<string, unknown>;
+}
+
 type JsonSafe =
   | null
   | string
@@ -87,6 +92,10 @@ function bigintFrom(value: unknown, fallback = 0n): bigint {
   }
   if (typeof value === "string" && /^[0-9]+$/.test(value)) return BigInt(value);
   return fallback;
+}
+
+function stringArrayFrom(value: unknown): string[] {
+  return Array.isArray(value) ? value.map(String) : [];
 }
 
 function numberFrom(value: unknown, fallback = 0): number {
@@ -396,19 +405,52 @@ export function publicFeeBreakdown(
   };
 }
 
+function quoteBaseFields(quote: FameSwapQuote): Record<string, unknown> {
+  return {
+    status: quote.status,
+    tokenIn: quote.tokenIn,
+    tokenOut: quote.tokenOut,
+    requestedAmountIn: quote.requestedAmountIn,
+    message: quote.message,
+    diagnosticsVisibleByDefault: quote.diagnosticsVisibleByDefault,
+  };
+}
+
+function quoteDebugFields(quote: FameSwapQuote): Record<string, unknown> {
+  const debug: Record<string, unknown> = {};
+
+  if ("rejectedCandidates" in quote) {
+    debug.rejectedCandidates = quote.rejectedCandidates;
+  }
+
+  if (quote.status === "ready") {
+    const requests = fameSwapTransactionRequests(quote);
+    debug.approval = requests.approval;
+    debug.swap = requests.swap;
+    debug.optimizerSummary = quote.optimizerSummary;
+    debug.warnings = quote.warnings;
+  }
+
+  return debug;
+}
+
+function optionalDebugFields(
+  quote: FameSwapQuote,
+  options: SerializeQuoteResponseOptions,
+): { debug?: Record<string, unknown> } {
+  return options.includeDebug === true
+    ? { debug: { ...quoteDebugFields(quote), ...(options.debug ?? {}) } }
+    : {};
+}
+
 export function serializeFameSwapQuoteResponse(
   quote: FameSwapQuote,
+  options: SerializeQuoteResponseOptions = {},
 ): Record<string, JsonSafe> {
   switch (quote.status) {
     case "ready": {
-      const requests = fameSwapTransactionRequests(quote);
       return toJsonSafe({
-        status: quote.status,
-        tokenIn: quote.tokenIn,
-        tokenOut: quote.tokenOut,
-        requestedAmountIn: quote.requestedAmountIn,
-        message: quote.message,
-        diagnosticsVisibleByDefault: quote.diagnosticsVisibleByDefault,
+        ...quoteBaseFields(quote),
         routeArtifactId: quote.routeArtifactId,
         routeSource: quote.routeSource,
         routerAddress: quote.routerAddress,
@@ -427,22 +469,42 @@ export function serializeFameSwapQuoteResponse(
         materializedRouteHash: quote.materializedRouteHash,
         routeHash: quote.materializedRouteHash,
         poolIds: quote.poolIds,
-        warnings: quote.warnings,
-        optimizerSummary: quote.optimizerSummary,
-        rejectedCandidates: quote.rejectedCandidates,
-        approval: requests.approval,
-        swap: requests.swap,
         route: quote.route,
         routeDisplay: quote.routeDisplay,
+        ...optionalDebugFields(quote, options),
       }) as Record<string, JsonSafe>;
     }
     case "unsupported":
+      return toJsonSafe({
+        ...quoteBaseFields(quote),
+        availableDirections: quote.availableDirections,
+        ...optionalDebugFields(quote, options),
+      }) as Record<string, JsonSafe>;
     case "stale_artifact":
+      return toJsonSafe({
+        ...quoteBaseFields(quote),
+        reason: quote.reason,
+        ...optionalDebugFields(quote, options),
+      }) as Record<string, JsonSafe>;
     case "not_live_ready":
+      return toJsonSafe({
+        ...quoteBaseFields(quote),
+        routeArtifactId: quote.routeArtifactId,
+        readiness: quote.readiness,
+        ...optionalDebugFields(quote, options),
+      }) as Record<string, JsonSafe>;
     case "no_safe_route":
     case "quote_adapter_failure":
+      return toJsonSafe({
+        ...quoteBaseFields(quote),
+        ...optionalDebugFields(quote, options),
+      }) as Record<string, JsonSafe>;
     case "simulation_failure":
-      return toJsonSafe(quote) as Record<string, JsonSafe>;
+      return toJsonSafe({
+        ...quoteBaseFields(quote),
+        reason: quote.reason,
+        ...optionalDebugFields(quote, options),
+      }) as Record<string, JsonSafe>;
     default:
       return assertNever(quote);
   }
@@ -453,6 +515,7 @@ export function deserializeFameSwapQuoteResponse(
   input: DeserializeQuoteInput,
 ): FameSwapQuote {
   const raw = asRecord(data);
+  const debug = asRecord(raw.debug);
   const status = raw.status;
   const message = String(raw.message ?? "FAME quote unavailable.");
   const requestedAmountIn = bigintFrom(raw.requestedAmountIn, input.amountIn);
@@ -514,14 +577,18 @@ export function deserializeFameSwapQuoteResponse(
         routeDisplay: Array.isArray(raw.routeDisplay)
           ? (raw.routeDisplay as FameSwapRouteDisplayLeg[])
           : [],
-        rejectedCandidates: parseRejections(raw.rejectedCandidates),
+        rejectedCandidates: parseRejections(
+          raw.rejectedCandidates ?? debug.rejectedCandidates,
+        ),
         slippageBps: numberFrom(
           raw.slippageBps,
           input.config.defaultSlippageBps,
         ),
         expiresAt: new Date(String(raw.expiresAt ?? Date.now())),
-        warnings: Array.isArray(raw.warnings) ? raw.warnings.map(String) : [],
-        optimizerSummary: parseOptimizerSummary(raw.optimizerSummary),
+        warnings: stringArrayFrom(raw.warnings ?? debug.warnings),
+        optimizerSummary: parseOptimizerSummary(
+          raw.optimizerSummary ?? debug.optimizerSummary,
+        ),
         message,
         diagnosticsVisibleByDefault: booleanFrom(
           raw.diagnosticsVisibleByDefault,
@@ -585,7 +652,9 @@ export function deserializeFameSwapQuoteResponse(
       tokenIn: input.tokenIn,
       tokenOut: input.tokenOut,
       requestedAmountIn,
-      rejectedCandidates: parseRejections(raw.rejectedCandidates),
+      rejectedCandidates: parseRejections(
+        raw.rejectedCandidates ?? debug.rejectedCandidates,
+      ),
       message,
       diagnosticsVisibleByDefault: booleanFrom(
         raw.diagnosticsVisibleByDefault,
@@ -601,7 +670,9 @@ export function deserializeFameSwapQuoteResponse(
       tokenOut: input.tokenOut,
       requestedAmountIn,
       reason: String(raw.reason ?? message),
-      rejectedCandidates: parseRejections(raw.rejectedCandidates),
+      rejectedCandidates: parseRejections(
+        raw.rejectedCandidates ?? debug.rejectedCandidates,
+      ),
       message,
       diagnosticsVisibleByDefault: booleanFrom(
         raw.diagnosticsVisibleByDefault,
@@ -615,7 +686,9 @@ export function deserializeFameSwapQuoteResponse(
     tokenIn: input.tokenIn,
     tokenOut: input.tokenOut,
     requestedAmountIn,
-    rejectedCandidates: parseRejections(raw.rejectedCandidates),
+    rejectedCandidates: parseRejections(
+      raw.rejectedCandidates ?? debug.rejectedCandidates,
+    ),
     message,
     diagnosticsVisibleByDefault: booleanFrom(
       raw.diagnosticsVisibleByDefault,


### PR DESCRIPTION
## Summary
FAME swap quotes now return the small frontend contract by default while preserving the executable route data needed to rebuild approval and swap calls client-side. Developer/debug callers can opt into the heavier diagnostics with `includeDebug: true`, including sanitized indexed pool-state helper status that explains whether the backend helper was configured, attempted, wrapped, or fell back.

This also records the implementation plan in `docs/plans/2026-05-19-001-refactor-fame-swap-quote-response-plan.md`.

## Details
- Moves top-level `approval`, `swap`, `rejectedCandidates`, `optimizerSummary`, and raw warnings out of the default quote response and under `debug` only when requested.
- Keeps ready responses executable through route/hash/output/fee/slippage/context fields and updates deserialization to tolerate compact/default and debug-backed shapes.
- Adds `debug.indexedPoolState` with non-secret helper status (`reason`, `attempted`, source-registry match, block/pool counts, and status counts) for diagnosing live vs indexed quote behavior.
- Adds coverage for compact ready/non-ready responses, debug opt-in, helper configured/not-configured paths, warning reconstruction, and client-side transaction request reconstruction.

## Tests
- `bun test src/features/fame-swap/solver/quoteWire.test.ts src/app/api/fame/swap/quote/route.test.ts src/features/fame-swap/hooks/useFameSwapQuote.test.ts src/features/fame-swap/transactions.test.ts`
- `bun test src/features/fame-swap/components/FameSwapWidget.test.ts src/features/fame-swap/ui/quoteView.test.ts src/features/fame-swap/ui/routeGraph.test.ts`
- `TMPDIR=/tmp yarn --cache-folder /tmp/yarn-cache lint --ignore-pattern ".worktrees/**"`
- `git diff --check`

## Review Notes
- API contract review flagged the compact default as an intentional breaking response-shape change; release notes should call this out for any non-repo clients.
- The new `society-bots` CL head market-state entries are not consumed yet by `www`; this PR adds diagnostics that make that mismatch visible.

---
[![Compound Engineering](https://img.shields.io/badge/Compound%20Engineering-✓-blueviolet)](https://github.com/CompoundEngineering)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
