### PR TITLE
feat(fame): consume CL head pool state

### DIFF
--- a/docs/fame-swap-route-lab.md
+++ b/docs/fame-swap-route-lab.md
@@ -6,7 +6,7 @@ The route lab runs amount buckets through the shared FAME swap solver without Re
 
 - Recorded mode is the default: `bun scripts/fame-swap-route-lab.ts`. It replays the recorded-state artifact `base-v1-pool-state-snapshot.json`, captured from read-only Base quote calls and pool state at `base-v1-live-45964183`.
 - Deterministic mode is explicit: `bun scripts/fame-swap-route-lab.ts --deterministic`. It uses the pinned test-only deterministic capacity profile to prove old cap failures and pure solver behavior.
-- Indexed mode: `BASE_RPC_URL=... FAME_POOL_STATE_API_URL=... FAME_POOL_STATE_SERVICE_TOKEN=... bun scripts/fame-swap-route-lab.ts --indexed`. It asks the `society-bots` pool-state API for the current reviewed candidate pools, replays fresh V2-style reserves locally, and falls back to recorded quote evidence for stale, unknown, or unsupported pools. Freshness is checked against a live Base block from server-only `BASE_RPC_URL`, or an explicit `FAME_POOL_STATE_CURRENT_BLOCK`; indexed mode no longer falls back to the pinned artifact block.
+- Indexed mode: `BASE_RPC_URL=... FAME_POOL_STATE_API_URL=... FAME_POOL_STATE_SERVICE_TOKEN=... bun scripts/fame-swap-route-lab.ts --indexed`. It asks the `society-bots` pool-state API for the current reviewed candidate pools, including CL head snapshots, replays fresh V2-style reserves locally, and falls back to recorded quote evidence for stale, unknown, unsupported, or non-replayable state. Freshness is checked against a live Base block from server-only `BASE_RPC_URL`, or an explicit `FAME_POOL_STATE_CURRENT_BLOCK`; indexed mode no longer falls back to the pinned artifact block.
 - Live mode: `doppler run -- bun scripts/fame-swap-route-lab.ts --live`. It reads Base RPC liquidity through the live adapters and records a live block quote context. Server/operator runs prefer `BASE_RPC_URL`; `NEXT_PUBLIC_BASE_RPC_URL_1` is only a fallback for browser-safe or local endpoints.
 - Live simulation: add `--simulate` and set `FAME_SWAP_SIMULATION_ACCOUNT` or `NEXT_PUBLIC_FAME_SWAP_SIMULATION_ACCOUNT`. ERC20 routes simulate approval plus swap as one bundle, derive a slippage-protected minimum from the probe result, then simulate the protected route; native routes do the same with direct router calls. This is the initiating-account path for below-balance and route-execution checks. Default JSON and Markdown use a shortened account label.
 - Markdown output: add `--markdown` to any mode.
@@ -19,11 +19,11 @@ Ready rows include a quote context:
 
 - `deterministic-test:<profile>` for test-only cap profiles.
 - `recorded:<captureId>:<pinnedBaseBlock>` for deterministic recorded-state replay.
-- `indexed:8453:<block>:fresh <n>, stale <n>, unknown <n>, unsupported <n>` when fresh indexed pool state supplied at least one selected quote-model leg.
+- `indexed:8453:<block>:fresh <n>, stale <n>, unknown <n>, unsupported <n>` when fresh indexed pool state supplied at least one selected quote-model leg. The Markdown `Indexed pool state` line also separates reserve-replay rows from CL head snapshot rows.
 - `live:8453:<block>` for read-only Base liquidity quotes.
 
 Recorded and live quote outputs are exact-input leg quotes. Venue fees are already included in adapter outputs; the FLS router fee is calculated and emitted separately.
-Indexed quote outputs use the same reserve replay math as recorded snapshots for quote-model pools. Freshness is based on `observedThroughBlock`; `lastReserveChangeBlock` is diagnostic only because quiet pools can remain fresh without a recent Sync event.
+Indexed quote outputs use the same reserve replay math as recorded snapshots for quote-model pools. Freshness is based on `observedThroughBlock`; `lastReserveChangeBlock` is diagnostic only because quiet pools can remain fresh without a recent Sync event. CL head snapshots are complete head-state rows for identity, fee metadata, tick spacing, state-view address where relevant, `sqrtPriceX96`, current tick, active liquidity, source, and provenance. They intentionally do not include tick-boundary warnings; clients should continue using live CL reads when they need quote math or when indexed state is stale, unknown, unsupported, malformed, or otherwise not replayable.
 
 Server-only helper env for route lab and quote API:
 

--- a/scripts/fame-swap-route-lab.test.ts
+++ b/scripts/fame-swap-route-lab.test.ts
@@ -156,19 +156,44 @@ describe("FAME route lab", () => {
       (candidate) => candidate.id === "weth-fame-small-direct",
     );
     assert.ok(entry);
+    const requestedStateSurfaces: Array<readonly string[] | undefined> = [];
     const rows = await runIndexedRouteLab([entry], {
       currentBlock: 125,
       poolStateClient: {
         async fetchPoolStates(request) {
+          requestedStateSurfaces.push(request.stateSurfaces);
           return {
             sourceRegistryId: famePoolStateRegistrySourceId(),
             currentBlock: request.currentBlock,
             producerMaxFreshnessBlocks: 120,
             effectiveMaxFreshnessBlocks: 120,
             pools: request.poolIds.map((poolId) =>
-              poolId === "scale-equalizer-weth-fame" ||
-              poolId === "uniswap-v2-fame-direct"
+              poolId === "uniswap-v3-usdc-weth-5bps"
                 ? {
+                    status: "fresh" as const,
+                    stateKind: "cl-head-snapshot" as const,
+                    poolId,
+                    chainId: 8453,
+                    poolAddress: "0xd0b53d9277642d899df5c87a3966a349a798f224",
+                    poolKey: null,
+                    token0: WETH,
+                    token1: USDC,
+                    venueFamily: "UniswapV3",
+                    feeBps: 5,
+                    feeLabel: "5 bps",
+                    tickSpacing: 10,
+                    stateViewAddress: null,
+                    sqrtPriceX96: "79228162514264337593543950336",
+                    tick: 0,
+                    liquidity: "1000000",
+                    observedThroughBlock: 124,
+                    source: "pool-slot0-liquidity" as const,
+                    sourceRegistryId: famePoolStateRegistrySourceId(),
+                    maxFreshnessBlocks: 120,
+                  }
+                : poolId === "scale-equalizer-weth-fame" ||
+                    poolId === "uniswap-v2-fame-direct"
+                  ? {
                     status: "fresh" as const,
                     poolId,
                     chainId: 8453,
@@ -187,7 +212,7 @@ describe("FAME route lab", () => {
                     quoteModel: "constant-product-reserves" as const,
                     maxFreshnessBlocks: 120,
                   }
-                : {
+                  : {
                     status: "unknown" as const,
                     requested: { poolId },
                     reason: "unit-test",
@@ -202,7 +227,20 @@ describe("FAME route lab", () => {
 
     assert.equal(row.mode, "indexed");
     assert.ok((row.indexedPoolState?.statusCounts.fresh ?? 0) > 0);
+    assert.deepEqual(requestedStateSurfaces[0], ["cl-head-snapshot"]);
+    assert.equal(
+      row.indexedPoolState?.stateSurfaceCounts.constantProductReserves.fresh,
+      2,
+    );
+    assert.equal(
+      row.indexedPoolState?.stateSurfaceCounts.clHeadSnapshots.fresh,
+      1,
+    );
     assert.match(row.quoteContext ?? "", /^indexed:8453:125:/);
+
+    const markdown = formatRouteLabMarkdown(rows);
+    assert.match(markdown, /CL head fresh 1/);
+    assert.doesNotMatch(markdown, /boundary/i);
   });
 
   it("fails indexed mode clearly without a current block source", async () => {

--- a/scripts/fame-swap-route-lab.ts
+++ b/scripts/fame-swap-route-lab.ts
@@ -113,6 +113,16 @@ export interface FameRouteLabIndexedPoolStateSummary {
     unknown: number;
     unsupported: number;
   };
+  stateSurfaceCounts: {
+    constantProductReserves: {
+      fresh: number;
+      stale: number;
+    };
+    clHeadSnapshots: {
+      fresh: number;
+      stale: number;
+    };
+  };
 }
 
 export interface FameRouteLabOptimizerSummary {
@@ -311,6 +321,7 @@ export async function runIndexedRouteLab(
     const indexedState = await options.poolStateClient.fetchPoolStates({
       currentBlock,
       maxFreshnessBlocks: options.maxFreshnessBlocks,
+      stateSurfaces: ["cl-head-snapshot"],
       poolIds: famePoolStateRegistryPoolIdsForPair(
         entry.tokenIn,
         entry.tokenOut,
@@ -513,23 +524,41 @@ function candidateGenerationDiagnostics(
 function indexedPoolStateSummary(
   indexedState: FameIndexedPoolStateBatchResponse,
 ): FameRouteLabIndexedPoolStateSummary {
-  const statusCounts = indexedState.pools.reduce(
-    (counts, pool) => ({
-      ...counts,
-      [pool.status]: counts[pool.status] + 1,
-    }),
-    {
+  const statusCounts = {
+    fresh: 0,
+    stale: 0,
+    unknown: 0,
+    unsupported: 0,
+  };
+  const stateSurfaceCounts = {
+    constantProductReserves: {
       fresh: 0,
       stale: 0,
-      unknown: 0,
-      unsupported: 0,
     },
-  );
+    clHeadSnapshots: {
+      fresh: 0,
+      stale: 0,
+    },
+  };
+  for (const pool of indexedState.pools) {
+    statusCounts[pool.status] += 1;
+    if (pool.status !== "fresh" && pool.status !== "stale") continue;
+    if (
+      "quoteModel" in pool &&
+      pool.quoteModel === "constant-product-reserves"
+    ) {
+      stateSurfaceCounts.constantProductReserves[pool.status] += 1;
+    }
+    if ("stateKind" in pool && pool.stateKind === "cl-head-snapshot") {
+      stateSurfaceCounts.clHeadSnapshots[pool.status] += 1;
+    }
+  }
   return {
     sourceRegistryId: indexedState.sourceRegistryId,
     currentBlock: indexedState.currentBlock,
     effectiveMaxFreshnessBlocks: indexedState.effectiveMaxFreshnessBlocks,
     statusCounts,
+    stateSurfaceCounts,
   };
 }
 
@@ -1062,6 +1091,10 @@ function indexedPoolStateSummaryLine(
     `stale ${indexed.statusCounts.stale}`,
     `unknown ${indexed.statusCounts.unknown}`,
     `unsupported ${indexed.statusCounts.unsupported}`,
+    `reserve replay fresh ${indexed.stateSurfaceCounts.constantProductReserves.fresh}`,
+    `reserve replay stale ${indexed.stateSurfaceCounts.constantProductReserves.stale}`,
+    `CL head fresh ${indexed.stateSurfaceCounts.clHeadSnapshots.fresh}`,
+    `CL head stale ${indexed.stateSurfaceCounts.clHeadSnapshots.stale}`,
     `max freshness ${indexed.effectiveMaxFreshnessBlocks}`,
   ].join(", ");
 }

--- a/src/app/api/fame/swap/quote/handler.ts
+++ b/src/app/api/fame/swap/quote/handler.ts
@@ -371,6 +371,7 @@ async function maybeWrapIndexedQuoteAdapter(options: {
       maxFreshnessBlocks: optionalServerIntegerEnv(
         "FAME_POOL_STATE_MAX_FRESHNESS_BLOCKS",
       ),
+      stateSurfaces: ["cl-head-snapshot"],
       poolIds,
     });
     if (indexedState.sourceRegistryId !== expectedSourceRegistryId) {

--- a/src/app/api/fame/swap/quote/route.test.ts
+++ b/src/app/api/fame/swap/quote/route.test.ts
@@ -268,6 +268,7 @@ describe("/api/fame/swap/quote", () => {
   it("wraps server quotes with indexed pool-state when configured", async () => {
     const snapshot = createSnapshotQuoteAdapter();
     const requestedPoolIds: string[][] = [];
+    const requestedStateSurfaces: Array<readonly string[] | undefined> = [];
     const response = await handleFameSwapQuotePost(
       request({
         tokenIn: WETH,
@@ -304,6 +305,7 @@ describe("/api/fame/swap/quote", () => {
         indexedPoolStateClient: {
           async fetchPoolStates(indexedRequest) {
             requestedPoolIds.push([...indexedRequest.poolIds]);
+            requestedStateSurfaces.push(indexedRequest.stateSurfaces);
             return {
               sourceRegistryId: famePoolStateRegistrySourceId(),
               currentBlock: indexedRequest.currentBlock,
@@ -348,6 +350,7 @@ describe("/api/fame/swap/quote", () => {
     assert.equal(json.status, "ready");
     assert.equal(json.quoteContext.source, "indexed");
     assert.ok(requestedPoolIds[0]?.includes("uniswap-v2-fame-direct"));
+    assert.deepEqual(requestedStateSurfaces[0], ["cl-head-snapshot"]);
     assert.doesNotMatch(JSON.stringify(json), /unit-token|protocolEvidence/);
   });
 

--- a/src/features/fame-swap/solver/poolStateRegistry.test.ts
+++ b/src/features/fame-swap/solver/poolStateRegistry.test.ts
@@ -24,6 +24,17 @@ describe("FAME pool-state registry", () => {
       "uniswap-v2-fame-direct",
       "uniswap-v2-usdc-weth",
     ]);
+    assert.equal(
+      registry.pools
+        .filter((pool) => pool.capability === "quote-model")
+        .every(
+          (pool) =>
+            pool.stateSurface === "constant-product-reserves" &&
+            pool.quoteModel === "constant-product-reserves" &&
+            pool.unsupportedReason === null,
+        ),
+      true,
+    );
   });
 
   it("keeps tracked-only pools visible instead of dropping unsupported math", () => {
@@ -46,11 +57,57 @@ describe("FAME pool-state registry", () => {
           pool.unsupportedReason === "native-wrap",
       ),
     );
-    assert.ok(
-      trackedOnly.some((pool) => pool.venue === "aerodrome-slipstream"),
+    assert.equal(
+      trackedOnly.every(
+        (pool) => pool.stateSurface === null && pool.unsupportedReason !== null,
+      ),
+      true,
     );
-    assert.ok(trackedOnly.some((pool) => pool.venue === "uniswap-v3"));
-    assert.ok(trackedOnly.some((pool) => pool.venue === "uniswap-v4"));
+  });
+
+  it("marks reviewed concentrated-liquidity pools as head-snapshot market state", () => {
+    const registry = famePoolStateRegistry();
+    const marketState = registry.pools.filter(
+      (pool) => pool.capability === "market-state",
+    );
+
+    assert.ok(
+      marketState.some(
+        (pool) =>
+          pool.venue === "aerodrome-slipstream" &&
+          pool.stateSurface === "cl-head-snapshot" &&
+          pool.poolAddress !== null &&
+          pool.tickSpacing !== null,
+      ),
+    );
+    assert.equal(
+      marketState
+        .filter((pool) => pool.venue === "aerodrome-slipstream2")
+        .every(
+          (pool) =>
+            pool.stateSurface === "cl-head-snapshot" &&
+            pool.poolAddress !== null &&
+            pool.tickSpacing !== null,
+        ),
+      true,
+    );
+    assert.ok(
+      marketState.some(
+        (pool) =>
+          pool.venue === "uniswap-v3" &&
+          pool.stateSurface === "cl-head-snapshot" &&
+          pool.poolAddress !== null &&
+          pool.tickSpacing !== null,
+      ),
+    );
+
+    const uniswapV4 = marketState.find((pool) => pool.venue === "uniswap-v4");
+    assert.ok(uniswapV4);
+    assert.equal(uniswapV4.stateSurface, "cl-head-snapshot");
+    assert.equal(uniswapV4.poolAddress, null);
+    assert.ok(uniswapV4.poolKey);
+    assert.ok(uniswapV4.stateViewAddress);
+    assert.ok(uniswapV4.tickSpacing);
   });
 
   it("omits direct SPX/FAME and cbBTC/FAME until authoritative metadata exists", () => {

--- a/src/features/fame-swap/solver/poolStateRegistry.ts
+++ b/src/features/fame-swap/solver/poolStateRegistry.ts
@@ -18,7 +18,7 @@ import {
   type FamePoolFeeDescriptor,
 } from "./poolUniverse";
 
-export const FAME_POOL_STATE_REGISTRY_SCHEMA_VERSION = 1;
+export const FAME_POOL_STATE_REGISTRY_SCHEMA_VERSION = 2;
 
 export const QUOTE_MODEL_CAPABLE_FAME_POOL_IDS = [
   "aerodrome-v2-usdc-weth",
@@ -30,8 +30,14 @@ export const QUOTE_MODEL_CAPABLE_FAME_POOL_IDS = [
   "uniswap-v2-usdc-weth",
 ] as const;
 
-export type FamePoolStateCapability = "quote-model" | "tracked-only";
+export type FamePoolStateCapability =
+  | "market-state"
+  | "quote-model"
+  | "tracked-only";
 export type FamePoolStateQuoteModel = "constant-product-reserves";
+export type FamePoolStateSurface =
+  | "cl-head-snapshot"
+  | "constant-product-reserves";
 export type FamePoolStateUnsupportedReason =
   | "concentrated-liquidity"
   | "missing-fee-metadata"
@@ -66,7 +72,10 @@ export interface FamePoolStateRegistryEntry {
   token1: Address;
   stable: boolean | null;
   fee: FamePoolFeeDescriptor;
+  tickSpacing: number | null;
+  stateViewAddress: Address | null;
   capability: FamePoolStateCapability;
+  stateSurface: FamePoolStateSurface | null;
   quoteModel: FamePoolStateQuoteModel | null;
   unsupportedReason: FamePoolStateUnsupportedReason | null;
 }
@@ -139,7 +148,11 @@ export function famePoolStateRegistrySourceId(
 function unsupportedReasonForPool(
   pool: FamePoolConfig,
   fee: FamePoolFeeDescriptor,
+  stateSurface: FamePoolStateSurface | null,
 ): FamePoolStateUnsupportedReason | null {
+  if (stateSurface !== null) {
+    return null;
+  }
   if (pool.venue === "uniswap-v2") {
     return fee.status === "available" ? null : "missing-fee-metadata";
   }
@@ -147,16 +160,47 @@ function unsupportedReasonForPool(
     if (pool.stable) return "stable-pool";
     return fee.status === "available" ? null : "missing-fee-metadata";
   }
-  if (
+  if (isConcentratedLiquidityPool(pool)) {
+    return fee.status === "available"
+      ? "unsupported-venue"
+      : "missing-fee-metadata";
+  }
+  if (pool.venue === "native-wrap") return "native-wrap";
+  return "unsupported-venue";
+}
+
+function isConcentratedLiquidityPool(pool: FamePoolConfig): boolean {
+  return (
     pool.venue === "aerodrome-slipstream" ||
     pool.venue === "aerodrome-slipstream2" ||
     pool.venue === "uniswap-v3" ||
     pool.venue === "uniswap-v4"
-  ) {
-    return "concentrated-liquidity";
+  );
+}
+
+function stateSurfaceForPool(
+  pool: FamePoolConfig,
+  fee: FamePoolFeeDescriptor,
+): FamePoolStateSurface | null {
+  if (pool.venue === "uniswap-v2") {
+    return fee.status === "available" ? "constant-product-reserves" : null;
   }
-  if (pool.venue === "native-wrap") return "native-wrap";
-  return "unsupported-venue";
+  if (pool.venue === "solidly" || pool.venue === "aerodrome-v2") {
+    if (pool.stable) return null;
+    return fee.status === "available" ? "constant-product-reserves" : null;
+  }
+  if (isConcentratedLiquidityPool(pool) && fee.status === "available") {
+    return "cl-head-snapshot";
+  }
+  return null;
+}
+
+function capabilityForStateSurface(
+  stateSurface: FamePoolStateSurface | null,
+): FamePoolStateCapability {
+  if (stateSurface === "constant-product-reserves") return "quote-model";
+  if (stateSurface === "cl-head-snapshot") return "market-state";
+  return "tracked-only";
 }
 
 function stableFlag(pool: FamePoolConfig): boolean | null {
@@ -174,6 +218,14 @@ function poolKey(pool: FamePoolConfig): Hex | null {
   return "poolId" in pool ? pool.poolId : null;
 }
 
+function tickSpacing(pool: FamePoolConfig): number | null {
+  return "tickSpacing" in pool ? pool.tickSpacing : null;
+}
+
+function stateViewAddress(pool: FamePoolConfig): Address | null {
+  return pool.venue === "uniswap-v4" ? pool.stateView : null;
+}
+
 function token0(pool: FamePoolConfig): Address {
   if (pool.venue === "uniswap-v4") return pool.currency0;
   if (pool.venue === "native-wrap") return NATIVE_ETH;
@@ -188,9 +240,9 @@ function token1(pool: FamePoolConfig): Address {
 
 function registryEntry(pool: FamePoolConfig): FamePoolStateRegistryEntry {
   const fee = feeDescriptorForPool(pool);
-  const unsupportedReason = unsupportedReasonForPool(pool, fee);
-  const capability: FamePoolStateCapability =
-    unsupportedReason === null ? "quote-model" : "tracked-only";
+  const stateSurface = stateSurfaceForPool(pool, fee);
+  const capability = capabilityForStateSurface(stateSurface);
+  const unsupportedReason = unsupportedReasonForPool(pool, fee, stateSurface);
 
   return {
     id: pool.id,
@@ -204,7 +256,10 @@ function registryEntry(pool: FamePoolConfig): FamePoolStateRegistryEntry {
     token1: token1(pool),
     stable: stableFlag(pool),
     fee,
+    tickSpacing: tickSpacing(pool),
+    stateViewAddress: stateViewAddress(pool),
     capability,
+    stateSurface,
     quoteModel:
       capability === "quote-model" ? "constant-product-reserves" : null,
     unsupportedReason,

--- a/src/features/fame-swap/solver/quotes/indexedPoolStateClient.test.ts
+++ b/src/features/fame-swap/solver/quotes/indexedPoolStateClient.test.ts
@@ -29,6 +29,7 @@ describe("FAME indexed pool-state client", () => {
       currentBlock: 125,
       maxFreshnessBlocks: 10,
       poolIds: ["uniswap-v2-fame-direct"],
+      stateSurfaces: ["cl-head-snapshot"],
     });
 
     assert.equal(response.effectiveMaxFreshnessBlocks, 10);
@@ -36,11 +37,12 @@ describe("FAME indexed pool-state client", () => {
     assert.deepEqual(await requests[0]?.json(), {
       currentBlock: 125,
       maxFreshnessBlocks: 10,
+      stateSurfaces: ["cl-head-snapshot"],
       pools: [{ poolId: "uniswap-v2-fame-direct" }],
     });
   });
 
-  it("parses fresh, stale, unsupported, and unknown entries", () => {
+  it("parses fresh, stale, CL head, unsupported, and unknown entries", () => {
     const parsed = parseIndexedPoolStateResponse({
       sourceRegistryId: "unit",
       currentBlock: 125,
@@ -80,6 +82,28 @@ describe("FAME indexed pool-state client", () => {
           maxFreshnessBlocks: 120,
         },
         {
+          status: "fresh",
+          stateKind: "cl-head-snapshot",
+          poolId: "uniswap-v3-usdc-weth-5bps",
+          chainId: 8453,
+          poolAddress: "0xd0b53d9277642d899df5c87a3966a349a798f224",
+          poolKey: null,
+          token0: "0x4200000000000000000000000000000000000006",
+          token1: "0x833589fcd6edb6e08f4c7c32d4f71b54bdA02913",
+          venueFamily: "UniswapV3",
+          feeBps: 5,
+          feeLabel: "5 bps",
+          tickSpacing: 10,
+          stateViewAddress: null,
+          sqrtPriceX96: "79228162514264337593543950336",
+          tick: 0,
+          liquidity: "1000000",
+          observedThroughBlock: 124,
+          source: "pool-slot0-liquidity",
+          sourceRegistryId: "unit",
+          maxFreshnessBlocks: 120,
+        },
+        {
           status: "unsupported",
           poolId: "uniswap-v4-usdc-eth",
           chainId: 8453,
@@ -96,7 +120,72 @@ describe("FAME indexed pool-state client", () => {
 
     assert.deepEqual(
       parsed.pools.map((pool) => pool.status),
-      ["fresh", "stale", "unsupported", "unknown"],
+      ["fresh", "stale", "fresh", "unsupported", "unknown"],
+    );
+    const clHead = parsed.pools[2];
+    if (!("stateKind" in clHead)) {
+      assert.fail("Expected a CL head entry.");
+    }
+    assert.equal(clHead.stateKind, "cl-head-snapshot");
+    assert.equal(clHead.venueFamily, "UniswapV3");
+    assert.equal(clHead.tickSpacing, 10);
+    assert.equal(clHead.tick, 0);
+  });
+
+  it("rejects malformed CL head contract fields", () => {
+    const clHeadEntry = {
+      status: "fresh",
+      stateKind: "cl-head-snapshot",
+      poolId: "uniswap-v3-usdc-weth-5bps",
+      chainId: 8453,
+      poolAddress: "0xd0b53d9277642d899df5c87a3966a349a798f224",
+      poolKey: null,
+      token0: "0x4200000000000000000000000000000000000006",
+      token1: "0x833589fcd6edb6e08f4c7c32d4f71b54bdA02913",
+      venueFamily: "UniswapV3",
+      feeBps: 5,
+      feeLabel: "5 bps",
+      tickSpacing: 10,
+      stateViewAddress: null,
+      sqrtPriceX96: "79228162514264337593543950336",
+      tick: 0,
+      liquidity: "1000000",
+      observedThroughBlock: 124,
+      source: "pool-slot0-liquidity",
+      sourceRegistryId: "unit",
+      maxFreshnessBlocks: 120,
+    };
+    const response = {
+      sourceRegistryId: "unit",
+      currentBlock: 125,
+      producerMaxFreshnessBlocks: 120,
+      effectiveMaxFreshnessBlocks: 120,
+      pools: [clHeadEntry],
+    };
+
+    assert.throws(
+      () =>
+        parseIndexedPoolStateResponse({
+          ...response,
+          pools: [{ ...clHeadEntry, venueFamily: "uniswap-v3" }],
+        }),
+      /venueFamily/,
+    );
+    assert.throws(
+      () =>
+        parseIndexedPoolStateResponse({
+          ...response,
+          pools: [{ ...clHeadEntry, tickSpacing: 10.5 }],
+        }),
+      /tickSpacing/,
+    );
+    assert.throws(
+      () =>
+        parseIndexedPoolStateResponse({
+          ...response,
+          currentBlock: 125.5,
+        }),
+      /currentBlock/,
     );
   });
 

--- a/src/features/fame-swap/solver/quotes/indexedPoolStateClient.ts
+++ b/src/features/fame-swap/solver/quotes/indexedPoolStateClient.ts
@@ -1,10 +1,20 @@
-import { isAddress, type Address } from "viem";
+import { isAddress, isHex, type Address, type Hex } from "viem";
 
 export type FameIndexedPoolStateStatus =
   | "fresh"
   | "stale"
   | "unknown"
   | "unsupported";
+export type FameIndexedPoolStateRequestSurface = "cl-head-snapshot";
+export type FameIndexedPoolStateVenueFamily =
+  | "AerodromeV2"
+  | "NativeWrap"
+  | "Slipstream"
+  | "Slipstream2"
+  | "Solidly"
+  | "UniswapV2"
+  | "UniswapV3"
+  | "UniswapV4";
 
 export type FameIndexedPoolStateEntry =
   | {
@@ -21,6 +31,28 @@ export type FameIndexedPoolStateEntry =
       lastReserveChangeBlock: number;
       source: "sync-event" | "getReserves";
       quoteModel: "constant-product-reserves";
+      maxFreshnessBlocks: number;
+    }
+  | {
+      status: "fresh" | "stale";
+      stateKind: "cl-head-snapshot";
+      poolId: string;
+      chainId: number;
+      poolAddress: Address | null;
+      poolKey: Hex | null;
+      token0: Address;
+      token1: Address;
+      venueFamily: FameIndexedPoolStateVenueFamily;
+      feeBps: number;
+      feeLabel: string;
+      tickSpacing: number;
+      stateViewAddress: Address | null;
+      sqrtPriceX96: string;
+      tick: number;
+      liquidity: string;
+      observedThroughBlock: number;
+      source: "pool-slot0-liquidity" | "v4-state-view";
+      sourceRegistryId: string;
       maxFreshnessBlocks: number;
     }
   | {
@@ -53,6 +85,7 @@ export interface FameIndexedPoolStateClient {
     currentBlock: number;
     poolIds: readonly string[];
     maxFreshnessBlocks?: number;
+    stateSurfaces?: readonly FameIndexedPoolStateRequestSurface[];
   }): Promise<FameIndexedPoolStateBatchResponse>;
 }
 
@@ -86,6 +119,25 @@ function numberField(record: Record<string, unknown>, key: string): number {
   return value;
 }
 
+function integerField(record: Record<string, unknown>, key: string): number {
+  const value = record[key];
+  if (typeof value !== "number" || !Number.isSafeInteger(value)) {
+    throw new Error(`FAME indexed pool-state response invalid at ${key}.`);
+  }
+  return value;
+}
+
+function nonNegativeIntegerField(
+  record: Record<string, unknown>,
+  key: string,
+): number {
+  const value = integerField(record, key);
+  if (value < 0) {
+    throw new Error(`FAME indexed pool-state response invalid at ${key}.`);
+  }
+  return value;
+}
+
 function addressField(record: Record<string, unknown>, key: string): Address {
   const value = stringField(record, key);
   if (!isAddress(value, { strict: false })) {
@@ -101,6 +153,49 @@ function nullableAddressField(
   return record[key] === null ? null : addressField(record, key);
 }
 
+function nullableHexField(
+  record: Record<string, unknown>,
+  key: string,
+): Hex | null {
+  const value = record[key];
+  if (value === null) return null;
+  if (typeof value !== "string" || !isHex(value, { strict: true })) {
+    throw new Error(`FAME indexed pool-state response invalid at ${key}.`);
+  }
+  return value;
+}
+
+function clHeadSourceField(
+  record: Record<string, unknown>,
+  key: string,
+): "pool-slot0-liquidity" | "v4-state-view" {
+  const value = stringField(record, key);
+  if (value !== "pool-slot0-liquidity" && value !== "v4-state-view") {
+    throw new Error(`FAME indexed pool-state response invalid at ${key}.`);
+  }
+  return value;
+}
+
+function venueFamilyField(
+  record: Record<string, unknown>,
+  key: string,
+): FameIndexedPoolStateVenueFamily {
+  const value = stringField(record, key);
+  switch (value) {
+    case "AerodromeV2":
+    case "NativeWrap":
+    case "Slipstream":
+    case "Slipstream2":
+    case "Solidly":
+    case "UniswapV2":
+    case "UniswapV3":
+    case "UniswapV4":
+      return value;
+    default:
+      throw new Error(`FAME indexed pool-state response invalid at ${key}.`);
+  }
+}
+
 function parseRequestKey(value: unknown, path: string): {
   poolId?: string;
   chainId?: number;
@@ -111,8 +206,8 @@ function parseRequestKey(value: unknown, path: string): {
     return { poolId: record.poolId };
   }
   return {
-    ...(typeof record.chainId === "number"
-      ? { chainId: record.chainId }
+    ...(record.chainId !== undefined
+      ? { chainId: nonNegativeIntegerField(record, "chainId") }
       : {}),
     ...(typeof record.poolAddress === "string" &&
     isAddress(record.poolAddress, { strict: false })
@@ -125,6 +220,36 @@ function parseEntry(value: unknown, path: string): FameIndexedPoolStateEntry {
   const record = asRecord(value, path);
   const status = stringField(record, "status");
   if (status === "fresh" || status === "stale") {
+    if (record.stateKind === "cl-head-snapshot") {
+      return {
+        status,
+        stateKind: "cl-head-snapshot",
+        poolId: stringField(record, "poolId"),
+        chainId: nonNegativeIntegerField(record, "chainId"),
+        poolAddress: nullableAddressField(record, "poolAddress"),
+        poolKey: nullableHexField(record, "poolKey"),
+        token0: addressField(record, "token0"),
+        token1: addressField(record, "token1"),
+        venueFamily: venueFamilyField(record, "venueFamily"),
+        feeBps: numberField(record, "feeBps"),
+        feeLabel: stringField(record, "feeLabel"),
+        tickSpacing: nonNegativeIntegerField(record, "tickSpacing"),
+        stateViewAddress: nullableAddressField(record, "stateViewAddress"),
+        sqrtPriceX96: stringField(record, "sqrtPriceX96"),
+        tick: integerField(record, "tick"),
+        liquidity: stringField(record, "liquidity"),
+        observedThroughBlock: nonNegativeIntegerField(
+          record,
+          "observedThroughBlock",
+        ),
+        source: clHeadSourceField(record, "source"),
+        sourceRegistryId: stringField(record, "sourceRegistryId"),
+        maxFreshnessBlocks: nonNegativeIntegerField(
+          record,
+          "maxFreshnessBlocks",
+        ),
+      };
+    }
     const source = stringField(record, "source");
     if (source !== "sync-event" && source !== "getReserves") {
       throw new Error("FAME indexed pool-state response invalid at source.");
@@ -136,25 +261,31 @@ function parseEntry(value: unknown, path: string): FameIndexedPoolStateEntry {
     return {
       status,
       poolId: stringField(record, "poolId"),
-      chainId: numberField(record, "chainId"),
+      chainId: nonNegativeIntegerField(record, "chainId"),
       poolAddress: addressField(record, "poolAddress"),
       token0: addressField(record, "token0"),
       token1: addressField(record, "token1"),
       reserve0: stringField(record, "reserve0"),
       reserve1: stringField(record, "reserve1"),
       k: stringField(record, "k"),
-      observedThroughBlock: numberField(record, "observedThroughBlock"),
-      lastReserveChangeBlock: numberField(record, "lastReserveChangeBlock"),
+      observedThroughBlock: nonNegativeIntegerField(
+        record,
+        "observedThroughBlock",
+      ),
+      lastReserveChangeBlock: nonNegativeIntegerField(
+        record,
+        "lastReserveChangeBlock",
+      ),
       source,
       quoteModel,
-      maxFreshnessBlocks: numberField(record, "maxFreshnessBlocks"),
+      maxFreshnessBlocks: nonNegativeIntegerField(record, "maxFreshnessBlocks"),
     };
   }
   if (status === "unsupported") {
     return {
       status,
       poolId: stringField(record, "poolId"),
-      chainId: numberField(record, "chainId"),
+      chainId: nonNegativeIntegerField(record, "chainId"),
       poolAddress: nullableAddressField(record, "poolAddress"),
       unsupportedReason: stringField(record, "unsupportedReason"),
     };
@@ -179,12 +310,12 @@ export function parseIndexedPoolStateResponse(
   }
   return {
     sourceRegistryId: stringField(record, "sourceRegistryId"),
-    currentBlock: numberField(record, "currentBlock"),
-    producerMaxFreshnessBlocks: numberField(
+    currentBlock: nonNegativeIntegerField(record, "currentBlock"),
+    producerMaxFreshnessBlocks: nonNegativeIntegerField(
       record,
       "producerMaxFreshnessBlocks",
     ),
-    effectiveMaxFreshnessBlocks: numberField(
+    effectiveMaxFreshnessBlocks: nonNegativeIntegerField(
       record,
       "effectiveMaxFreshnessBlocks",
     ),
@@ -212,6 +343,7 @@ export function createIndexedPoolStateClient(
           body: JSON.stringify({
             currentBlock: request.currentBlock,
             maxFreshnessBlocks: request.maxFreshnessBlocks,
+            stateSurfaces: request.stateSurfaces,
             pools: request.poolIds.map((poolId) => ({ poolId })),
           }),
           signal: controller.signal,

--- a/src/features/fame-swap/solver/quotes/indexedReserveAdapter.test.ts
+++ b/src/features/fame-swap/solver/quotes/indexedReserveAdapter.test.ts
@@ -20,6 +20,10 @@ type IndexedReserveEntry = Extract<
   FameIndexedPoolStateBatchResponse["pools"][number],
   { quoteModel: "constant-product-reserves" }
 >;
+type IndexedClHeadEntry = Extract<
+  FameIndexedPoolStateBatchResponse["pools"][number],
+  { stateKind: "cl-head-snapshot" }
+>;
 
 function indexedState(
   overrides: Partial<IndexedReserveEntry> = {},
@@ -39,6 +43,42 @@ function indexedState(
     lastReserveChangeBlock: 123,
     source: "sync-event",
     quoteModel: "constant-product-reserves",
+    maxFreshnessBlocks: 120,
+    ...overrides,
+  };
+  return {
+    sourceRegistryId: "unit-registry",
+    currentBlock: 125,
+    producerMaxFreshnessBlocks: 120,
+    effectiveMaxFreshnessBlocks: 120,
+    pools: [pool],
+  };
+}
+
+function indexedClHeadState(
+  overrides: Partial<IndexedClHeadEntry> = {},
+): FameIndexedPoolStateBatchResponse {
+  const pool: IndexedClHeadEntry = {
+    status: "fresh",
+    stateKind: "cl-head-snapshot",
+    poolId: "uniswap-v2-fame-direct",
+    chainId: 8453,
+    poolAddress:
+      "0x3e2cab55bebf41719148b4e6b63f6644b18ae49c" as const satisfies Address,
+    poolKey: null,
+    token0: WETH,
+    token1: FAME,
+    venueFamily: "UniswapV3",
+    feeBps: 5,
+    feeLabel: "5 bps",
+    tickSpacing: 10,
+    stateViewAddress: null,
+    sqrtPriceX96: "79228162514264337593543950336",
+    tick: 0,
+    liquidity: "1000000",
+    observedThroughBlock: 124,
+    source: "pool-slot0-liquidity",
+    sourceRegistryId: "unit-registry",
     maxFreshnessBlocks: 120,
     ...overrides,
   };
@@ -134,6 +174,21 @@ describe("FAME indexed reserve adapter", () => {
     const fallback = { calls: 0 };
     const indexed = createIndexedReserveQuoteAdapter({
       indexedState: indexedState({ status: "stale" }),
+      fallback: fallbackAdapter(fallback),
+    });
+
+    const quote = await indexed.quoteEdge({ edge, amountIn: 1n });
+
+    assert.equal(fallback.calls, 1);
+    assert.equal(quote.status, "quoted");
+    if (quote.status === "quoted") assert.equal(quote.amountOut, 42n);
+  });
+
+  it("delegates fresh CL head snapshots to the fallback adapter", async () => {
+    const edge = wethFameDirectEdge();
+    const fallback = { calls: 0 };
+    const indexed = createIndexedReserveQuoteAdapter({
+      indexedState: indexedClHeadState(),
       fallback: fallbackAdapter(fallback),
     });
 

--- a/src/features/fame-swap/solver/quotes/indexedReserveAdapter.ts
+++ b/src/features/fame-swap/solver/quotes/indexedReserveAdapter.ts
@@ -79,7 +79,9 @@ function isIndexedReservePoolState(
 ): state is FameIndexedReservePoolState {
   return (
     state !== undefined &&
-    (state.status === "fresh" || state.status === "stale")
+    (state.status === "fresh" || state.status === "stale") &&
+    "quoteModel" in state &&
+    state.quoteModel === "constant-product-reserves"
   );
 }
 


### PR DESCRIPTION
## Summary

`www` can now ask the pool-state helper for CL head snapshots in shadow mode while keeping live adapters as the source of quote truth. The generated registry marks reviewed CL dependencies as `cl-head-snapshot` market state, route-lab reports their freshness, and indexed reserve replay still falls back for CL rows.

## Design Notes

- The helper request now opts into `cl-head-snapshot` rows so route tooling can inspect CL market-state coverage alongside reserve rows.
- The client parser enforces the settled server contract: typed `venueFamily` values, integer block/tick-spacing fields, CL identity fields, and source provenance.
- Indexed reserve replay ignores fresh CL snapshots and delegates to live quoting, preserving the boundary between market-state evidence and executable quote authority.
- Route-lab now separates constant-product reserve counts from CL head snapshot counts without introducing a boundary-warning requirement.

## Validation

- `/home/user/.bun/bin/bun test src/features/fame-swap/solver/poolStateRegistry.test.ts src/features/fame-swap/solver/quotes/indexedPoolStateClient.test.ts src/features/fame-swap/solver/quotes/indexedReserveAdapter.test.ts src/app/api/fame/swap/quote/route.test.ts scripts/fame-swap-route-lab.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `/home/user/.bun/bin/bun run lint` — 0 errors, 3 unrelated existing warnings in `src/app/[network]/profile/image/[tokenId]/route.tsx`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
