### PR TITLE
fix(fame): gate compact quotes to direct pools

### DIFF
--- a/docs/fame-swap-route-lab.md
+++ b/docs/fame-swap-route-lab.md
@@ -7,11 +7,25 @@ The route lab runs amount buckets through the shared FAME swap solver without Re
 - Recorded mode is the default: `bun scripts/fame-swap-route-lab.ts`. It replays the recorded-state artifact `base-v1-pool-state-snapshot.json`, captured from read-only Base quote calls and pool state at `base-v1-live-45964183`.
 - Deterministic mode is explicit: `bun scripts/fame-swap-route-lab.ts --deterministic`. It uses the pinned test-only deterministic capacity profile to prove old cap failures and pure solver behavior.
 - Indexed mode: `BASE_RPC_URL=... FAME_POOL_API_URL=... FAME_POOL_STATE_SERVICE_TOKEN=... bun scripts/fame-swap-route-lab.ts --indexed`. It derives `/fame/pool-state` from the `society-bots` pool API base for proof-only raw state, replays fresh V2-style reserves locally, requests `cl-replay-v1` for `slipstream-usdc-weth-100`, and runs Slipstream CL replay in shadow mode before falling back to the normal quote source. Freshness is checked against a live Base block from server-only `BASE_RPC_URL`, or an explicit `FAME_POOL_STATE_CURRENT_BLOCK`; indexed mode no longer falls back to the pinned artifact block.
+- Quote API mode: `BASE_RPC_URL=... FAME_POOL_API_URL=... FAME_POOL_STATE_SERVICE_TOKEN=... bun scripts/fame-swap-route-lab.ts --quote-api`. It derives `/fame/pool-quotes`, wraps the normal fallback adapter with compact quote rows, and records quote API diagnostics. `--indexed --simulate` also uses quote API mode because route simulation must prove the same compact quote route, not the raw pool-state shadow path.
 - Live mode: `doppler run -- bun scripts/fame-swap-route-lab.ts --live`. It reads Base RPC liquidity through the live adapters and records a live block quote context. Server/operator runs prefer `BASE_RPC_URL`; `NEXT_PUBLIC_BASE_RPC_URL_1` is only a fallback for browser-safe or local endpoints.
 - Live simulation: add `--simulate` and set `FAME_SWAP_SIMULATION_ACCOUNT` or `NEXT_PUBLIC_FAME_SWAP_SIMULATION_ACCOUNT`. ERC20 routes simulate approval plus swap as one bundle, derive a slippage-protected minimum from the probe result, then simulate the protected route; native routes do the same with direct router calls. This is the initiating-account path for below-balance and route-execution checks. Default JSON and Markdown use a shortened account label.
 - Markdown output: add `--markdown` to any mode.
 
 Fork/router execution is still handled by `yarn fame-swap:fork-smoke`; route lab remains the amount grid, quote evidence, optional initiating-account simulation, and contract-todo source.
+
+## Targeted Runs
+
+Route lab can run one focused proof instead of the full corpus:
+
+- `--case <corpus-id>` selects one `FAME_ROUTE_CORPUS` case.
+- `--route <route-artifact-id>` selects the corpus case with the same token pair and amount, filters solver candidates to the artifact pool/token sequence, and fails if the selected route evidence does not match that requested artifact.
+- `--pool <pool-id>` filters to candidates containing the selected pool.
+- `--token-in <address>` and `--token-out <address>` narrow the selected pool leg direction.
+
+Missing targets and ambiguous filters fail loudly. A selected route that omits the requested pool or direction also fails; the command does not emit release evidence for a merely adjacent route.
+
+Ready rows include `requestedRouteId`, `routeArtifactId`, `selectedCandidateId`, `materializedRouteHash`, selected pools, and quote API diagnostics when quote API mode is used.
 
 ## Quote Context
 
@@ -27,6 +41,8 @@ Indexed quote outputs use the same reserve replay math as recorded snapshots for
 
 `cl-replay-v1` output is deliberately separate from reserve replay. Route lab requests the complete Slipstream replay snapshot and reports snapshot freshness, observed block, state hash, bitmap word count, and initialized tick count in the indexed-pool-state summary. While shadow mode is active, selected CL legs still attribute to the live or recorded fallback quote source; a successful local replay is not public quote authority.
 
+Quote API mode reports compact quote diagnostics separately from route quote context. A selected compact leg includes row evidence id, fallback reason if any, source registry id, current block, and effective freshness in debug output. For `uniswap-v4-basedflick-zora`, quote API mode uses a validation-only V4 activation override so the compact row can be proven before production activation is flipped.
+
 Server-only helper env for route lab and quote API:
 
 - `FAME_POOL_API_URL`
@@ -39,7 +55,7 @@ Server-only helper env for route lab and quote API:
 
 Do not create `NEXT_PUBLIC_` variants for pool API URL or token. Normal `/api/fame/swap/quote` calls `/fame/pool-quotes`; raw `/fame/pool-state` is only for route-lab and parity proof tooling.
 
-## Slipstream CL Replay Parity
+## Compact Quote Parity
 
 `slipstream-usdc-weth-100` has a focused parity harness for the first replayable concentrated-liquidity proof:
 
@@ -54,6 +70,22 @@ bun scripts/fame-swap-cl-replay-parity.ts
 The harness fetches fresh `cl-replay-v1` state, builds a live Slipstream quoter adapter pinned to the snapshot block, and compares local replay against live quotes for representative WETH -> USDC and USDC -> WETH exact-input amounts. Promotion requires exact `amountOut` equality, not a rounded bps tolerance. A mismatch means state capture, dynamic fee units, tick crossing, rounding, or block consistency needs investigation.
 
 Expected output includes the snapshot id, observed block, state hash, bitmap word count, initialized tick count, and one local/live/drift line per amount. Missing, stale, incomplete, malformed, outside-range, or mismatched state should be treated as live-fallback evidence, not as an indexed CL quote.
+
+The same harness also supports the targeted V4 compact quote lane for `uniswap-v4-basedflick-zora`. When the requested pool is the V4 target, it fetches `/fame/pool-quotes`, validates exactly one fresh V4 `cl-quote-v1` row, pins the live V4 quoter to that row's observed block, and requires exact amount-out equality:
+
+```bash
+BASE_RPC_URL=https://... \
+FAME_POOL_API_URL=https://... \
+FAME_POOL_STATE_SERVICE_TOKEN=... \
+FAME_POOL_QUOTE_MAX_FRESHNESS_BLOCKS=120 \
+bun scripts/fame-swap-cl-replay-parity.ts \
+  --pool uniswap-v4-basedflick-zora \
+  --token-in 0x15e012abf9d32cd67fc6cf480ea0e318e9ed5926 \
+  --token-out 0x1111111111166b7fe7bd91427724b487980afc69 \
+  --amount 1045794780078973192
+```
+
+Run the reverse direction with the token addresses swapped. V4 parity output includes surface, source registry id, current block, observed block, block hash, parent hash, state hash, evidence id, and one local/live/drift line per amount. Sending the V4 target through the old Slipstream replay path fails closed.
 
 ## Allocation Optimizer Evidence
 
@@ -140,6 +172,7 @@ Recent verified runs:
 - Solidly FAME -> USDC routes now report one computable market-impact leg for the volatile FAME/frxUSD hop; the stable USDC/frxUSD hop remains quoted but non-computable for market impact.
 - Representative larger USDC, WETH, and native ETH buckets now quote from liquidity evidence instead of deterministic capacity caps.
 - CL replay promotion evidence is separate from these historical route-lab runs. Attach the latest indexed route-lab plus `fame-swap-cl-replay-parity` output before treating `slipstream-usdc-weth-100` as locally replayable in the hot path.
+- BASEDFLICK/ZORA V4 compact quote promotion evidence is also separate from the historical live V4 selections above. The required current artifact is a focused `--quote-api --simulate` row whose `requestedRouteId` matches `routeArtifactId`, whose `selectedCandidateId` and `materializedRouteHash` are present, whose selected pools include `uniswap-v4-basedflick-zora`, whose `quoteApi.sourceRegistryId` matches the producer registry, and whose `simulation.status` is `passed`, paired with compact quote parity in both BASEDFLICK -> ZORA and ZORA -> BASEDFLICK directions.
 
 ## Contract Follow-Ups
 

--- a/docs/fame-swap-route-lab.md
+++ b/docs/fame-swap-route-lab.md
@@ -6,12 +6,12 @@ The route lab runs amount buckets through the shared FAME swap solver without Re
 
 - Recorded mode is the default: `bun scripts/fame-swap-route-lab.ts`. It replays the recorded-state artifact `base-v1-pool-state-snapshot.json`, captured from read-only Base quote calls and pool state at `base-v1-live-45964183`.
 - Deterministic mode is explicit: `bun scripts/fame-swap-route-lab.ts --deterministic`. It uses the pinned test-only deterministic capacity profile to prove old cap failures and pure solver behavior.
-- Indexed mode: `BASE_RPC_URL=... FAME_POOL_API_URL=... FAME_POOL_STATE_SERVICE_TOKEN=... bun scripts/fame-swap-route-lab.ts --indexed`. It derives `/fame/pool-state` from the `society-bots` pool API base for proof-only raw state, replays fresh V2-style reserves locally, requests `cl-replay-v1` for `slipstream-usdc-weth-100`, and runs Slipstream CL replay in shadow mode before falling back to the normal quote source. Freshness is checked against a live Base block from server-only `BASE_RPC_URL`, or an explicit `FAME_POOL_STATE_CURRENT_BLOCK`; indexed mode no longer falls back to the pinned artifact block.
+- Indexed mode: `BASE_RPC_URL=... FAME_POOL_API_URL=... FAME_POOL_STATE_SERVICE_TOKEN=... bun scripts/fame-swap-route-lab.ts --indexed`. It derives `/fame/pool-state` from the `society-bots` pool API base for proof-only raw state, replays fresh V2-style reserves locally, requests `cl-replay-v1` for replay proof pools, and can report selected `slipstream-basedflick-fame` as raw replay indexed evidence while keeping `uniswap-v4-basedflick-zora` live through a `BASE_RPC_URL` fallback. Freshness is checked against a live Base block from server-only `BASE_RPC_URL`, or an explicit `FAME_POOL_STATE_CURRENT_BLOCK`; indexed mode no longer falls back to the pinned artifact block.
 - Live mode: `doppler run -- bun scripts/fame-swap-route-lab.ts --live`. It reads Base RPC liquidity through the live adapters and records a live block quote context. Server/operator runs prefer `BASE_RPC_URL`; `NEXT_PUBLIC_BASE_RPC_URL_1` is only a fallback for browser-safe or local endpoints.
 - Live simulation: add `--simulate` and set `FAME_SWAP_SIMULATION_ACCOUNT` or `NEXT_PUBLIC_FAME_SWAP_SIMULATION_ACCOUNT`. ERC20 routes simulate approval plus swap as one bundle, derive a slippage-protected minimum from the probe result, then simulate the protected route; native routes do the same with direct router calls. This is the initiating-account path for below-balance and route-execution checks. Default JSON and Markdown use a shortened account label.
 - Markdown output: add `--markdown` to any mode.
 
-Fork/router execution is still handled by `yarn fame-swap:fork-smoke`; route lab remains the amount grid, quote evidence, optional initiating-account simulation, and contract-todo source.
+Fork/router execution is still handled by `yarn fame-swap:fork-smoke`; route lab remains the amount grid, quote evidence, optional initiating-account simulation, and contract-todo source. Add `--route <artifact-id>` when proving one activation lane; route lab rejects generated candidate ids and narrows indexed pool-state reads to the requested artifact's compact-capable pools.
 
 ## Quote Context
 
@@ -37,11 +37,11 @@ Server-only helper env for route lab and quote API:
 - Route-lab/parity raw-state proof only: optional `FAME_POOL_STATE_MAX_FRESHNESS_BLOCKS`
 - Route-lab-only override `FAME_POOL_STATE_CURRENT_BLOCK`
 
-Do not create `NEXT_PUBLIC_` variants for pool API URL or token. Normal `/api/fame/swap/quote` calls `/fame/pool-quotes`; raw `/fame/pool-state` is only for route-lab and parity proof tooling.
+Do not create `NEXT_PUBLIC_` variants for pool API URL or token. Normal `/api/fame/swap/quote` calls `/fame/pool-quotes`; raw `/fame/pool-state` is only for route-lab and parity proof tooling. Public quote requests may pass a pinned route artifact id as `routeId`; generated candidate ids stay internal.
 
 ## Slipstream CL Replay Parity
 
-`slipstream-usdc-weth-100` has a focused parity harness for the first replayable concentrated-liquidity proof:
+The parity harness defaults to the baseline `slipstream-usdc-weth-100` pool and the selected `slipstream-basedflick-fame` pool, with WETH/USDC and basedflick/FAME amount bands. Set `FAME_CL_REPLAY_PARITY_POOL_ID` to a specific pool id when you only need one route family:
 
 ```bash
 BASE_RPC_URL=https://... \
@@ -127,6 +127,17 @@ Every route-lab row also includes protocol coverage rows derived from the edge m
 
 Protocol coverage is route-lab/operator evidence. `/api/fame/swap/quote` strips route-lab-only protocol evidence from public ready responses.
 
+## Selected Pool Activation Evidence
+
+The selected basedflick/ZORA lane is route-bounded evidence, not a broad CL promotion. A passing indexed route-lab row should show:
+
+- `selectedPools` includes `slipstream-basedflick-fame` and `uniswap-v4-basedflick-zora`.
+- `selectedQuoteSources` reports `slipstream-basedflick-fame raw-replay-indexed` from route-lab, while the paired `/fame/pool-quotes` response contains the matching compact `cl-quote-v1` row for the same pool, direction, and amount.
+- `selectedQuoteSources` reports `uniswap-v4-basedflick-zora live`.
+- `selectedActivation.outcome` is `raw_replay_with_live_dependency` in route-lab; the smoke bundle combines that with matching compact quote evidence.
+
+Pair this route-lab output with `bun scripts/fame-swap-pool-activation-report.ts`, the `/fame/pool-quotes` response, and the `society-bots` `yarn fame-pool-state:delta-replay-smoke <input-json>` bundle. The bundle should be `activationEvidence.status: "ready"` before making a release claim. A ready bundle still means exactly one additional compact CL leg is usable for the selected route; it does not mean Uniswap V4 compact quote support exists.
+
 ## Current Evidence
 
 Recent verified runs:
@@ -139,7 +150,7 @@ Recent verified runs:
 - FAME -> USDC and representative WETH -> FAME live buckets now select the reviewed `slipstream-usdc-weth-100` connector. Native ETH buckets select `uniswap-v4-usdc-eth` without adding an ETH/WETH wrap or unwrap leg.
 - Solidly FAME -> USDC routes now report one computable market-impact leg for the volatile FAME/frxUSD hop; the stable USDC/frxUSD hop remains quoted but non-computable for market impact.
 - Representative larger USDC, WETH, and native ETH buckets now quote from liquidity evidence instead of deterministic capacity caps.
-- CL replay promotion evidence is separate from these historical route-lab runs. Attach the latest indexed route-lab plus `fame-swap-cl-replay-parity` output before treating `slipstream-usdc-weth-100` as locally replayable in the hot path.
+- CL replay promotion evidence is separate from these historical route-lab runs. Attach the latest indexed route-lab, `fame-swap-cl-replay-parity` output, activation report, and delta replay smoke bundle before treating a selected CL leg as compact quote-capable in the hot path.
 
 ## Contract Follow-Ups
 

--- a/docs/solutions/architecture-patterns/fame-swap-indexed-pool-state-quote-helper-2026-05-19.md
+++ b/docs/solutions/architecture-patterns/fame-swap-indexed-pool-state-quote-helper-2026-05-19.md
@@ -1,7 +1,7 @@
 ---
 title: FAME Swap Indexed Pool-State Quote Helper
 date: 2026-05-19
-last_updated: 2026-05-23
+last_updated: 2026-06-01
 category: architecture-patterns
 module: fame-swap
 problem_type: architecture_pattern
@@ -85,11 +85,11 @@ Use compact quote rows in normal flow. `src/features/fame-swap/solver/quotes/ind
 
 For CL replay, parse and validate `stateKind: "cl-replay-v1"` as a distinct state surface. The indexed CL replay adapter accepts only fresh `slipstream-usdc-weth-100` state with matching registry provenance, pool address, token order, dynamic fee, and complete tick records. Missing state, stale or future-block state, malformed decimals or bitmap words, unsupported pools, token-direction mismatch, outside-range replay, replay exceptions, and parity mismatches all keep the request on the live fallback path.
 
-Keep the ownership line crisp, but let it evolve. The proof slice made `society-bots` the replayable market-state producer and `www` the shadow math/parity consumer. The compact quote slice makes `society-bots` own exact-input quote execution for this one indexed pool so `www` does not need raw ticks in the hot path. `www` still owns route ranking, route attribution, quote safety, slippage, public readiness, and live-quoter fallback.
+Keep the ownership line crisp, but let it evolve. The proof slice made `society-bots` the replayable market-state producer and `www` the shadow math/parity consumer. The compact quote slice makes `society-bots` own exact-input quote execution for reviewed indexed CL lanes so `www` does not need raw ticks in the hot path. `www` still owns route ranking, activation eligibility, route attribution, quote safety, slippage, public readiness, and live-quoter fallback. For the selected basedflick/FAME lane, compact `cl-quote-v1` evidence is valid only when route lab also proves the selected basedflick/ZORA route still depends on live `uniswap-v4-basedflick-zora` quoting.
 
 Quote attribution must be per selected leg, not per adapter. `src/features/fame-swap/solver/quotes/rankRoutes.ts` now reports route-level indexed context only when all selected legs share the same indexed context. Mixed indexed/live fallback routes should not claim a fully indexed quote. `src/features/fame-swap/solver/quoteWire.ts` preserves the public indexed context fields without leaking helper credentials or protocol evidence.
 
-Keep helper failure visible without breaking fallback. The API logs sanitized `fame-pool-quote-api-unavailable` events for compact helper failures. `includeDebug: true` returns structured `debug.quoteApi` counts and capped per-edge details, not server logs, service tokens, helper URLs, raw reserve state, or raw tick payloads. In `society-bots`, CL replay capture failures must remain error-level operational failures, not INFO-only metrics, because bad replay snapshots are the correctness boundary for every downstream quote.
+Keep helper failure visible without breaking fallback. The API logs sanitized `fame-pool-quote-api-unavailable` events for compact helper failures. In local development and tests, `includeDebug: true` returns structured `debug.quoteApi` counts and capped per-edge details, not server logs, service tokens, helper URLs, raw reserve state, or raw tick payloads. Production responses redact that debug surface. In `society-bots`, CL replay capture failures must remain error-level operational failures, not INFO-only metrics, because bad replay snapshots are the correctness boundary for every downstream quote.
 
 ## Why This Matters
 
@@ -126,6 +126,14 @@ This also continues earlier quote-builder lessons (session history):
 - Expanding the solver toward allocation optimization where many quote trials reuse the same reserves, slot0, liquidity, or quoter state.
 
 ## Current State and TODO Triage
+
+Selected activation evidence:
+
+- Run indexed route lab with `--route <artifact-id>` for the selected basedflick/ZORA route to avoid full-corpus compute when proving this lane.
+- Route lab must show `slipstream-basedflick-fame raw-replay-indexed`, `uniswap-v4-basedflick-zora live`, and `selectedActivation.outcome: "raw_replay_with_live_dependency"`; the delta replay smoke bundle must also match a compact `cl-quote-v1` row for the selected pool, direction, and amount.
+- Pair route-lab rows with `bun scripts/fame-swap-pool-activation-report.ts` and the `society-bots` delta replay smoke bundle.
+- Treat `activationEvidence.status: "blocked"` as a gate failure, not as a reason to discard reducer candidate state.
+- Do not claim V4 compact quote support from this lane; the selected route remains mixed compact/live until a reviewed V4 reducer exists.
 
 Route lab readiness:
 
@@ -165,7 +173,7 @@ Follow-up soon:
 - TODO: Split reserve compact-quote unavailable reasons from CL replay reasons and require non-null reserve post-swap price fields when a reserve row is quoted, with fixture coverage for malformed reserve state and zero-output math.
 - TODO: Add a compact quote batching regression for repeated optimizer waves so `www` proves duplicate evaluated edges are coalesced and total helper requests stay bounded before live fallback.
 - TODO: Add a bounded replay-work path for dense CL `/fame/pool-quotes`: avoid bitmap chunk reads for compact quotes when possible, prepare parsed tick state once per pool/batch, use cursor or binary search traversal instead of repeated full scans, and cap crossed ticks/work before Lambda timeout.
-- TODO: Add selected-route and losing-route smoke evidence for compact quote attribution after dev deploy.
+- TODO: Attach selected-route activation evidence from indexed route lab, the activation report, and the delta replay smoke bundle after dev deploy.
 - TODO: Contain backend replay exceptions per quote and return typed `unavailable` entries instead of failing the whole `/fame/pool-quotes` batch.
 - TODO: Continue compact quote observability in runtime logs after `debug.quoteApi` proves configured/attempted/used, status/reason counts, helper failure, source mismatch, no matching quote, unusable quote, and selected evidence identity.
 

--- a/scripts/fame-swap-cl-replay-parity.test.ts
+++ b/scripts/fame-swap-cl-replay-parity.test.ts
@@ -10,7 +10,10 @@ import type {
 } from "../src/features/fame-swap/solver/quotes/adapters";
 import type { FameIndexedPoolStateBatchResponse } from "../src/features/fame-swap/solver/quotes/indexedPoolStateClient";
 import { quoteFromIndexedSlipstreamReplay } from "../src/features/fame-swap/solver/quotes/indexedClReplayAdapter";
-import { FAME_V4_ZORA_REVIEWED_POOL_SHAPE } from "../src/features/fame-swap/solver/poolStateRegistry";
+import {
+  FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE,
+  FAME_V4_ZORA_REVIEWED_POOL_SHAPE,
+} from "../src/features/fame-swap/solver/poolStateRegistry";
 import {
   buildClReplayParityCases,
   displaySafeErrorMessage,
@@ -19,7 +22,10 @@ import {
   runCompactQuoteParity,
   runClReplayParity,
 } from "./fame-swap-cl-replay-parity";
-import type { FamePoolQuoteBatchResponse } from "../src/features/fame-swap/solver/quotes/indexedQuoteApiClient";
+import type {
+  FamePoolQuoteBatchResponse,
+  FameV4ClPoolQuoteQuotedEntry,
+} from "../src/features/fame-swap/solver/quotes/indexedQuoteApiClient";
 
 type IndexedClReplayEntry = Extract<
   FameIndexedPoolStateBatchResponse["pools"][number],
@@ -41,13 +47,15 @@ function slipstreamEdge(
   return edge;
 }
 
-function v4ZoraEdge(
-  tokenIn: Address = FAME_V4_ZORA_REVIEWED_POOL_SHAPE.currency1,
-  tokenOut: Address = FAME_V4_ZORA_REVIEWED_POOL_SHAPE.currency0,
+function v4ReviewedEdge(
+  reviewed:
+    | typeof FAME_V4_ZORA_REVIEWED_POOL_SHAPE
+    | typeof FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE = FAME_V4_ZORA_REVIEWED_POOL_SHAPE,
+  tokenIn: Address = reviewed.currency1,
+  tokenOut: Address = reviewed.currency0,
 ) {
   const edge = famePoolEdgesForPair(tokenIn, tokenOut).find(
-    (candidate) =>
-      candidate.poolId === FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId,
+    (candidate) => candidate.poolId === reviewed.poolId,
   );
   assert.ok(edge);
   return edge;
@@ -191,85 +199,112 @@ function liveAdapter(
   };
 }
 
+function compactQuoteRow(
+  amountIn: bigint,
+  amountOut: bigint,
+  reviewed:
+    | typeof FAME_V4_ZORA_REVIEWED_POOL_SHAPE
+    | typeof FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE = FAME_V4_ZORA_REVIEWED_POOL_SHAPE,
+  tokenIn: Address = reviewed.currency1,
+  tokenOut: Address = reviewed.currency0,
+): FameV4ClPoolQuoteQuotedEntry {
+  const provenanceRequired =
+    reviewed.poolId === FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId;
+  return {
+    status: "quoted",
+    quoteKind: "cl-quote-v1",
+    poolId: reviewed.poolId,
+    chainId: 8453,
+    poolAddress: null,
+    poolKey: reviewed.poolKey,
+    poolManager: reviewed.poolManager,
+    stateViewAddress: reviewed.stateViewAddress,
+    token0: reviewed.currency0,
+    token1: reviewed.currency1,
+    tokenIn,
+    tokenOut,
+    venueFamily: "UniswapV4",
+    tickSpacing: reviewed.tickSpacing,
+    amountIn: amountIn.toString(),
+    amountOut: amountOut.toString(),
+    sqrtPriceX96: Q96.toString(),
+    sqrtPriceX96After: (Q96 - 1n).toString(),
+    tick: 0,
+    liquidity: "1000000000000000000",
+    fee: reviewed.fee.toString(),
+    lpFee: reviewed.fee.toString(),
+    protocolFee: "0",
+    protocolFeeStatus: "zero",
+    staticFee: reviewed.fee.toString(),
+    feeSource: "v4-slot0",
+    observedThroughBlock: 124,
+    blockHash:
+      "0x4444444444444444444444444444444444444444444444444444444444444444",
+    parentHash:
+      "0x5555555555555555555555555555555555555555555555555555555555555555",
+    snapshotId: "unit-v4-compact-quote",
+    stateHash:
+      "0x6666666666666666666666666666666666666666666666666666666666666666",
+    source: "uniswap-v4-state-view",
+    sourceRegistryId: "unit-registry",
+    maxFreshnessBlocks: 120,
+    hookAddress: reviewed.hooks,
+    hookData: reviewed.hookData,
+    hookDataStatus: "empty",
+    reviewedPoolEvidence: {
+      status: "verified",
+      source: "reviewed-v4-manifest",
+      kind: provenanceRequired ? "zora-protocol-pool" : "zero-hook-static-fee",
+      manifestVersion: 1,
+      poolId: reviewed.poolId,
+      poolKey: reviewed.poolKey,
+      staticFee: reviewed.fee.toString(),
+      hookAddress: reviewed.hooks,
+      hookData: reviewed.hookData,
+      protocolFeeStatus: "zero",
+    },
+    ...(provenanceRequired
+      ? {
+          zoraProvenance: {
+            status: "verified" as const,
+            source: "zora-factory-event" as const,
+            chainId: 8453 as const,
+            factoryAddress:
+              "0x0000000000000000000000000000000000000003" as const,
+            coinAddress: reviewed.currency1,
+            poolKey: reviewed.poolKey,
+            poolId: reviewed.poolKey,
+            transactionHash:
+              "0x7777777777777777777777777777777777777777777777777777777777777777" as const,
+            eventName: "CoinCreatedV4",
+          },
+        }
+      : {}),
+  };
+}
+
 function compactQuoteResponse(
   amountIn: bigint,
   amountOut: bigint,
-  tokenIn: Address = FAME_V4_ZORA_REVIEWED_POOL_SHAPE.currency1,
-  tokenOut: Address = FAME_V4_ZORA_REVIEWED_POOL_SHAPE.currency0,
+  tokenIn?: Address,
+  tokenOut?: Address,
+  reviewed:
+    | typeof FAME_V4_ZORA_REVIEWED_POOL_SHAPE
+    | typeof FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE = FAME_V4_ZORA_REVIEWED_POOL_SHAPE,
 ): FamePoolQuoteBatchResponse {
-  const reviewed = FAME_V4_ZORA_REVIEWED_POOL_SHAPE;
   return {
     sourceRegistryId: "unit-registry",
     currentBlock: 125,
     producerMaxFreshnessBlocks: 120,
     effectiveMaxFreshnessBlocks: 120,
     quotes: [
-      {
-        status: "quoted",
-        quoteKind: "cl-quote-v1",
-        poolId: reviewed.poolId,
-        chainId: 8453,
-        poolAddress: null,
-        poolKey: reviewed.poolKey,
-        poolManager: reviewed.poolManager,
-        stateViewAddress: reviewed.stateViewAddress,
-        token0: reviewed.currency0,
-        token1: reviewed.currency1,
-        tokenIn,
-        tokenOut,
-        venueFamily: "UniswapV4",
-        tickSpacing: reviewed.tickSpacing,
-        amountIn: amountIn.toString(),
-        amountOut: amountOut.toString(),
-        sqrtPriceX96: Q96.toString(),
-        sqrtPriceX96After: (Q96 - 1n).toString(),
-        tick: 0,
-        liquidity: "1000000000000000000",
-        fee: "30000",
-        lpFee: "30000",
-        protocolFee: "0",
-        protocolFeeStatus: "zero",
-        staticFee: "30000",
-        feeSource: "v4-slot0",
-        observedThroughBlock: 124,
-        blockHash:
-          "0x4444444444444444444444444444444444444444444444444444444444444444",
-        parentHash:
-          "0x5555555555555555555555555555555555555555555555555555555555555555",
-        snapshotId: "unit-v4-compact-quote",
-        stateHash:
-          "0x6666666666666666666666666666666666666666666666666666666666666666",
-        source: "uniswap-v4-state-view",
-        sourceRegistryId: "unit-registry",
-        maxFreshnessBlocks: 120,
-        hookAddress: reviewed.hooks,
-        hookData: reviewed.hookData,
-        hookDataStatus: "empty",
-        reviewedPoolEvidence: {
-          status: "verified",
-          source: "reviewed-v4-manifest",
-          kind: "zora-protocol-pool",
-          manifestVersion: 1,
-          poolId: reviewed.poolId,
-          poolKey: reviewed.poolKey,
-          staticFee: reviewed.fee.toString(),
-          hookAddress: reviewed.hooks,
-          hookData: reviewed.hookData,
-          protocolFeeStatus: "zero",
-        },
-        zoraProvenance: {
-          status: "verified",
-          source: "zora-factory-event",
-          chainId: 8453,
-          factoryAddress: "0x0000000000000000000000000000000000000003",
-          coinAddress: reviewed.currency1,
-          poolKey: reviewed.poolKey,
-          poolId: reviewed.poolKey,
-          transactionHash:
-            "0x7777777777777777777777777777777777777777777777777777777777777777",
-          eventName: "CoinCreatedV4",
-        },
-      },
+      compactQuoteRow(
+        amountIn,
+        amountOut,
+        reviewed,
+        tokenIn ?? reviewed.currency1,
+        tokenOut ?? reviewed.currency0,
+      ),
     ],
   };
 }
@@ -439,7 +474,8 @@ describe("FAME Slipstream CL replay parity harness", () => {
       {
         label: "BASED->ZORA",
         request: {
-          edge: v4ZoraEdge(
+          edge: v4ReviewedEdge(
+            FAME_V4_ZORA_REVIEWED_POOL_SHAPE,
             FAME_V4_ZORA_REVIEWED_POOL_SHAPE.currency1,
             FAME_V4_ZORA_REVIEWED_POOL_SHAPE.currency0,
           ),
@@ -463,6 +499,91 @@ describe("FAME Slipstream CL replay parity harness", () => {
     assert.equal(report.results.length, 1);
     assert.equal(report.results[0]?.localAmountOut, amountOut);
     assert.equal(report.results[0]?.driftBps, 0n);
+  });
+
+  it("reports exact compact quote/live parity for the no-hook V4 ZORA/ETH target", async () => {
+    const amountIn = 1_000_000_000_000_000n;
+    const ethToZoraOut = 170_174_733_551_265_108_370n;
+    const zoraToEthOut = 5_876_315_014_197n;
+    const cases = [
+      {
+        label: "ETH->ZORA",
+        request: {
+          edge: v4ReviewedEdge(
+            FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE,
+            FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.currency0,
+            FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.currency1,
+          ),
+          amountIn,
+        },
+      },
+      {
+        label: "ZORA->ETH",
+        request: {
+          edge: v4ReviewedEdge(
+            FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE,
+            FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.currency1,
+            FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.currency0,
+          ),
+          amountIn,
+        },
+      },
+    ];
+
+    const report = await runCompactQuoteParity({
+      quoteResponse: {
+        ...compactQuoteResponse(
+          amountIn,
+          ethToZoraOut,
+          FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.currency0,
+          FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.currency1,
+          FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE,
+        ),
+        quotes: [
+          compactQuoteRow(
+            amountIn,
+            ethToZoraOut,
+            FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE,
+            FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.currency0,
+            FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.currency1,
+          ),
+          compactQuoteRow(
+            amountIn,
+            zoraToEthOut,
+            FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE,
+            FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.currency1,
+            FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.currency0,
+          ),
+        ],
+      },
+      liveAdapter: {
+        async quoteEdge(request) {
+          return {
+            status: "quoted",
+            amountIn: request.amountIn,
+            amountOut:
+              request.edge.tokenIn ===
+              FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.currency0
+                ? ethToZoraOut
+                : zoraToEthOut,
+            capacityIn: null,
+            fee: request.edge.fee,
+            evidence: "unit live v4 zora-eth quoter",
+          };
+        },
+      },
+      currentBlock: 125,
+      cases,
+      expectedSourceRegistryId: "unit-registry",
+    });
+
+    assert.equal(report.poolId, FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.poolId);
+    assert.equal(report.surface, "compact-quote-v1");
+    assert.equal(report.results.length, 2);
+    assert.deepEqual(
+      report.results.map((result) => result.driftBps),
+      [0n, 0n],
+    );
   });
 
   it("keeps V4 targets out of the Slipstream replay runner", async () => {

--- a/scripts/fame-swap-cl-replay-parity.test.ts
+++ b/scripts/fame-swap-cl-replay-parity.test.ts
@@ -245,6 +245,18 @@ function compactQuoteResponse(
         hookAddress: reviewed.hooks,
         hookData: reviewed.hookData,
         hookDataStatus: "empty",
+        reviewedPoolEvidence: {
+          status: "verified",
+          source: "reviewed-v4-manifest",
+          kind: "zora-protocol-pool",
+          manifestVersion: 1,
+          poolId: reviewed.poolId,
+          poolKey: reviewed.poolKey,
+          staticFee: reviewed.fee.toString(),
+          hookAddress: reviewed.hooks,
+          hookData: reviewed.hookData,
+          protocolFeeStatus: "zero",
+        },
         zoraProvenance: {
           status: "verified",
           source: "zora-factory-event",

--- a/scripts/fame-swap-cl-replay-parity.test.ts
+++ b/scripts/fame-swap-cl-replay-parity.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import type { Address } from "viem";
-import { USDC, WETH } from "../src/features/fame-swap/tokens";
+import { FAME, USDC, WETH } from "../src/features/fame-swap/tokens";
 import { famePoolEdgesForPair } from "../src/features/fame-swap/solver/poolUniverse";
 import type {
   FameAsyncQuoteAdapter,
@@ -22,10 +22,15 @@ type IndexedClReplayEntry = Extract<
 >;
 
 const Q96 = 79_228_162_514_264_337_593_543_950_336n;
+const BASEDFLICK = "0x15e012abf9d32cd67fc6cf480ea0e318e9ed5926" as const;
 
-function slipstreamEdge(tokenIn: Address = WETH, tokenOut: Address = USDC) {
+function slipstreamEdge(
+  poolId = "slipstream-usdc-weth-100",
+  tokenIn: Address = WETH,
+  tokenOut: Address = USDC,
+) {
   const edge = famePoolEdgesForPair(tokenIn, tokenOut).find(
-    (candidate) => candidate.poolId === "slipstream-usdc-weth-100",
+    (candidate) => candidate.poolId === poolId,
   );
   assert.ok(edge);
   return edge;
@@ -85,13 +90,51 @@ function replayEntry(): IndexedClReplayEntry {
   };
 }
 
-function indexedState(): FameIndexedPoolStateBatchResponse {
+function selectedReplayEntry(): IndexedClReplayEntry {
+  return {
+    ...replayEntry(),
+    poolId: "slipstream-basedflick-fame",
+    poolAddress: "0xbd7e5bb5a6251f6dde2cf56afa50ed0c8b4c2cdb",
+    token0: BASEDFLICK,
+    token1: FAME,
+    tickSpacing: 2000,
+    sqrtPriceX96: "14225627699858779769529171968",
+    tick: -34350,
+    liquidity: "1000000000000000000000000000000",
+    fee: "10000",
+    snapshotId: "unit-selected-candidate",
+    minWordPosition: -10,
+    maxWordPosition: 0,
+    minTick: -40000,
+    maxTick: 0,
+    bitmapWords: [
+      {
+        wordPosition: -10,
+        bitmap:
+          "0x0000000000000000000000000000000000000000000000000000000000000010",
+      },
+      {
+        wordPosition: 0,
+        bitmap:
+          "0x0000000000000000000000000000000000000000000000000000000000000001",
+      },
+    ],
+    initializedTicks: [
+      { tick: -40000, liquidityGross: "1000", liquidityNet: "-1000" },
+      { tick: 0, liquidityGross: "1000", liquidityNet: "1000" },
+    ],
+  };
+}
+
+function indexedState(
+  pools: FameIndexedPoolStateBatchResponse["pools"] = [replayEntry()],
+): FameIndexedPoolStateBatchResponse {
   return {
     sourceRegistryId: "unit-registry",
     currentBlock: 125,
     producerMaxFreshnessBlocks: 120,
     effectiveMaxFreshnessBlocks: 120,
-    pools: [replayEntry()],
+    pools,
   };
 }
 
@@ -200,20 +243,66 @@ describe("FAME Slipstream CL replay parity harness", () => {
       cases: [
         {
           label: "WETH->USDC",
-          request: { edge: slipstreamEdge(), amountIn: 1_000_000n },
+          request: {
+            edge: slipstreamEdge("slipstream-usdc-weth-100", WETH, USDC),
+            amountIn: 1_000_000n,
+          },
         },
         {
           label: "USDC->WETH",
           request: {
-            edge: slipstreamEdge(USDC, WETH),
+            edge: slipstreamEdge("slipstream-usdc-weth-100", USDC, WETH),
             amountIn: 1_000_000n,
           },
         },
       ],
     });
 
+    assert.equal(report.poolId, "slipstream-usdc-weth-100");
     assert.equal(report.snapshotId, "unit-cl-replay");
     assert.equal(report.results.length, 2);
+    assert.ok(report.results.every((result) => result.driftBps === 0n));
+  });
+
+  it("reports selected-pool parity cases in both directions", async () => {
+    const state = indexedState([selectedReplayEntry()]);
+    const report = await runClReplayParity({
+      indexedState: state,
+      liveAdapter: liveAdapter(state, 0n),
+      currentBlock: 125,
+      poolId: "slipstream-basedflick-fame",
+      cases: [
+        {
+          label: "FAME->basedflick",
+          request: {
+            edge: slipstreamEdge(
+              "slipstream-basedflick-fame",
+              FAME,
+              BASEDFLICK,
+            ),
+            amountIn: 1_000_000n,
+          },
+        },
+        {
+          label: "basedflick->FAME",
+          request: {
+            edge: slipstreamEdge(
+              "slipstream-basedflick-fame",
+              BASEDFLICK,
+              FAME,
+            ),
+            amountIn: 1_000_000n,
+          },
+        },
+      ],
+    });
+
+    assert.equal(report.poolId, "slipstream-basedflick-fame");
+    assert.equal(report.snapshotId, "unit-selected-candidate");
+    assert.deepEqual(
+      report.results.map((result) => result.label),
+      ["FAME->basedflick", "basedflick->FAME"],
+    );
     assert.ok(report.results.every((result) => result.driftBps === 0n));
   });
 
@@ -229,7 +318,10 @@ describe("FAME Slipstream CL replay parity harness", () => {
           cases: [
             {
               label: "WETH->USDC",
-              request: { edge: slipstreamEdge(), amountIn: 1_000_000n },
+              request: {
+                edge: slipstreamEdge("slipstream-usdc-weth-100", WETH, USDC),
+                amountIn: 1_000_000n,
+              },
             },
           ],
         }),

--- a/scripts/fame-swap-cl-replay-parity.test.ts
+++ b/scripts/fame-swap-cl-replay-parity.test.ts
@@ -10,11 +10,16 @@ import type {
 } from "../src/features/fame-swap/solver/quotes/adapters";
 import type { FameIndexedPoolStateBatchResponse } from "../src/features/fame-swap/solver/quotes/indexedPoolStateClient";
 import { quoteFromIndexedSlipstreamReplay } from "../src/features/fame-swap/solver/quotes/indexedClReplayAdapter";
+import { FAME_V4_ZORA_REVIEWED_POOL_SHAPE } from "../src/features/fame-swap/solver/poolStateRegistry";
 import {
+  buildClReplayParityCases,
   displaySafeErrorMessage,
+  poolQuoteEndpointUrlFromEnv,
   poolStateEndpointUrlFromEnv,
+  runCompactQuoteParity,
   runClReplayParity,
 } from "./fame-swap-cl-replay-parity";
+import type { FamePoolQuoteBatchResponse } from "../src/features/fame-swap/solver/quotes/indexedQuoteApiClient";
 
 type IndexedClReplayEntry = Extract<
   FameIndexedPoolStateBatchResponse["pools"][number],
@@ -26,6 +31,18 @@ const Q96 = 79_228_162_514_264_337_593_543_950_336n;
 function slipstreamEdge(tokenIn: Address = WETH, tokenOut: Address = USDC) {
   const edge = famePoolEdgesForPair(tokenIn, tokenOut).find(
     (candidate) => candidate.poolId === "slipstream-usdc-weth-100",
+  );
+  assert.ok(edge);
+  return edge;
+}
+
+function v4ZoraEdge(
+  tokenIn: Address = FAME_V4_ZORA_REVIEWED_POOL_SHAPE.currency1,
+  tokenOut: Address = FAME_V4_ZORA_REVIEWED_POOL_SHAPE.currency0,
+) {
+  const edge = famePoolEdgesForPair(tokenIn, tokenOut).find(
+    (candidate) =>
+      candidate.poolId === FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId,
   );
   assert.ok(edge);
   return edge;
@@ -131,6 +148,92 @@ function liveAdapter(
   };
 }
 
+function compactQuoteResponse(
+  amountIn: bigint,
+  amountOut: bigint,
+  tokenIn: Address = FAME_V4_ZORA_REVIEWED_POOL_SHAPE.currency1,
+  tokenOut: Address = FAME_V4_ZORA_REVIEWED_POOL_SHAPE.currency0,
+): FamePoolQuoteBatchResponse {
+  const reviewed = FAME_V4_ZORA_REVIEWED_POOL_SHAPE;
+  return {
+    sourceRegistryId: "unit-registry",
+    currentBlock: 125,
+    producerMaxFreshnessBlocks: 120,
+    effectiveMaxFreshnessBlocks: 120,
+    quotes: [
+      {
+        status: "quoted",
+        quoteKind: "cl-quote-v1",
+        poolId: reviewed.poolId,
+        chainId: 8453,
+        poolAddress: null,
+        poolKey: reviewed.poolKey,
+        poolManager: reviewed.poolManager,
+        stateViewAddress: reviewed.stateViewAddress,
+        token0: reviewed.currency0,
+        token1: reviewed.currency1,
+        tokenIn,
+        tokenOut,
+        venueFamily: "UniswapV4",
+        tickSpacing: reviewed.tickSpacing,
+        amountIn: amountIn.toString(),
+        amountOut: amountOut.toString(),
+        sqrtPriceX96: Q96.toString(),
+        sqrtPriceX96After: (Q96 - 1n).toString(),
+        tick: 0,
+        liquidity: "1000000000000000000",
+        fee: "30000",
+        lpFee: "30000",
+        protocolFee: "0",
+        protocolFeeStatus: "zero",
+        staticFee: "30000",
+        feeSource: "v4-slot0",
+        observedThroughBlock: 124,
+        blockHash:
+          "0x4444444444444444444444444444444444444444444444444444444444444444",
+        parentHash:
+          "0x5555555555555555555555555555555555555555555555555555555555555555",
+        snapshotId: "unit-v4-compact-quote",
+        stateHash:
+          "0x6666666666666666666666666666666666666666666666666666666666666666",
+        source: "uniswap-v4-state-view",
+        sourceRegistryId: "unit-registry",
+        maxFreshnessBlocks: 120,
+        hookAddress: reviewed.hooks,
+        hookData: reviewed.hookData,
+        hookDataStatus: "empty",
+        zoraProvenance: {
+          status: "verified",
+          source: "zora-factory-event",
+          chainId: 8453,
+          factoryAddress: "0x0000000000000000000000000000000000000003",
+          coinAddress: reviewed.currency1,
+          poolKey: reviewed.poolKey,
+          poolId: reviewed.poolKey,
+          transactionHash:
+            "0x7777777777777777777777777777777777777777777777777777777777777777",
+          eventName: "CoinCreatedV4",
+        },
+      },
+    ],
+  };
+}
+
+function compactLiveAdapter(amountOut: bigint): FameAsyncQuoteAdapter {
+  return {
+    async quoteEdge(request) {
+      return {
+        status: "quoted",
+        amountIn: request.amountIn,
+        amountOut,
+        capacityIn: null,
+        fee: request.edge.fee,
+        evidence: "unit live v4 quoter",
+      };
+    },
+  };
+}
+
 describe("FAME Slipstream CL replay parity harness", () => {
   it("derives the raw pool-state proof endpoint from FAME_POOL_API_URL", () => {
     const previousBase = process.env.FAME_POOL_API_URL;
@@ -142,6 +245,10 @@ describe("FAME Slipstream CL replay parity harness", () => {
       assert.equal(
         poolStateEndpointUrlFromEnv(),
         "https://api.fame.support/base/fame/pool-state",
+      );
+      assert.equal(
+        poolQuoteEndpointUrlFromEnv(),
+        "https://api.fame.support/base/fame/pool-quotes",
       );
     } finally {
       if (previousBase === undefined) delete process.env.FAME_POOL_API_URL;
@@ -213,8 +320,128 @@ describe("FAME Slipstream CL replay parity harness", () => {
     });
 
     assert.equal(report.snapshotId, "unit-cl-replay");
+    assert.equal(report.surface, "cl-replay-v1");
+    assert.equal(report.sourceRegistryId, "unit-registry");
+    assert.equal(report.currentBlock, 125);
+    assert.equal(
+      report.blockHash,
+      "0x1111111111111111111111111111111111111111111111111111111111111111",
+    );
     assert.equal(report.results.length, 2);
     assert.ok(report.results.every((result) => result.driftBps === 0n));
+  });
+
+  it("reports exact compact quote/live parity for the V4 Zora target", async () => {
+    const amountIn = 980_100_000_232_613_992n;
+    const amountOut = 950_696_999_225_635_572n;
+    const cases = [
+      {
+        label: "BASED->ZORA",
+        request: {
+          edge: v4ZoraEdge(
+            FAME_V4_ZORA_REVIEWED_POOL_SHAPE.currency1,
+            FAME_V4_ZORA_REVIEWED_POOL_SHAPE.currency0,
+          ),
+          amountIn,
+        },
+      },
+    ];
+
+    const report = await runCompactQuoteParity({
+      quoteResponse: compactQuoteResponse(amountIn, amountOut),
+      liveAdapter: compactLiveAdapter(amountOut),
+      currentBlock: 125,
+      cases,
+      expectedSourceRegistryId: "unit-registry",
+    });
+
+    assert.equal(report.surface, "compact-quote-v1");
+    assert.equal(report.snapshotId, "unit-v4-compact-quote");
+    assert.equal(report.evidenceId, "unit-v4-compact-quote");
+    assert.equal(report.observedThroughBlock, 124);
+    assert.equal(report.results.length, 1);
+    assert.equal(report.results[0]?.localAmountOut, amountOut);
+    assert.equal(report.results[0]?.driftBps, 0n);
+  });
+
+  it("keeps V4 targets out of the Slipstream replay runner", async () => {
+    const state = indexedState();
+    const cases = buildClReplayParityCases([
+      {
+        poolId: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId,
+        tokenIn: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.currency1,
+        tokenOut: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.currency0,
+        amounts: [1_000_000n],
+      },
+    ]);
+
+    await assert.rejects(
+      () =>
+        runClReplayParity({
+          indexedState: state,
+          liveAdapter: liveAdapter(state, 0n),
+          currentBlock: 125,
+          cases,
+        }),
+      /use compact quote parity for V4 targets/,
+    );
+  });
+
+  it("builds targeted parity cases for a requested pool direction", () => {
+    const cases = buildClReplayParityCases([
+      {
+        poolId: "slipstream-usdc-weth-100",
+        tokenIn: WETH,
+        tokenOut: USDC,
+        amounts: [1_000_000n, 2_000_000n],
+      },
+    ]);
+
+    assert.deepEqual(
+      cases.map((item) => item.request.amountIn),
+      [1_000_000n, 2_000_000n],
+    );
+    assert.ok(
+      cases.every(
+        (item) => item.request.edge.poolId === "slipstream-usdc-weth-100",
+      ),
+    );
+    assert.match(cases[0]?.label ?? "", /slipstream-usdc-weth-100/);
+  });
+
+  it("rejects mixed-pool parity cases before comparing live quotes", async () => {
+    const state = indexedState();
+    const first = buildClReplayParityCases([
+      {
+        poolId: "slipstream-usdc-weth-100",
+        tokenIn: WETH,
+        tokenOut: USDC,
+        amounts: [1_000_000n],
+      },
+    ])[0];
+    assert.ok(first);
+    await assert.rejects(
+      () =>
+        runClReplayParity({
+          indexedState: state,
+          liveAdapter: liveAdapter(state, 0n),
+          currentBlock: 125,
+          cases: [
+            first,
+            {
+              ...first,
+              request: {
+                ...first.request,
+                edge: {
+                  ...first.request.edge,
+                  poolId: "other-pool",
+                },
+              },
+            },
+          ],
+        }),
+      /must target one pool id/,
+    );
   });
 
   it("rejects any amount-out mismatch even when integer bps drift rounds to zero", async () => {

--- a/scripts/fame-swap-cl-replay-parity.ts
+++ b/scripts/fame-swap-cl-replay-parity.ts
@@ -1,6 +1,6 @@
 import { createPublicClient, http, type Address } from "viem";
 import { base } from "viem/chains";
-import { USDC, WETH } from "../src/features/fame-swap/tokens";
+import { FAME, USDC, WETH } from "../src/features/fame-swap/tokens";
 import { famePoolEdgesForPair } from "../src/features/fame-swap/solver/poolUniverse";
 import { famePoolStateRegistrySourceId } from "../src/features/fame-swap/solver/poolStateRegistry";
 import {
@@ -9,6 +9,7 @@ import {
   type FameIndexedPoolStateEntry,
 } from "../src/features/fame-swap/solver/quotes/indexedPoolStateClient";
 import { quoteFromIndexedSlipstreamReplay } from "../src/features/fame-swap/solver/quotes/indexedClReplayAdapter";
+import { displaySafeDiagnosticMessage } from "../src/features/fame-swap/solver/diagnostics";
 import { createLiveLiquidityQuoteAdapter } from "../src/features/fame-swap/solver/quotes/liveAdapters";
 import type {
   FameAsyncQuoteAdapter,
@@ -20,11 +21,22 @@ type ReplayEntry = Extract<
   { stateKind: "cl-replay-v1" }
 >;
 
-const POOL_ID = "slipstream-usdc-weth-100";
+const DEFAULT_CL_REPLAY_PARITY_POOL_ID = "slipstream-usdc-weth-100";
+const SELECTED_CL_REPLAY_PARITY_POOL_ID = "slipstream-basedflick-fame";
+const BASEDFLICK =
+  "0x15e012abf9d32cd67fc6cf480ea0e318e9ed5926" as const satisfies Address;
+
 export const DEFAULT_CL_REPLAY_PARITY_AMOUNTS = {
   wethToUsdc: [10n ** 14n, 10n ** 15n, 10n ** 16n],
   usdcToWeth: [1_000_000n, 10_000_000n, 100_000_000n],
+  fameToBasedflick: [10n ** 14n, 10n ** 15n, 31_597_600_141_347_829n],
+  basedflickToFame: [10n ** 14n, 10n ** 15n, 10n ** 16n],
 } as const;
+
+export const DEFAULT_CL_REPLAY_PARITY_POOL_IDS = [
+  DEFAULT_CL_REPLAY_PARITY_POOL_ID,
+  SELECTED_CL_REPLAY_PARITY_POOL_ID,
+] as const;
 
 export interface FameClReplayParityCase {
   label: string;
@@ -39,6 +51,7 @@ export interface FameClReplayParityResult {
 }
 
 export interface FameClReplayParityReport {
+  poolId: string;
   snapshotId: string;
   observedThroughBlock: number;
   stateHash: string;
@@ -112,35 +125,21 @@ export function poolStateEndpointUrlFromEnv(): string {
 }
 
 export function displaySafeErrorMessage(error: unknown): string {
-  const raw = error instanceof Error ? error.message : String(error);
-  return (
-    raw
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .find(
-        (line) =>
-          line.length > 0 &&
-          !/\b(request body|calldata|approval|swap request|private key|signer|authorization|api[-_ ]?key)\b|(?:^|\s)secret(?:[-_ ]?(?:key|token))?\s*[:=]/i.test(
-            line,
-          ),
-      ) ?? "FAME CL replay parity failed."
-  )
-    .replace(/(?:https?|wss?):\/\/\S+/g, "[redacted-url]")
-    .replace(/\b(?:bearer|token)\s+[a-z0-9._~+/=-]+/gi, "[redacted-secret]")
-    .replace(/0x[a-fA-F0-9]{64,}/g, "[redacted-hex]");
+  return displaySafeDiagnosticMessage(error);
 }
 
-function edge(tokenIn: Address, tokenOut: Address) {
+function edge(poolId: string, tokenIn: Address, tokenOut: Address) {
   const found = famePoolEdgesForPair(tokenIn, tokenOut).find(
-    (candidate) => candidate.poolId === POOL_ID,
+    (candidate) => candidate.poolId === poolId,
   );
-  if (!found) throw new Error(`Missing ${POOL_ID} edge.`);
+  if (!found) throw new Error(`Missing ${poolId} edge.`);
   return found;
 }
 
 function replayEntry(
   entry: FameIndexedPoolStateEntry | undefined,
   expectedSourceRegistryId: string,
+  poolId: string,
 ): ReplayEntry {
   if (
     !entry ||
@@ -148,11 +147,11 @@ function replayEntry(
     !("stateKind" in entry) ||
     entry.stateKind !== "cl-replay-v1"
   ) {
-    throw new Error(`${POOL_ID} did not return fresh cl-replay-v1 state.`);
+    throw new Error(`${poolId} did not return fresh cl-replay-v1 state.`);
   }
   if (entry.sourceRegistryId !== expectedSourceRegistryId) {
     throw new Error(
-      `${POOL_ID} returned cl-replay-v1 state for registry ${entry.sourceRegistryId}, expected ${expectedSourceRegistryId}.`,
+      `${poolId} returned cl-replay-v1 state for registry ${entry.sourceRegistryId}, expected ${expectedSourceRegistryId}.`,
     );
   }
   return entry;
@@ -165,15 +164,28 @@ function parityBps(left: bigint, right: bigint): bigint {
   return (delta * 10_000n) / bigger;
 }
 
-function defaultParityCases(): FameClReplayParityCase[] {
+function defaultParityCases(poolId: string): FameClReplayParityCase[] {
+  if (poolId === SELECTED_CL_REPLAY_PARITY_POOL_ID) {
+    return [
+      ...DEFAULT_CL_REPLAY_PARITY_AMOUNTS.fameToBasedflick.map((amountIn) => ({
+        label: `FAME->basedflick ${amountIn.toString()}`,
+        request: { edge: edge(poolId, FAME, BASEDFLICK), amountIn },
+      })),
+      ...DEFAULT_CL_REPLAY_PARITY_AMOUNTS.basedflickToFame.map((amountIn) => ({
+        label: `basedflick->FAME ${amountIn.toString()}`,
+        request: { edge: edge(poolId, BASEDFLICK, FAME), amountIn },
+      })),
+    ];
+  }
+
   return [
     ...DEFAULT_CL_REPLAY_PARITY_AMOUNTS.wethToUsdc.map((amountIn) => ({
       label: `WETH->USDC ${amountIn.toString()}`,
-      request: { edge: edge(WETH, USDC), amountIn },
+      request: { edge: edge(poolId, WETH, USDC), amountIn },
     })),
     ...DEFAULT_CL_REPLAY_PARITY_AMOUNTS.usdcToWeth.map((amountIn) => ({
       label: `USDC->WETH ${amountIn.toString()}`,
-      request: { edge: edge(USDC, WETH), amountIn },
+      request: { edge: edge(poolId, USDC, WETH), amountIn },
     })),
   ];
 }
@@ -184,17 +196,20 @@ export async function runClReplayParity(options: {
   currentBlock: number;
   cases?: readonly FameClReplayParityCase[];
   expectedSourceRegistryId?: string;
+  poolId?: string;
 }): Promise<FameClReplayParityReport> {
   const expectedSourceRegistryId =
     options.expectedSourceRegistryId ?? options.indexedState.sourceRegistryId;
+  const poolId = options.poolId ?? DEFAULT_CL_REPLAY_PARITY_POOL_ID;
   const state = replayEntry(
     options.indexedState.pools.find(
-      (pool) => "poolId" in pool && pool.poolId === POOL_ID,
+      (pool) => "poolId" in pool && pool.poolId === poolId,
     ),
     expectedSourceRegistryId,
+    poolId,
   );
   const results: FameClReplayParityResult[] = [];
-  for (const item of options.cases ?? defaultParityCases()) {
+  for (const item of options.cases ?? defaultParityCases(poolId)) {
     const context = {
       source: "indexed" as const,
       chainId: base.id,
@@ -239,6 +254,7 @@ export async function runClReplayParity(options: {
     }
   }
   return {
+    poolId,
     snapshotId: state.snapshotId,
     observedThroughBlock: state.observedThroughBlock,
     stateHash: state.stateHash,
@@ -266,13 +282,18 @@ async function main(): Promise<void> {
   if (!Number.isSafeInteger(currentBlock)) {
     throw new Error("Current Base block exceeds Number.MAX_SAFE_INTEGER.");
   }
+  const poolIds = process.env.FAME_CL_REPLAY_PARITY_POOL_ID?.split(",")
+    .map((poolId) => poolId.trim())
+    .filter((poolId) => poolId.length > 0) ?? [
+    ...DEFAULT_CL_REPLAY_PARITY_POOL_IDS,
+  ];
   const indexed = await helper.fetchPoolStates({
     currentBlock,
     maxFreshnessBlocks: optionalIntegerEnv(
       "FAME_POOL_STATE_MAX_FRESHNESS_BLOCKS",
     ),
     stateSurfaces: ["cl-replay-v1"],
-    poolIds: [POOL_ID],
+    poolIds,
   });
   const expectedSourceRegistryId = famePoolStateRegistrySourceId();
   if (indexed.sourceRegistryId !== expectedSourceRegistryId) {
@@ -280,41 +301,50 @@ async function main(): Promise<void> {
       `Indexed state registry mismatch: got ${indexed.sourceRegistryId}, expected ${expectedSourceRegistryId}.`,
     );
   }
-  const state = replayEntry(indexed.pools[0], expectedSourceRegistryId);
-  const live = await createLiveLiquidityQuoteAdapter({
-    client: {
-      getBlockNumber: async () => BigInt(state.observedThroughBlock),
-      readContract: (request) => publicClient.readContract(request),
-    },
-    chainId: base.id,
-    blockNumber: BigInt(state.observedThroughBlock),
-  });
-  const report = await runClReplayParity({
-    indexedState: indexed,
-    liveAdapter: live,
-    currentBlock,
-    expectedSourceRegistryId,
-  });
 
-  console.log(
-    [
-      `snapshot=${report.snapshotId}`,
-      `block=${report.observedThroughBlock.toString()}`,
-      `stateHash=${report.stateHash}`,
-      `bitmapWords=${report.bitmapWordCount.toString()}`,
-      `initializedTicks=${report.initializedTickCount.toString()}`,
-    ].join(" "),
-  );
+  for (const poolId of poolIds) {
+    const state = replayEntry(
+      indexed.pools.find((pool) => "poolId" in pool && pool.poolId === poolId),
+      expectedSourceRegistryId,
+      poolId,
+    );
+    const live = await createLiveLiquidityQuoteAdapter({
+      client: {
+        getBlockNumber: async () => BigInt(state.observedThroughBlock),
+        readContract: (request) => publicClient.readContract(request),
+      },
+      chainId: base.id,
+      blockNumber: BigInt(state.observedThroughBlock),
+    });
+    const report = await runClReplayParity({
+      indexedState: indexed,
+      liveAdapter: live,
+      currentBlock,
+      expectedSourceRegistryId,
+      poolId,
+    });
 
-  for (const result of report.results) {
     console.log(
       [
-        result.label,
-        `local=${result.localAmountOut.toString()}`,
-        `live=${result.liveAmountOut.toString()}`,
-        `driftBps=${result.driftBps.toString()}`,
+        `pool=${report.poolId}`,
+        `snapshot=${report.snapshotId}`,
+        `block=${report.observedThroughBlock.toString()}`,
+        `stateHash=${report.stateHash}`,
+        `bitmapWords=${report.bitmapWordCount.toString()}`,
+        `initializedTicks=${report.initializedTickCount.toString()}`,
       ].join(" "),
     );
+
+    for (const result of report.results) {
+      console.log(
+        [
+          result.label,
+          `local=${result.localAmountOut.toString()}`,
+          `live=${result.liveAmountOut.toString()}`,
+          `driftBps=${result.driftBps.toString()}`,
+        ].join(" "),
+      );
+    }
   }
 }
 

--- a/scripts/fame-swap-cl-replay-parity.ts
+++ b/scripts/fame-swap-cl-replay-parity.ts
@@ -2,12 +2,22 @@ import { createPublicClient, http, type Address } from "viem";
 import { base } from "viem/chains";
 import { USDC, WETH } from "../src/features/fame-swap/tokens";
 import { famePoolEdgesForPair } from "../src/features/fame-swap/solver/poolUniverse";
-import { famePoolStateRegistrySourceId } from "../src/features/fame-swap/solver/poolStateRegistry";
+import {
+  FAME_V4_ZORA_REVIEWED_POOL_SHAPE,
+  famePoolStateRegistrySourceId,
+} from "../src/features/fame-swap/solver/poolStateRegistry";
 import {
   createIndexedPoolStateClient,
   type FameIndexedPoolStateBatchResponse,
   type FameIndexedPoolStateEntry,
 } from "../src/features/fame-swap/solver/quotes/indexedPoolStateClient";
+import {
+  createIndexedQuoteApiClient,
+  type FamePoolQuoteBatchResponse,
+  type FamePoolQuoteClient,
+  type FamePoolQuoteQuotedEntry,
+  type FameV4ClPoolQuoteQuotedEntry,
+} from "../src/features/fame-swap/solver/quotes/indexedQuoteApiClient";
 import { quoteFromIndexedSlipstreamReplay } from "../src/features/fame-swap/solver/quotes/indexedClReplayAdapter";
 import { createLiveLiquidityQuoteAdapter } from "../src/features/fame-swap/solver/quotes/liveAdapters";
 import type {
@@ -19,12 +29,20 @@ type ReplayEntry = Extract<
   FameIndexedPoolStateEntry,
   { stateKind: "cl-replay-v1" }
 >;
+type ParitySurface = "cl-replay-v1" | "compact-quote-v1";
 
-const POOL_ID = "slipstream-usdc-weth-100";
+const DEFAULT_POOL_ID = "slipstream-usdc-weth-100";
 export const DEFAULT_CL_REPLAY_PARITY_AMOUNTS = {
   wethToUsdc: [10n ** 14n, 10n ** 15n, 10n ** 16n],
   usdcToWeth: [1_000_000n, 10_000_000n, 100_000_000n],
 } as const;
+
+export interface FameClReplayParityTarget {
+  poolId: string;
+  tokenIn: Address;
+  tokenOut: Address;
+  amounts: readonly bigint[];
+}
 
 export interface FameClReplayParityCase {
   label: string;
@@ -36,14 +54,21 @@ export interface FameClReplayParityResult {
   localAmountOut: bigint;
   liveAmountOut: bigint;
   driftBps: bigint;
+  evidenceId?: string;
 }
 
 export interface FameClReplayParityReport {
+  surface: ParitySurface;
+  sourceRegistryId: string;
+  currentBlock: number;
   snapshotId: string;
   observedThroughBlock: number;
+  blockHash: string;
+  parentHash: string;
   stateHash: string;
-  bitmapWordCount: number;
-  initializedTickCount: number;
+  evidenceId: string;
+  bitmapWordCount?: number;
+  initializedTickCount?: number;
   results: FameClReplayParityResult[];
 }
 
@@ -61,6 +86,63 @@ function optionalIntegerEnv(name: string): number | undefined {
     throw new Error(`${name} must be a non-negative safe integer.`);
   }
   return parsed;
+}
+
+function cliValue(args: readonly string[], name: string): string | undefined {
+  const prefix = `${name}=`;
+  const inline = args.find((arg) => arg.startsWith(prefix));
+  if (inline) return inline.slice(prefix.length);
+  const index = args.indexOf(name);
+  if (index === -1) return undefined;
+  const value = args[index + 1];
+  return value && !value.startsWith("--") ? value : undefined;
+}
+
+function cliAddress(
+  args: readonly string[],
+  name: string,
+): Address | undefined {
+  const value = cliValue(args, name);
+  if (value === undefined) return undefined;
+  if (!/^0x[0-9a-fA-F]{40}$/.test(value)) {
+    throw new Error(`${name} must be an address.`);
+  }
+  return value as Address;
+}
+
+function cliAmounts(args: readonly string[]): bigint[] | undefined {
+  const rawValues = args
+    .flatMap((arg, index) => {
+      if (arg === "--amount") return [args[index + 1] ?? ""];
+      if (arg.startsWith("--amount=")) return [arg.slice("--amount=".length)];
+      return [];
+    })
+    .flatMap((value) => value.split(","))
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+  if (rawValues.length === 0) return undefined;
+  return rawValues.map((value) => {
+    if (!/^[1-9][0-9]*$/.test(value)) {
+      throw new Error("--amount values must be positive integer decimals.");
+    }
+    return BigInt(value);
+  });
+}
+
+function parityTargetsFromCliArgs(
+  args: readonly string[],
+): FameClReplayParityTarget[] | undefined {
+  const poolId = cliValue(args, "--pool");
+  const tokenIn = cliAddress(args, "--token-in");
+  const tokenOut = cliAddress(args, "--token-out");
+  const amounts = cliAmounts(args);
+  if (!poolId && !tokenIn && !tokenOut && !amounts) return undefined;
+  if (!poolId || !tokenIn || !tokenOut || !amounts) {
+    throw new Error(
+      "Targeted parity requires --pool, --token-in, --token-out, and --amount.",
+    );
+  }
+  return [{ poolId, tokenIn, tokenOut, amounts }];
 }
 
 function localOrTestPoolApiBase(url: URL): boolean {
@@ -111,6 +193,15 @@ export function poolStateEndpointUrlFromEnv(): string {
   return url.toString();
 }
 
+export function poolQuoteEndpointUrlFromEnv(): string {
+  const url = poolApiBaseUrlFromEnv();
+  const basePath = url.pathname.replace(/\/+$/u, "");
+  url.pathname = `${basePath}/fame/pool-quotes`;
+  url.search = "";
+  url.hash = "";
+  return url.toString();
+}
+
 export function displaySafeErrorMessage(error: unknown): string {
   const raw = error instanceof Error ? error.message : String(error);
   return (
@@ -130,17 +221,22 @@ export function displaySafeErrorMessage(error: unknown): string {
     .replace(/0x[a-fA-F0-9]{64,}/g, "[redacted-hex]");
 }
 
-function edge(tokenIn: Address, tokenOut: Address) {
+function edge(poolId: string, tokenIn: Address, tokenOut: Address) {
   const found = famePoolEdgesForPair(tokenIn, tokenOut).find(
-    (candidate) => candidate.poolId === POOL_ID,
+    (candidate) => candidate.poolId === poolId,
   );
-  if (!found) throw new Error(`Missing ${POOL_ID} edge.`);
+  if (!found) {
+    throw new Error(
+      `Missing ${poolId} edge for ${tokenIn.toLowerCase()} -> ${tokenOut.toLowerCase()}.`,
+    );
+  }
   return found;
 }
 
 function replayEntry(
   entry: FameIndexedPoolStateEntry | undefined,
   expectedSourceRegistryId: string,
+  poolId: string,
 ): ReplayEntry {
   if (
     !entry ||
@@ -148,11 +244,11 @@ function replayEntry(
     !("stateKind" in entry) ||
     entry.stateKind !== "cl-replay-v1"
   ) {
-    throw new Error(`${POOL_ID} did not return fresh cl-replay-v1 state.`);
+    throw new Error(`${poolId} did not return fresh cl-replay-v1 state.`);
   }
   if (entry.sourceRegistryId !== expectedSourceRegistryId) {
     throw new Error(
-      `${POOL_ID} returned cl-replay-v1 state for registry ${entry.sourceRegistryId}, expected ${expectedSourceRegistryId}.`,
+      `${poolId} returned cl-replay-v1 state for registry ${entry.sourceRegistryId}, expected ${expectedSourceRegistryId}.`,
     );
   }
   return entry;
@@ -165,17 +261,206 @@ function parityBps(left: bigint, right: bigint): bigint {
   return (delta * 10_000n) / bigger;
 }
 
-function defaultParityCases(): FameClReplayParityCase[] {
+function defaultParityTargets(): FameClReplayParityTarget[] {
   return [
-    ...DEFAULT_CL_REPLAY_PARITY_AMOUNTS.wethToUsdc.map((amountIn) => ({
-      label: `WETH->USDC ${amountIn.toString()}`,
-      request: { edge: edge(WETH, USDC), amountIn },
-    })),
-    ...DEFAULT_CL_REPLAY_PARITY_AMOUNTS.usdcToWeth.map((amountIn) => ({
-      label: `USDC->WETH ${amountIn.toString()}`,
-      request: { edge: edge(USDC, WETH), amountIn },
-    })),
+    {
+      poolId: DEFAULT_POOL_ID,
+      tokenIn: WETH,
+      tokenOut: USDC,
+      amounts: DEFAULT_CL_REPLAY_PARITY_AMOUNTS.wethToUsdc,
+    },
+    {
+      poolId: DEFAULT_POOL_ID,
+      tokenIn: USDC,
+      tokenOut: WETH,
+      amounts: DEFAULT_CL_REPLAY_PARITY_AMOUNTS.usdcToWeth,
+    },
   ];
+}
+
+export function buildClReplayParityCases(
+  targets: readonly FameClReplayParityTarget[] = defaultParityTargets(),
+): FameClReplayParityCase[] {
+  return targets.flatMap((target) =>
+    target.amounts.map((amountIn) => ({
+      label: `${target.poolId} ${target.tokenIn.toLowerCase()}->${target.tokenOut.toLowerCase()} ${amountIn.toString()}`,
+      request: {
+        edge: edge(target.poolId, target.tokenIn, target.tokenOut),
+        amountIn,
+      },
+    })),
+  );
+}
+
+function paritySurfaceForCases(
+  cases: readonly FameClReplayParityCase[],
+): ParitySurface {
+  const surfaces = new Set<ParitySurface>();
+  for (const item of cases) {
+    if (item.request.edge.poolId === FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId) {
+      surfaces.add("compact-quote-v1");
+      continue;
+    }
+    if (item.request.edge.pool.venue === "aerodrome-slipstream") {
+      surfaces.add("cl-replay-v1");
+      continue;
+    }
+    throw new Error(
+      `${item.request.edge.poolId} is not supported by the parity harness.`,
+    );
+  }
+  if (surfaces.size !== 1) {
+    throw new Error("FAME parity cases must target one quote surface.");
+  }
+  const [surface] = surfaces;
+  if (!surface) throw new Error("FAME parity requires at least one case.");
+  return surface;
+}
+
+function compactQuoteEvidenceId(quote: FamePoolQuoteQuotedEntry): string {
+  if (quote.quoteKind === "cl-quote-v1") return quote.snapshotId;
+  return `${quote.poolId}:${quote.observedThroughBlock.toString()}`;
+}
+
+function compactQuoteRowsForCases(options: {
+  quoteResponse: FamePoolQuoteBatchResponse;
+  cases: readonly FameClReplayParityCase[];
+  currentBlock: number;
+  expectedSourceRegistryId: string;
+  maxFreshnessBlocks?: number;
+}): FameV4ClPoolQuoteQuotedEntry[] {
+  const {
+    quoteResponse,
+    cases,
+    currentBlock,
+    expectedSourceRegistryId,
+    maxFreshnessBlocks,
+  } = options;
+  if (quoteResponse.sourceRegistryId !== expectedSourceRegistryId) {
+    throw new Error(
+      `Compact quote registry mismatch: got ${quoteResponse.sourceRegistryId}, expected ${expectedSourceRegistryId}.`,
+    );
+  }
+  if (quoteResponse.currentBlock !== currentBlock) {
+    throw new Error(
+      `Compact quote current block mismatch: got ${quoteResponse.currentBlock.toString()}, expected ${currentBlock.toString()}.`,
+    );
+  }
+
+  return cases.map((item) => {
+    const rows = quoteResponse.quotes.filter(
+      (quote): quote is FamePoolQuoteQuotedEntry =>
+        quote.status === "quoted" &&
+        quote.poolId === item.request.edge.poolId &&
+        quote.tokenIn.toLowerCase() ===
+          item.request.edge.tokenIn.toLowerCase() &&
+        quote.tokenOut.toLowerCase() ===
+          item.request.edge.tokenOut.toLowerCase() &&
+        quote.amountIn === item.request.amountIn.toString(),
+    );
+    if (rows.length !== 1) {
+      throw new Error(
+        `${item.label} expected exactly one compact quote row, got ${rows.length.toString()}.`,
+      );
+    }
+    const row = rows[0]!;
+    if (item.request.edge.poolId === FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId) {
+      if (
+        row.quoteKind !== "cl-quote-v1" ||
+        row.source !== "uniswap-v4-state-view"
+      ) {
+        throw new Error(
+          `${item.label} did not return a V4 compact CL quote row.`,
+        );
+      }
+      if (
+        row.poolKey.toLowerCase() !==
+          FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolKey.toLowerCase() ||
+        row.hookData.toLowerCase() !==
+          FAME_V4_ZORA_REVIEWED_POOL_SHAPE.hookData.toLowerCase()
+      ) {
+        throw new Error(
+          `${item.label} did not return the reviewed V4 row shape.`,
+        );
+      }
+      const v4Row: FameV4ClPoolQuoteQuotedEntry = row;
+      if (v4Row.observedThroughBlock > currentBlock) {
+        throw new Error(`${item.label} compact quote is from a future block.`);
+      }
+      const effectiveFreshness = Math.min(
+        v4Row.maxFreshnessBlocks,
+        quoteResponse.effectiveMaxFreshnessBlocks,
+        maxFreshnessBlocks ?? Number.MAX_SAFE_INTEGER,
+      );
+      if (currentBlock - v4Row.observedThroughBlock > effectiveFreshness) {
+        throw new Error(`${item.label} compact quote is stale.`);
+      }
+      return v4Row;
+    }
+    throw new Error(
+      `${item.request.edge.poolId} is not supported by compact quote parity.`,
+    );
+  });
+}
+
+export async function runCompactQuoteParity(options: {
+  quoteResponse: FamePoolQuoteBatchResponse;
+  liveAdapter: FameAsyncQuoteAdapter;
+  currentBlock: number;
+  cases: readonly FameClReplayParityCase[];
+  expectedSourceRegistryId?: string;
+  maxFreshnessBlocks?: number;
+}): Promise<FameClReplayParityReport> {
+  const expectedSourceRegistryId =
+    options.expectedSourceRegistryId ?? options.quoteResponse.sourceRegistryId;
+  const rows = compactQuoteRowsForCases({
+    quoteResponse: options.quoteResponse,
+    cases: options.cases,
+    currentBlock: options.currentBlock,
+    expectedSourceRegistryId,
+    maxFreshnessBlocks: options.maxFreshnessBlocks,
+  });
+  const observedBlocks = new Set(rows.map((row) => row.observedThroughBlock));
+  if (observedBlocks.size !== 1) {
+    throw new Error("Compact quote parity requires one observed block.");
+  }
+
+  const results: FameClReplayParityResult[] = [];
+  for (let index = 0; index < options.cases.length; index += 1) {
+    const item = options.cases[index]!;
+    const row = rows[index]!;
+    const liveQuote = await options.liveAdapter.quoteEdge(item.request);
+    if (liveQuote.status !== "quoted") {
+      throw new Error(`${item.label} failed: live=${liveQuote.status}`);
+    }
+    const localAmountOut = BigInt(row.amountOut);
+    const driftBps = parityBps(localAmountOut, liveQuote.amountOut);
+    const evidenceId = compactQuoteEvidenceId(row);
+    results.push({
+      label: item.label,
+      localAmountOut,
+      liveAmountOut: liveQuote.amountOut,
+      driftBps,
+      evidenceId,
+    });
+    if (localAmountOut !== liveQuote.amountOut) {
+      throw new Error(`${item.label} failed exact compact quote parity.`);
+    }
+  }
+
+  const first = rows[0]!;
+  return {
+    surface: "compact-quote-v1",
+    sourceRegistryId: options.quoteResponse.sourceRegistryId,
+    currentBlock: options.currentBlock,
+    snapshotId: first.snapshotId,
+    observedThroughBlock: first.observedThroughBlock,
+    blockHash: first.blockHash,
+    parentHash: first.parentHash,
+    stateHash: first.stateHash,
+    evidenceId: compactQuoteEvidenceId(first),
+    results,
+  };
 }
 
 export async function runClReplayParity(options: {
@@ -183,18 +468,33 @@ export async function runClReplayParity(options: {
   liveAdapter: FameAsyncQuoteAdapter;
   currentBlock: number;
   cases?: readonly FameClReplayParityCase[];
+  poolId?: string;
   expectedSourceRegistryId?: string;
 }): Promise<FameClReplayParityReport> {
+  const poolId =
+    options.poolId ??
+    options.cases?.[0]?.request.edge.poolId ??
+    DEFAULT_POOL_ID;
+  const cases = options.cases ?? buildClReplayParityCases();
+  if (cases.some((item) => item.request.edge.poolId !== poolId) === true) {
+    throw new Error("FAME CL replay parity cases must target one pool id.");
+  }
+  if (paritySurfaceForCases(cases) !== "cl-replay-v1") {
+    throw new Error(
+      "runClReplayParity only supports cl-replay-v1 cases; use compact quote parity for V4 targets.",
+    );
+  }
   const expectedSourceRegistryId =
     options.expectedSourceRegistryId ?? options.indexedState.sourceRegistryId;
   const state = replayEntry(
     options.indexedState.pools.find(
-      (pool) => "poolId" in pool && pool.poolId === POOL_ID,
+      (pool) => "poolId" in pool && pool.poolId === poolId,
     ),
     expectedSourceRegistryId,
+    poolId,
   );
   const results: FameClReplayParityResult[] = [];
-  for (const item of options.cases ?? defaultParityCases()) {
+  for (const item of cases) {
     const context = {
       source: "indexed" as const,
       chainId: base.id,
@@ -233,15 +533,22 @@ export async function runClReplayParity(options: {
       localAmountOut: local.amountOut,
       liveAmountOut: liveQuote.amountOut,
       driftBps,
+      evidenceId: state.snapshotId,
     });
     if (local.amountOut !== liveQuote.amountOut) {
       throw new Error(`${item.label} failed exact parity.`);
     }
   }
   return {
+    surface: "cl-replay-v1",
+    sourceRegistryId: options.indexedState.sourceRegistryId,
+    currentBlock: options.currentBlock,
     snapshotId: state.snapshotId,
     observedThroughBlock: state.observedThroughBlock,
+    blockHash: state.blockHash,
+    parentHash: state.parentHash,
     stateHash: state.stateHash,
+    evidenceId: state.snapshotId,
     bitmapWordCount: state.bitmapWordCount,
     initializedTickCount: state.initializedTickCount,
     results,
@@ -249,12 +556,14 @@ export async function runClReplayParity(options: {
 }
 
 async function main(): Promise<void> {
+  const targets = parityTargetsFromCliArgs(process.argv.slice(2));
+  const cases = buildClReplayParityCases(targets);
+  const poolIds = [...new Set(cases.map((item) => item.request.edge.poolId))];
+  if (poolIds.length !== 1) {
+    throw new Error("FAME CL replay parity CLI targets must resolve to one pool.");
+  }
+  const surface = paritySurfaceForCases(cases);
   const rpcUrl = env("BASE_RPC_URL");
-  const helper = createIndexedPoolStateClient({
-    endpointUrl: poolStateEndpointUrlFromEnv(),
-    serviceToken: env("FAME_POOL_STATE_SERVICE_TOKEN"),
-    timeoutMs: optionalIntegerEnv("FAME_POOL_STATE_TIMEOUT_MS"),
-  });
   const publicClient = createPublicClient({
     chain: base,
     transport: http(rpcUrl, {
@@ -266,44 +575,123 @@ async function main(): Promise<void> {
   if (!Number.isSafeInteger(currentBlock)) {
     throw new Error("Current Base block exceeds Number.MAX_SAFE_INTEGER.");
   }
-  const indexed = await helper.fetchPoolStates({
-    currentBlock,
-    maxFreshnessBlocks: optionalIntegerEnv(
-      "FAME_POOL_STATE_MAX_FRESHNESS_BLOCKS",
-    ),
-    stateSurfaces: ["cl-replay-v1"],
-    poolIds: [POOL_ID],
-  });
   const expectedSourceRegistryId = famePoolStateRegistrySourceId();
-  if (indexed.sourceRegistryId !== expectedSourceRegistryId) {
-    throw new Error(
-      `Indexed state registry mismatch: got ${indexed.sourceRegistryId}, expected ${expectedSourceRegistryId}.`,
+  let report: FameClReplayParityReport;
+
+  if (surface === "compact-quote-v1") {
+    const maxFreshnessBlocks = optionalIntegerEnv(
+      "FAME_POOL_QUOTE_MAX_FRESHNESS_BLOCKS",
     );
+    const quoteClient: FamePoolQuoteClient = createIndexedQuoteApiClient({
+      endpointUrl: poolQuoteEndpointUrlFromEnv(),
+      serviceToken: env("FAME_POOL_STATE_SERVICE_TOKEN"),
+      timeoutMs: optionalIntegerEnv("FAME_POOL_QUOTE_TIMEOUT_MS"),
+    });
+    const quoteResponse = await quoteClient.fetchQuotes({
+      currentBlock,
+      maxFreshnessBlocks,
+      quotes: cases.map((item) => ({
+        poolId: item.request.edge.poolId,
+        tokenIn: item.request.edge.tokenIn,
+        tokenOut: item.request.edge.tokenOut,
+        amountIn: item.request.amountIn.toString(),
+      })),
+    });
+    const rows = compactQuoteRowsForCases({
+      quoteResponse,
+      cases,
+      currentBlock,
+      expectedSourceRegistryId,
+      maxFreshnessBlocks,
+    });
+    const observedBlocks = [
+      ...new Set(rows.map((row) => row.observedThroughBlock)),
+    ];
+    if (observedBlocks.length !== 1) {
+      throw new Error("Compact quote parity requires one observed block.");
+    }
+    const [observedThroughBlock] = observedBlocks;
+    if (observedThroughBlock === undefined) {
+      throw new Error("Compact quote parity returned no quoted rows.");
+    }
+    const live = await createLiveLiquidityQuoteAdapter({
+      client: {
+        getBlockNumber: async () => BigInt(observedThroughBlock),
+        readContract: (request) => publicClient.readContract(request),
+      },
+      chainId: base.id,
+      blockNumber: BigInt(observedThroughBlock),
+    });
+    report = await runCompactQuoteParity({
+      quoteResponse,
+      liveAdapter: live,
+      currentBlock,
+      cases,
+      expectedSourceRegistryId,
+      maxFreshnessBlocks,
+    });
+  } else {
+    const helper = createIndexedPoolStateClient({
+      endpointUrl: poolStateEndpointUrlFromEnv(),
+      serviceToken: env("FAME_POOL_STATE_SERVICE_TOKEN"),
+      timeoutMs: optionalIntegerEnv("FAME_POOL_STATE_TIMEOUT_MS"),
+    });
+    const indexed = await helper.fetchPoolStates({
+      currentBlock,
+      maxFreshnessBlocks: optionalIntegerEnv(
+        "FAME_POOL_STATE_MAX_FRESHNESS_BLOCKS",
+      ),
+      stateSurfaces: ["cl-replay-v1"],
+      poolIds,
+    });
+    if (indexed.sourceRegistryId !== expectedSourceRegistryId) {
+      throw new Error(
+        `Indexed state registry mismatch: got ${indexed.sourceRegistryId}, expected ${expectedSourceRegistryId}.`,
+      );
+    }
+    const state = replayEntry(
+      indexed.pools[0],
+      expectedSourceRegistryId,
+      poolIds[0],
+    );
+    const live = await createLiveLiquidityQuoteAdapter({
+      client: {
+        getBlockNumber: async () => BigInt(state.observedThroughBlock),
+        readContract: (request) => publicClient.readContract(request),
+      },
+      chainId: base.id,
+      blockNumber: BigInt(state.observedThroughBlock),
+    });
+    report = await runClReplayParity({
+      indexedState: indexed,
+      liveAdapter: live,
+      currentBlock,
+      cases,
+      poolId: poolIds[0],
+      expectedSourceRegistryId,
+    });
   }
-  const state = replayEntry(indexed.pools[0], expectedSourceRegistryId);
-  const live = await createLiveLiquidityQuoteAdapter({
-    client: {
-      getBlockNumber: async () => BigInt(state.observedThroughBlock),
-      readContract: (request) => publicClient.readContract(request),
-    },
-    chainId: base.id,
-    blockNumber: BigInt(state.observedThroughBlock),
-  });
-  const report = await runClReplayParity({
-    indexedState: indexed,
-    liveAdapter: live,
-    currentBlock,
-    expectedSourceRegistryId,
-  });
 
   console.log(
     [
+      `surface=${report.surface}`,
+      `registry=${report.sourceRegistryId}`,
       `snapshot=${report.snapshotId}`,
+      `currentBlock=${report.currentBlock.toString()}`,
       `block=${report.observedThroughBlock.toString()}`,
+      `blockHash=${report.blockHash}`,
+      `parentHash=${report.parentHash}`,
       `stateHash=${report.stateHash}`,
-      `bitmapWords=${report.bitmapWordCount.toString()}`,
-      `initializedTicks=${report.initializedTickCount.toString()}`,
-    ].join(" "),
+      `evidence=${report.evidenceId}`,
+      report.bitmapWordCount === undefined
+        ? null
+        : `bitmapWords=${report.bitmapWordCount.toString()}`,
+      report.initializedTickCount === undefined
+        ? null
+        : `initializedTicks=${report.initializedTickCount.toString()}`,
+    ]
+      .filter((part): part is string => part !== null)
+      .join(" "),
   );
 
   for (const result of report.results) {

--- a/scripts/fame-swap-cl-replay-parity.ts
+++ b/scripts/fame-swap-cl-replay-parity.ts
@@ -3,7 +3,7 @@ import { base } from "viem/chains";
 import { FAME, USDC, WETH } from "../src/features/fame-swap/tokens";
 import { famePoolEdgesForPair } from "../src/features/fame-swap/solver/poolUniverse";
 import {
-  FAME_V4_ZORA_REVIEWED_POOL_SHAPE,
+  fameV4ZoraReviewedPoolManifestForPool,
   famePoolStateRegistrySourceId,
 } from "../src/features/fame-swap/solver/poolStateRegistry";
 import {
@@ -310,7 +310,7 @@ function paritySurfaceForCases(
 ): ParitySurface {
   const surfaces = new Set<ParitySurface>();
   for (const item of cases) {
-    if (item.request.edge.poolId === FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId) {
+    if (fameV4ZoraReviewedPoolManifestForPool(item.request.edge.poolId)) {
       surfaces.add("compact-quote-v1");
       continue;
     }
@@ -361,6 +361,9 @@ function compactQuoteRowsForCases(options: {
   }
 
   return cases.map((item) => {
+    const manifest = fameV4ZoraReviewedPoolManifestForPool(
+      item.request.edge.poolId,
+    );
     const rows = quoteResponse.quotes.filter(
       (quote): quote is FamePoolQuoteQuotedEntry =>
         quote.status === "quoted" &&
@@ -377,7 +380,8 @@ function compactQuoteRowsForCases(options: {
       );
     }
     const row = rows[0]!;
-    if (item.request.edge.poolId === FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId) {
+    if (manifest) {
+      const reviewed = manifest.reviewedPoolShape;
       if (
         row.quoteKind !== "cl-quote-v1" ||
         row.source !== "uniswap-v4-state-view"
@@ -387,10 +391,14 @@ function compactQuoteRowsForCases(options: {
         );
       }
       if (
-        row.poolKey.toLowerCase() !==
-          FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolKey.toLowerCase() ||
-        row.hookData.toLowerCase() !==
-          FAME_V4_ZORA_REVIEWED_POOL_SHAPE.hookData.toLowerCase()
+        row.poolKey.toLowerCase() !== reviewed.poolKey.toLowerCase() ||
+        row.hookData.toLowerCase() !== reviewed.hookData.toLowerCase() ||
+        row.reviewedPoolEvidence.manifestVersion !== manifest.version ||
+        row.reviewedPoolEvidence.poolId !== reviewed.poolId ||
+        row.reviewedPoolEvidence.kind !==
+          (manifest.provenanceRequired
+            ? "zora-protocol-pool"
+            : "zero-hook-static-fee")
       ) {
         throw new Error(
           `${item.label} did not return the reviewed V4 row shape.`,

--- a/scripts/fame-swap-pool-activation-report.test.ts
+++ b/scripts/fame-swap-pool-activation-report.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { formatFamePoolActivationReportJson } from "./fame-swap-pool-activation-report";
+
+describe("FAME pool activation report script", () => {
+  it("formats the activation report as reviewable JSON", () => {
+    const parsed = JSON.parse(formatFamePoolActivationReportJson()) as {
+      status?: string;
+      upstreamPoolCount?: number;
+      upstreamPools?: unknown[];
+      producerOnlyPools?: unknown[];
+    };
+
+    assert.equal(parsed.status, "generated-reviewed-activation");
+    assert.equal(parsed.upstreamPoolCount, 26);
+    assert.equal(parsed.upstreamPools?.length, 26);
+    assert.ok((parsed.producerOnlyPools?.length ?? 0) > 0);
+  });
+});

--- a/scripts/fame-swap-pool-activation-report.ts
+++ b/scripts/fame-swap-pool-activation-report.ts
@@ -1,0 +1,15 @@
+import { famePoolActivationReport } from "../src/features/fame-swap/solver/poolActivation";
+
+export function formatFamePoolActivationReportJson(): string {
+  return `${JSON.stringify(famePoolActivationReport(), null, 2)}\n`;
+}
+
+function shouldRunCli(): boolean {
+  return (
+    process.argv[1]?.endsWith("fame-swap-pool-activation-report.ts") ?? false
+  );
+}
+
+if (shouldRunCli()) {
+  process.stdout.write(formatFamePoolActivationReportJson());
+}

--- a/scripts/fame-swap-route-lab.test.ts
+++ b/scripts/fame-swap-route-lab.test.ts
@@ -170,6 +170,18 @@ function quoteApiResponseForRequest(
             hookAddress: reviewed.hooks,
             hookData: reviewed.hookData,
             hookDataStatus: "empty" as const,
+            reviewedPoolEvidence: {
+              status: "verified" as const,
+              source: "reviewed-v4-manifest" as const,
+              kind: "zora-protocol-pool" as const,
+              manifestVersion: 1,
+              poolId: reviewed.poolId,
+              poolKey: reviewed.poolKey,
+              staticFee: reviewed.fee.toString(),
+              hookAddress: reviewed.hooks,
+              hookData: reviewed.hookData,
+              protocolFeeStatus: "zero" as const,
+            },
             zoraProvenance: {
               status: "verified" as const,
               source: "zora-factory-event" as const,

--- a/scripts/fame-swap-route-lab.test.ts
+++ b/scripts/fame-swap-route-lab.test.ts
@@ -372,6 +372,59 @@ describe("FAME route lab", () => {
     );
   });
 
+  it("uses a fresh quote deadline for simulated quote-api route lab runs", async () => {
+    const routeId = "solver-fame-basedflick-zora-usdc";
+    const corpus = filterRouteLabCorpus(FAME_ROUTE_CORPUS, { routeId });
+    const targetFilter = {
+      routeId,
+      poolId: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId,
+      tokenIn: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.currency1,
+      tokenOut: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.currency0,
+    };
+    const quoteClient = {
+      async fetchQuotes(request: FamePoolQuoteBatchRequest) {
+        return quoteApiResponseForRequest(request);
+      },
+    };
+    const previousBaseRpcUrl = process.env.BASE_RPC_URL;
+    const previousPublicBaseRpcUrl = process.env.NEXT_PUBLIC_BASE_RPC_URL_1;
+    delete process.env.BASE_RPC_URL;
+    delete process.env.NEXT_PUBLIC_BASE_RPC_URL_1;
+
+    try {
+      const fixedRows = await runQuoteApiRouteLab(corpus, {
+        currentBlock: 125,
+        maxFreshnessBlocks: 120,
+        fallbackAdapter: createSnapshotQuoteAdapter(),
+        targetFilter,
+        quoteClient,
+      });
+      const simulatedRows = await runQuoteApiRouteLab(corpus, {
+        currentBlock: 125,
+        maxFreshnessBlocks: 120,
+        fallbackAdapter: createSnapshotQuoteAdapter(),
+        targetFilter,
+        quoteClient,
+        simulate: true,
+        now: new Date("2026-06-06T01:12:00Z"),
+      });
+
+      assert.notEqual(
+        simulatedRows[0]?.materializedRouteHash,
+        fixedRows[0]?.materializedRouteHash,
+      );
+      assert.equal(simulatedRows[0]?.simulation.status, "not_requested");
+    } finally {
+      if (previousBaseRpcUrl === undefined) delete process.env.BASE_RPC_URL;
+      else process.env.BASE_RPC_URL = previousBaseRpcUrl;
+      if (previousPublicBaseRpcUrl === undefined) {
+        delete process.env.NEXT_PUBLIC_BASE_RPC_URL_1;
+      } else {
+        process.env.NEXT_PUBLIC_BASE_RPC_URL_1 = previousPublicBaseRpcUrl;
+      }
+    }
+  });
+
   it("replays the full recorded-state corpus with executable quote evidence", async () => {
     const rows = await runSnapshotRouteLab();
 

--- a/scripts/fame-swap-route-lab.test.ts
+++ b/scripts/fame-swap-route-lab.test.ts
@@ -8,9 +8,105 @@ import {
   runSnapshotRouteLab,
   type FameRouteLabRow,
 } from "./fame-swap-route-lab";
+import type { FameEdgeQuoteRequest } from "../src/features/fame-swap/solver/quotes/adapters";
+import type { FameIndexedClReplayFreshEntry } from "../src/features/fame-swap/solver/quotes/indexedPoolStateClient";
 import { famePoolStateRegistrySourceId } from "../src/features/fame-swap/solver/poolStateRegistry";
 import { FAME_ROUTE_CORPUS } from "../src/features/fame-swap/solver/routeCorpus";
 import { FAME, USDC, WETH } from "../src/features/fame-swap/tokens";
+import { createSnapshotQuoteAdapter } from "../src/features/fame-swap/solver/quotes/snapshotAdapter";
+import { createDeterministicQuoteAdapter } from "../src/features/fame-swap/solver/quotes/deterministicAdapter";
+
+const BASEDFLICK = "0x15e012abf9d32cd67fc6cf480ea0e318e9ed5926" as const;
+
+function liveDeterministicFallbackAdapter() {
+  const deterministic = createDeterministicQuoteAdapter();
+  const context = {
+    source: "live" as const,
+    chainId: 8453,
+    blockNumber: 125n,
+  };
+  return {
+    quoteContext: context,
+    async quoteEdge(request: FameEdgeQuoteRequest) {
+      const quote = deterministic.quoteEdge(request);
+      return quote.status === "quoted" ? { ...quote, context } : quote;
+    },
+  };
+}
+
+function deterministicFallbackAdapter() {
+  const deterministic = createDeterministicQuoteAdapter();
+  return {
+    quoteContext: deterministic.quoteContext,
+    async quoteEdge(request: FameEdgeQuoteRequest) {
+      return deterministic.quoteEdge(request);
+    },
+  };
+}
+
+function selectedRawReplayPoolState(
+  poolId: string,
+): FameIndexedClReplayFreshEntry {
+  return {
+    status: "fresh" as const,
+    stateKind: "cl-replay-v1" as const,
+    poolId,
+    chainId: 8453,
+    poolAddress: "0xbd7e5bb5a6251f6dde2cf56afa50ed0c8b4c2cdb",
+    token0: BASEDFLICK,
+    token1: FAME,
+    venueFamily: "Slipstream" as const,
+    tickSpacing: 2000,
+    sqrtPriceX96: "14225627699858779769529171968",
+    tick: -34350,
+    liquidity: "1000000000000000000000000000000",
+    fee: "10000",
+    feeSource: "pool-fee" as const,
+    observedThroughBlock: 124,
+    blockHash:
+      "0x1111111111111111111111111111111111111111111111111111111111111111",
+    parentHash:
+      "0x2222222222222222222222222222222222222222222222222222222222222222",
+    snapshotId: "unit-selected-candidate",
+    stateHash:
+      "0x3333333333333333333333333333333333333333333333333333333333333333",
+    source: "slipstream-pool-state" as const,
+    sourceRegistryId: famePoolStateRegistrySourceId(),
+    maxFreshnessBlocks: 120,
+    bitmapWordCount: 2,
+    initializedTickCount: 2,
+    bitmapChunkCount: 1,
+    tickChunkCount: 1,
+    minWordPosition: -10,
+    maxWordPosition: 0,
+    minTick: -40000,
+    maxTick: 0,
+    bitmapWords: [
+      {
+        wordPosition: -10,
+        bitmap:
+          "0x0000000000000000000000000000000000000000000000000000000000000010",
+      },
+      {
+        wordPosition: 0,
+        bitmap:
+          "0x0000000000000000000000000000000000000000000000000000000000000001",
+      },
+    ],
+    initializedTicks: [
+      {
+        tick: -40000,
+        liquidityGross: "1000",
+        liquidityNet: "-1000",
+      },
+      {
+        tick: 0,
+        liquidityGross: "1000",
+        liquidityNet: "1000",
+      },
+    ],
+  };
+}
 
 describe("FAME route lab", () => {
   it("derives the raw pool-state proof endpoint from FAME_POOL_API_URL", () => {
@@ -339,6 +435,185 @@ describe("FAME route lab", () => {
     );
   });
 
+  it("identifies the selected raw replay leg and its V4 dependency as live", async () => {
+    const entry = FAME_ROUTE_CORPUS.find(
+      (candidate) => candidate.id === "fame-weth-fixture",
+    );
+    assert.ok(entry);
+    const requestedPoolIds: string[][] = [];
+    const rows = await runIndexedRouteLab([entry], {
+      currentBlock: 125,
+      requestedRouteId: "solver-fame-basedflick-zora-weth",
+      fallbackAdapter: liveDeterministicFallbackAdapter(),
+      poolStateClient: {
+        async fetchPoolStates(request) {
+          requestedPoolIds.push([...request.poolIds]);
+          return {
+            sourceRegistryId: famePoolStateRegistrySourceId(),
+            currentBlock: request.currentBlock,
+            producerMaxFreshnessBlocks: 120,
+            effectiveMaxFreshnessBlocks: 120,
+            pools: request.poolIds.map((poolId) =>
+              poolId === "slipstream-basedflick-fame"
+                ? {
+                    status: "fresh" as const,
+                    stateKind: "cl-replay-v1" as const,
+                    poolId,
+                    chainId: 8453,
+                    poolAddress: "0xbd7e5bb5a6251f6dde2cf56afa50ed0c8b4c2cdb",
+                    token0: BASEDFLICK,
+                    token1: FAME,
+                    venueFamily: "Slipstream" as const,
+                    tickSpacing: 2000,
+                    sqrtPriceX96: "14225627699858779769529171968",
+                    tick: -34350,
+                    liquidity: "1000000000000000000000000000000",
+                    fee: "10000",
+                    feeSource: "pool-fee" as const,
+                    observedThroughBlock: 124,
+                    blockHash:
+                      "0x1111111111111111111111111111111111111111111111111111111111111111",
+                    parentHash:
+                      "0x2222222222222222222222222222222222222222222222222222222222222222",
+                    snapshotId: "unit-selected-candidate",
+                    stateHash:
+                      "0x3333333333333333333333333333333333333333333333333333333333333333",
+                    source: "slipstream-pool-state" as const,
+                    sourceRegistryId: famePoolStateRegistrySourceId(),
+                    maxFreshnessBlocks: 120,
+                    bitmapWordCount: 2,
+                    initializedTickCount: 2,
+                    bitmapChunkCount: 1,
+                    tickChunkCount: 1,
+                    minWordPosition: -10,
+                    maxWordPosition: 0,
+                    minTick: -40000,
+                    maxTick: 0,
+                    bitmapWords: [
+                      {
+                        wordPosition: -10,
+                        bitmap:
+                          "0x0000000000000000000000000000000000000000000000000000000000000010",
+                      },
+                      {
+                        wordPosition: 0,
+                        bitmap:
+                          "0x0000000000000000000000000000000000000000000000000000000000000001",
+                      },
+                    ],
+                    initializedTicks: [
+                      {
+                        tick: -40000,
+                        liquidityGross: "1000",
+                        liquidityNet: "-1000",
+                      },
+                      {
+                        tick: 0,
+                        liquidityGross: "1000",
+                        liquidityNet: "1000",
+                      },
+                    ],
+                  }
+                : {
+                    status: "unknown" as const,
+                    requested: { poolId },
+                    reason: "unit-test",
+                  },
+            ),
+          };
+        },
+      },
+    });
+    const row = rows[0];
+    assert.ok(row);
+
+    assert.deepEqual(requestedPoolIds[0], ["slipstream-basedflick-fame"]);
+    assert.equal(row.status, "ready");
+    assert.ok(row.selectedPools.includes("slipstream-basedflick-fame"));
+    assert.ok(row.selectedPools.includes("uniswap-v4-basedflick-zora"));
+    const selectedSource = row.selectedQuoteSources.find(
+      (source) => source.poolId === "slipstream-basedflick-fame",
+    );
+    assert.equal(selectedSource?.source, "raw-replay-indexed");
+    assert.equal(selectedSource?.amountIn, "31597600141347829");
+    assert.equal(
+      row.selectedQuoteSources.find(
+        (source) => source.poolId === "uniswap-v4-basedflick-zora",
+      )?.source,
+      "live",
+    );
+    assert.equal(
+      row.selectedActivation?.outcome,
+      "raw_replay_with_live_dependency",
+    );
+    assert.equal(row.requestedRouteId, "solver-fame-basedflick-zora-weth");
+    assert.equal(row.routeArtifactId, "solver-fame-basedflick-zora-weth");
+
+    const markdown = formatRouteLabMarkdown(rows);
+    assert.match(markdown, /slipstream-basedflick-fame raw-replay-indexed/);
+    assert.match(markdown, /uniswap-v4-basedflick-zora live/);
+  });
+
+  it("keeps raw replay activation outcome distinct without a live dependency", async () => {
+    const entry = FAME_ROUTE_CORPUS.find(
+      (candidate) => candidate.id === "fame-weth-fixture",
+    );
+    assert.ok(entry);
+    const rows = await runIndexedRouteLab([entry], {
+      currentBlock: 125,
+      requestedRouteId: "solver-fame-basedflick-zora-weth",
+      fallbackAdapter: deterministicFallbackAdapter(),
+      poolStateClient: {
+        async fetchPoolStates(request) {
+          return {
+            sourceRegistryId: famePoolStateRegistrySourceId(),
+            currentBlock: request.currentBlock,
+            producerMaxFreshnessBlocks: 120,
+            effectiveMaxFreshnessBlocks: 120,
+            pools: request.poolIds.map((poolId) =>
+              poolId === "slipstream-basedflick-fame"
+                ? selectedRawReplayPoolState(poolId)
+                : {
+                    status: "unknown" as const,
+                    requested: { poolId },
+                    reason: "unit-test",
+                  },
+            ),
+          };
+        },
+      },
+    });
+    const row = rows[0];
+    assert.ok(row);
+
+    assert.equal(
+      row.selectedActivation?.outcome,
+      "raw_replay_without_live_dependency",
+    );
+    assert.equal(
+      row.selectedActivation?.selectedPoolSource,
+      "raw-replay-indexed",
+    );
+    assert.equal(
+      row.selectedActivation?.liveDependencySource,
+      "deterministic-test",
+    );
+  });
+
+  it("rejects generated route ids in requested-route mode", async () => {
+    const entry = FAME_ROUTE_CORPUS.find(
+      (candidate) => candidate.id === "weth-fame-small-direct",
+    );
+    assert.ok(entry);
+
+    await assert.rejects(
+      runRouteLab([entry], {
+        requestedRouteId: "solver-single_path-uniswap-v2-fame-direct",
+      }),
+      /pinned route artifact/,
+    );
+  });
+
   it("fails indexed mode clearly without a current block source", async () => {
     const entry = FAME_ROUTE_CORPUS.find(
       (candidate) => candidate.id === "weth-fame-small-direct",
@@ -381,8 +656,13 @@ describe("FAME route lab", () => {
         amountIn: "1000000",
         expectedStatus: "ready",
         status: "quote_adapter_failure",
-        message: "HTTP request failed.\nURL: https://example.invalid/secret",
+        requestedRouteId: null,
+        routeArtifactId: null,
+        message:
+          'HTTP request failed.\nresponse body {"token":"unit-secret"}\nURL: https://example.invalid/secret',
         selectedPools: [],
+        selectedQuoteSources: [],
+        selectedActivation: null,
         quoteContext: null,
         feeBreakdown: {
           routerFeeAmount: null,
@@ -491,7 +771,7 @@ describe("FAME route lab", () => {
     const markdown = formatRouteLabMarkdown(rows);
 
     assert.doesNotMatch(markdown, /https?:\/\//);
-    assert.doesNotMatch(markdown, /secret|Request body/);
+    assert.doesNotMatch(markdown, /secret|Request body|response body/);
     assert.doesNotMatch(markdown, /0x[a-fA-F0-9]{96,}/);
   });
 });

--- a/scripts/fame-swap-route-lab.test.ts
+++ b/scripts/fame-swap-route-lab.test.ts
@@ -1,16 +1,101 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  filterRouteLabCorpus,
   formatRouteLabMarkdown,
+  poolQuoteEndpointUrlFromEnv,
   poolStateEndpointUrlFromEnv,
   runIndexedRouteLab,
+  runQuoteApiRouteLab,
   runRouteLab,
   runSnapshotRouteLab,
   type FameRouteLabRow,
 } from "./fame-swap-route-lab";
-import { famePoolStateRegistrySourceId } from "../src/features/fame-swap/solver/poolStateRegistry";
+import {
+  FAME_V4_ZORA_REVIEWED_POOL_SHAPE,
+  famePoolStateRegistrySourceId,
+} from "../src/features/fame-swap/solver/poolStateRegistry";
+import { createSnapshotQuoteAdapter } from "../src/features/fame-swap/solver/quotes/snapshotAdapter";
+import type {
+  FamePoolQuoteBatchRequest,
+  FamePoolQuoteBatchResponse,
+} from "../src/features/fame-swap/solver/quotes/indexedQuoteApiClient";
 import { FAME_ROUTE_CORPUS } from "../src/features/fame-swap/solver/routeCorpus";
 import { FAME, USDC, WETH } from "../src/features/fame-swap/tokens";
+
+function quoteApiResponseForRequest(
+  request: FamePoolQuoteBatchRequest,
+): FamePoolQuoteBatchResponse {
+  const reviewed = FAME_V4_ZORA_REVIEWED_POOL_SHAPE;
+  return {
+    sourceRegistryId: famePoolStateRegistrySourceId(),
+    currentBlock: request.currentBlock,
+    producerMaxFreshnessBlocks: 120,
+    effectiveMaxFreshnessBlocks: request.maxFreshnessBlocks ?? 120,
+    quotes: request.quotes.map((quote) =>
+      quote.poolId === reviewed.poolId
+        ? {
+            status: "quoted" as const,
+            quoteKind: "cl-quote-v1" as const,
+            poolId: reviewed.poolId,
+            chainId: 8453,
+            poolAddress: null,
+            poolKey: reviewed.poolKey,
+            poolManager: reviewed.poolManager,
+            stateViewAddress: reviewed.stateViewAddress,
+            token0: reviewed.currency0,
+            token1: reviewed.currency1,
+            tokenIn: quote.tokenIn,
+            tokenOut: quote.tokenOut,
+            venueFamily: "UniswapV4" as const,
+            tickSpacing: reviewed.tickSpacing,
+            amountIn: quote.amountIn,
+            amountOut: "583370986295932128",
+            sqrtPriceX96: "79228162514264337593543950336",
+            sqrtPriceX96After: "79228162514264337593543950335",
+            tick: 0,
+            liquidity: "1000000000000000000",
+            fee: "30000",
+            lpFee: "30000",
+            protocolFee: "0",
+            protocolFeeStatus: "zero" as const,
+            staticFee: "30000",
+            feeSource: "v4-slot0" as const,
+            observedThroughBlock: request.currentBlock - 1,
+            blockHash:
+              "0x4444444444444444444444444444444444444444444444444444444444444444",
+            parentHash:
+              "0x5555555555555555555555555555555555555555555555555555555555555555",
+            snapshotId: "unit-v4-route-lab-quote",
+            stateHash:
+              "0x6666666666666666666666666666666666666666666666666666666666666666",
+            source: "uniswap-v4-state-view" as const,
+            sourceRegistryId: famePoolStateRegistrySourceId(),
+            maxFreshnessBlocks: 120,
+            hookAddress: reviewed.hooks,
+            hookData: reviewed.hookData,
+            hookDataStatus: "empty" as const,
+            zoraProvenance: {
+              status: "verified" as const,
+              source: "zora-factory-event" as const,
+              chainId: 8453,
+              factoryAddress: "0x0000000000000000000000000000000000000003",
+              coinAddress: reviewed.currency1,
+              poolKey: reviewed.poolKey,
+              poolId: reviewed.poolKey,
+              transactionHash:
+                "0x7777777777777777777777777777777777777777777777777777777777777777",
+              eventName: "CoinCreatedV4",
+            },
+          }
+        : {
+            status: "unavailable" as const,
+            requested: quote,
+            reason: "unsupported-pool" as const,
+          },
+    ),
+  };
+}
 
 describe("FAME route lab", () => {
   it("derives the raw pool-state proof endpoint from FAME_POOL_API_URL", () => {
@@ -23,6 +108,10 @@ describe("FAME route lab", () => {
       assert.equal(
         poolStateEndpointUrlFromEnv(),
         "https://api.fame.support/fame/pool-state",
+      );
+      assert.equal(
+        poolQuoteEndpointUrlFromEnv(),
+        "https://api.fame.support/fame/pool-quotes",
       );
     } finally {
       if (previousBase === undefined) delete process.env.FAME_POOL_API_URL;
@@ -70,6 +159,122 @@ describe("FAME route lab", () => {
         delete process.env.FAME_POOL_STATE_API_URL;
       else process.env.FAME_POOL_STATE_API_URL = previousEndpoint;
     }
+  });
+
+  it("filters route-lab to one requested basedflick/ZORA corpus case", () => {
+    const cases = filterRouteLabCorpus(FAME_ROUTE_CORPUS, {
+      caseId: "fame-usdc-fixture",
+      poolId: "uniswap-v4-basedflick-zora",
+    });
+
+    assert.deepEqual(
+      cases.map((entry) => entry.id),
+      ["fame-usdc-fixture"],
+    );
+  });
+
+  it("filters route-lab by pinned route artifact id", () => {
+    const cases = filterRouteLabCorpus(FAME_ROUTE_CORPUS, {
+      routeId: "solver-fame-basedflick-zora-usdc",
+    });
+
+    assert.deepEqual(
+      cases.map((entry) => entry.id),
+      ["fame-usdc-fixture"],
+    );
+  });
+
+  it("fails route-lab filters that are missing or ambiguous", () => {
+    assert.throws(
+      () =>
+        filterRouteLabCorpus(FAME_ROUTE_CORPUS, {
+          poolId: "uniswap-v4-basedflick-zora",
+        }),
+      /ambiguous.*fame-usdc-fixture.*fame-usdc-large-closed.*fame-weth-fixture/,
+    );
+    assert.throws(
+      () =>
+        filterRouteLabCorpus(FAME_ROUTE_CORPUS, {
+          routeId: "missing-route",
+        }),
+      /Unknown route-lab route id missing-route/,
+    );
+    assert.throws(
+      () =>
+        filterRouteLabCorpus(FAME_ROUTE_CORPUS, {
+          poolId: "missing-pool",
+        }),
+      /matched no corpus cases/,
+    );
+  });
+
+  it("fails when a targeted run selects a different route or omits the requested pool", async () => {
+    const entry = FAME_ROUTE_CORPUS.find(
+      (candidate) => candidate.id === "fame-usdc-fixture",
+    );
+    assert.ok(entry);
+
+    await assert.rejects(
+      () =>
+        runSnapshotRouteLab([entry], {
+          targetFilter: {
+            routeId: "solver-fame-basedflick-zora-weth",
+          },
+        }),
+      /did not produce a ready quote/,
+    );
+
+    await assert.rejects(
+      () =>
+        runSnapshotRouteLab([entry], {
+          targetFilter: {
+            poolId: "uniswap-v4-zora-eth",
+          },
+        }),
+      /did not produce a ready quote|did not include requested target pool uniswap-v4-zora-eth/,
+    );
+  });
+
+  it("runs a focused quote-api route lab through the compact V4 row", async () => {
+    const routeId = "solver-fame-basedflick-zora-usdc";
+    const corpus = filterRouteLabCorpus(FAME_ROUTE_CORPUS, { routeId });
+    const requests: FamePoolQuoteBatchRequest[] = [];
+
+    const rows = await runQuoteApiRouteLab(corpus, {
+      currentBlock: 125,
+      maxFreshnessBlocks: 120,
+      fallbackAdapter: createSnapshotQuoteAdapter(),
+      targetFilter: {
+        routeId,
+        poolId: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId,
+        tokenIn: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.currency1,
+        tokenOut: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.currency0,
+      },
+      quoteClient: {
+        async fetchQuotes(request) {
+          requests.push(request);
+          return quoteApiResponseForRequest(request);
+        },
+      },
+    });
+
+    const row = rows[0];
+    assert.ok(row);
+    assert.equal(row.mode, "quote-api");
+    assert.equal(row.requestedRouteId, routeId);
+    assert.equal(row.routeArtifactId, routeId);
+    assert.match(row.materializedRouteHash ?? "", /^0x[0-9a-f]{64}$/);
+    assert.ok(
+      row.selectedPools.includes(FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId),
+    );
+    assert.ok((row.quoteApi?.diagnostics.usedCount ?? 0) > 0);
+    assert.ok(
+      requests.some((request) =>
+        request.quotes.some(
+          (quote) => quote.poolId === FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId,
+        ),
+      ),
+    );
   });
 
   it("replays the full recorded-state corpus with executable quote evidence", async () => {
@@ -382,6 +587,10 @@ describe("FAME route lab", () => {
         expectedStatus: "ready",
         status: "quote_adapter_failure",
         message: "HTTP request failed.\nURL: https://example.invalid/secret",
+        requestedRouteId: null,
+        routeArtifactId: null,
+        selectedCandidateId: null,
+        materializedRouteHash: null,
         selectedPools: [],
         quoteContext: null,
         feeBreakdown: {
@@ -407,6 +616,7 @@ describe("FAME route lab", () => {
         ],
         optimizer: null,
         indexedPoolState: null,
+        quoteApi: null,
         edgeMatrix: [
           {
             chainId: 8453,

--- a/scripts/fame-swap-route-lab.ts
+++ b/scripts/fame-swap-route-lab.ts
@@ -17,6 +17,7 @@ import {
   type FameRouteCandidateBudgets,
 } from "../src/features/fame-swap/solver/graph/candidates";
 import type {
+  FameRouteCandidate,
   FameRouteCandidateRejected,
   FameRouteCandidateSet,
 } from "../src/features/fame-swap/solver/graph/routePlan";
@@ -39,18 +40,34 @@ import {
   type FameIndexedPoolStateClient,
   type FameIndexedPoolStateBatchResponse,
 } from "../src/features/fame-swap/solver/quotes/indexedPoolStateClient";
+import {
+  createIndexedQuoteApiClient,
+  type FamePoolQuoteClient,
+} from "../src/features/fame-swap/solver/quotes/indexedQuoteApiClient";
 import { createIndexedReserveQuoteAdapter } from "../src/features/fame-swap/solver/quotes/indexedReserveAdapter";
 import { createIndexedClReplayQuoteAdapter } from "../src/features/fame-swap/solver/quotes/indexedClReplayAdapter";
+import {
+  createIndexedQuoteApiAdapter,
+  createQuoteApiDiagnosticsRecorder,
+  type FameQuoteApiDiagnosticsSnapshot,
+} from "../src/features/fame-swap/solver/quotes/indexedQuoteApiAdapter";
 import { toAsyncQuoteAdapter } from "../src/features/fame-swap/solver/optimizer/quoteRunAdapter";
 import {
+  FAME_V4_ZORA_REVIEWED_POOL_SHAPE,
   famePoolStateRegistryPoolIdsForPair,
   famePoolStateRegistrySourceId,
+  type FameV4ZoraQuoteLaneActivation,
 } from "../src/features/fame-swap/solver/poolStateRegistry";
+import type {
+  FameAsyncQuoteAdapter,
+  FameQuoteAdapter,
+} from "../src/features/fame-swap/solver/quotes/adapters";
 import {
   corpusTokenLabel,
   FAME_ROUTE_CORPUS,
   type FameRouteCorpusCase,
 } from "../src/features/fame-swap/solver/routeCorpus";
+import { routeArtifactById } from "../src/features/fame-swap/solver/artifacts";
 import type {
   FameSwapExecutableQuote,
   FameSwapQuote,
@@ -71,13 +88,17 @@ const RECIPIENT =
   "0x0000000000000000000000000000000000000abc" as const satisfies Address;
 
 export interface FameRouteLabRow {
-  mode: "deterministic" | "recorded" | "indexed" | "live";
+  mode: "deterministic" | "recorded" | "indexed" | "quote-api" | "live";
   id: string;
   pair: string;
   amountIn: string;
   expectedStatus: string;
   status: string;
   message: string;
+  requestedRouteId: string | null;
+  routeArtifactId: string | null;
+  selectedCandidateId: string | null;
+  materializedRouteHash: string | null;
   selectedPools: string[];
   quoteContext: string | null;
   feeBreakdown: {
@@ -98,10 +119,18 @@ export interface FameRouteLabRow {
   }>;
   optimizer: FameRouteLabOptimizerSummary | null;
   indexedPoolState: FameRouteLabIndexedPoolStateSummary | null;
+  quoteApi: FameRouteLabQuoteApiSummary | null;
   edgeMatrix: FameRouteEdgeMatrixRow[];
   protocolCoverage: FameRouteProtocolCoverageRow[];
   simulation: FameRouteLabSimulation;
   suggestedContractTodo: string | null;
+}
+
+export interface FameRouteLabQuoteApiSummary {
+  sourceRegistryId: string;
+  currentBlock: number;
+  maxFreshnessBlocks: number | null;
+  diagnostics: FameQuoteApiDiagnosticsSnapshot;
 }
 
 export interface FameRouteLabIndexedPoolStateSummary {
@@ -180,13 +209,303 @@ interface RouteLabClient {
 
 interface RouteLabOptions {
   candidateBudgets?: Partial<FameRouteCandidateBudgets>;
+  targetFilter?: FameRouteLabTargetFilter;
 }
 
 interface IndexedRouteLabOptions extends RouteLabOptions {
   poolStateClient: FameIndexedPoolStateClient;
-  fallbackAdapter?: Awaited<ReturnType<typeof createLiveLiquidityQuoteAdapter>>;
+  fallbackAdapter?: FameAsyncQuoteAdapter | FameQuoteAdapter;
   currentBlock?: number;
   maxFreshnessBlocks?: number;
+}
+
+interface QuoteApiRouteLabOptions extends RouteLabOptions {
+  quoteClient: FamePoolQuoteClient;
+  fallbackAdapter?: FameAsyncQuoteAdapter | FameQuoteAdapter;
+  currentBlock?: number;
+  maxFreshnessBlocks?: number;
+  expectedSourceRegistryId?: string;
+  v4ZoraQuoteLaneActivation?: FameV4ZoraQuoteLaneActivation;
+  simulate?: boolean;
+}
+
+export interface FameRouteLabTargetFilter {
+  caseId?: string;
+  routeId?: string;
+  poolId?: string;
+  tokenIn?: Address;
+  tokenOut?: Address;
+}
+
+function sameAddress(left: Address, right: Address): boolean {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+function hasRouteLabTargetFilter(
+  filter: FameRouteLabTargetFilter | undefined,
+): filter is FameRouteLabTargetFilter {
+  return Boolean(
+    filter &&
+      (filter.caseId ||
+        filter.routeId ||
+        filter.poolId ||
+        filter.tokenIn ||
+        filter.tokenOut),
+  );
+}
+
+function routeLabTargetFilterLabel(filter: FameRouteLabTargetFilter): string {
+  return [
+    filter.caseId ? `case ${filter.caseId}` : null,
+    filter.routeId ? `route ${filter.routeId}` : null,
+    filter.poolId ? `pool ${filter.poolId}` : null,
+    filter.tokenIn ? `tokenIn ${filter.tokenIn}` : null,
+    filter.tokenOut ? `tokenOut ${filter.tokenOut}` : null,
+  ]
+    .filter((part): part is string => part !== null)
+    .join(", ");
+}
+
+function routeEntryMatchesRouteId(
+  entry: FameRouteCorpusCase,
+  routeId: string,
+): boolean {
+  const artifact = routeArtifactById(routeId);
+  if (!artifact) throw new Error(`Unknown route-lab route id ${routeId}.`);
+  return (
+    sameAddress(entry.tokenIn, artifact.route.tokenIn) &&
+    sameAddress(entry.tokenOut, artifact.route.tokenOut) &&
+    entry.amountIn === BigInt(artifact.route.amountIn)
+  );
+}
+
+function routeEntryMatchesPoolTarget(
+  entry: FameRouteCorpusCase,
+  filter: FameRouteLabTargetFilter,
+): boolean {
+  if (!filter.poolId && !filter.tokenIn && !filter.tokenOut) return true;
+  const candidateSet = routeCandidatesForPair(entry.tokenIn, entry.tokenOut);
+  return candidateSet.candidates.some((candidate) =>
+    candidate.legs.some((leg) => {
+      if (filter.poolId && leg.edge.poolId !== filter.poolId) return false;
+      if (filter.tokenIn && !sameAddress(leg.edge.tokenIn, filter.tokenIn)) {
+        return false;
+      }
+      if (filter.tokenOut && !sameAddress(leg.edge.tokenOut, filter.tokenOut)) {
+        return false;
+      }
+      return true;
+    }),
+  );
+}
+
+export function filterRouteLabCorpus(
+  corpus: readonly FameRouteCorpusCase[],
+  filter: FameRouteLabTargetFilter | undefined,
+): FameRouteCorpusCase[] {
+  if (!hasRouteLabTargetFilter(filter)) return [...corpus];
+
+  const matches = corpus.filter((entry) => {
+    if (filter.caseId && entry.id !== filter.caseId) return false;
+    if (filter.routeId && !routeEntryMatchesRouteId(entry, filter.routeId)) {
+      return false;
+    }
+    return routeEntryMatchesPoolTarget(entry, filter);
+  });
+
+  if (matches.length === 0) {
+    throw new Error(
+      `Route-lab target filter matched no corpus cases: ${routeLabTargetFilterLabel(filter)}.`,
+    );
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `Route-lab target filter is ambiguous (${routeLabTargetFilterLabel(filter)}): ${matches.map((entry) => entry.id).join(", ")}. Add --case or --route to select exactly one route.`,
+    );
+  }
+  return matches;
+}
+
+function selectedRouteArtifactId(quote: FameSwapQuote): string | null {
+  return quote.status === "ready" ? quote.routeArtifactId : null;
+}
+
+function selectedQuoteMatchesRouteArtifact(
+  quote: FameSwapQuote,
+  routeId: string,
+): boolean {
+  if (quote.status !== "ready") return false;
+  const artifact = routeArtifactById(routeId);
+  if (!artifact) throw new Error(`Unknown route-lab route id ${routeId}.`);
+  if (quote.feeBreakdown.legs.length !== artifact.route.legs.length) {
+    return false;
+  }
+  return quote.feeBreakdown.legs.every((leg, index) => {
+    const artifactLeg = artifact.route.legs[index];
+    const artifactPoolId = artifact.poolIds[index];
+    return (
+      artifactLeg !== undefined &&
+      artifactPoolId !== undefined &&
+      leg.poolId === artifactPoolId &&
+      sameAddress(leg.tokenIn, artifactLeg.tokenIn) &&
+      sameAddress(leg.tokenOut, artifactLeg.tokenOut)
+    );
+  });
+}
+
+function routeArtifactIdForEvidence(
+  quote: FameSwapQuote,
+  filter: FameRouteLabTargetFilter | undefined,
+): string | null {
+  if (
+    quote.status === "ready" &&
+    filter?.routeId &&
+    selectedQuoteMatchesRouteArtifact(quote, filter.routeId)
+  ) {
+    return filter.routeId;
+  }
+  return selectedRouteArtifactId(quote);
+}
+
+function materializedRouteHash(quote: FameSwapQuote): string | null {
+  return quote.status === "ready" ? quote.materializedRouteHash : null;
+}
+
+function requestedRouteId(
+  filter: FameRouteLabTargetFilter | undefined,
+): string | null {
+  return filter?.routeId ?? null;
+}
+
+function selectedQuoteHasTargetLeg(
+  quote: FameSwapQuote,
+  filter: FameRouteLabTargetFilter,
+): boolean {
+  if (quote.status !== "ready") return false;
+  return quote.feeBreakdown.legs.some((leg) => {
+    if (filter.poolId && leg.poolId !== filter.poolId) return false;
+    if (filter.tokenIn && !sameAddress(leg.tokenIn, filter.tokenIn)) {
+      return false;
+    }
+    if (filter.tokenOut && !sameAddress(leg.tokenOut, filter.tokenOut)) {
+      return false;
+    }
+    return true;
+  });
+}
+
+function validateRouteLabTargetSelection(options: {
+  entry: FameRouteCorpusCase;
+  quote: FameSwapQuote;
+  filter: FameRouteLabTargetFilter | undefined;
+  mode: FameRouteLabRow["mode"];
+}): void {
+  const { entry, quote, filter, mode } = options;
+  if (!hasRouteLabTargetFilter(filter)) return;
+
+  if (filter.routeId) {
+    if (quote.status !== "ready") {
+      throw new Error(
+        `${mode} route-lab target route ${filter.routeId} did not produce a ready quote for ${entry.id}: ${quote.status}.`,
+      );
+    }
+    if (
+      quote.routeArtifactId !== filter.routeId &&
+      !selectedQuoteMatchesRouteArtifact(quote, filter.routeId)
+    ) {
+      throw new Error(
+        `${mode} route-lab selected route ${quote.routeArtifactId} for ${entry.id}, expected ${filter.routeId}.`,
+      );
+    }
+  }
+
+  if (filter.poolId || filter.tokenIn || filter.tokenOut) {
+    if (quote.status !== "ready") {
+      throw new Error(
+        `${mode} route-lab target ${routeLabTargetFilterLabel(filter)} did not produce a ready quote for ${entry.id}: ${quote.status}.`,
+      );
+    }
+    if (!selectedQuoteHasTargetLeg(quote, filter)) {
+      throw new Error(
+        `${mode} route-lab selected route ${quote.routeArtifactId} for ${entry.id} did not include requested target ${routeLabTargetFilterLabel(filter)}.`,
+      );
+    }
+  }
+}
+
+function candidateMatchesRouteArtifact(
+  candidate: FameRouteCandidate,
+  routeId: string,
+): boolean {
+  const artifact = routeArtifactById(routeId);
+  if (!artifact) throw new Error(`Unknown route-lab route id ${routeId}.`);
+  if (candidate.legs.length !== artifact.route.legs.length) return false;
+  return candidate.legs.every((leg, index) => {
+    const artifactLeg = artifact.route.legs[index];
+    const artifactPoolId = artifact.poolIds[index];
+    return (
+      artifactLeg !== undefined &&
+      artifactPoolId !== undefined &&
+      leg.edge.poolId === artifactPoolId &&
+      sameAddress(leg.edge.tokenIn, artifactLeg.tokenIn) &&
+      sameAddress(leg.edge.tokenOut, artifactLeg.tokenOut)
+    );
+  });
+}
+
+function candidateMatchesPoolTarget(
+  candidate: FameRouteCandidate,
+  filter: FameRouteLabTargetFilter,
+): boolean {
+  if (!filter.poolId && !filter.tokenIn && !filter.tokenOut) return true;
+  return candidate.legs.some((leg) => {
+    if (filter.poolId && leg.edge.poolId !== filter.poolId) return false;
+    if (filter.tokenIn && !sameAddress(leg.edge.tokenIn, filter.tokenIn)) {
+      return false;
+    }
+    if (filter.tokenOut && !sameAddress(leg.edge.tokenOut, filter.tokenOut)) {
+      return false;
+    }
+    return true;
+  });
+}
+
+function candidateFilterForRouteLabTarget(
+  filter: FameRouteLabTargetFilter | undefined,
+): ((candidate: FameRouteCandidate) => boolean) | undefined {
+  if (!hasRouteLabTargetFilter(filter)) return undefined;
+  return (candidate) => {
+    if (filter.routeId && !candidateMatchesRouteArtifact(candidate, filter.routeId)) {
+      return false;
+    }
+    return candidateMatchesPoolTarget(candidate, filter);
+  };
+}
+
+function routeLabV4ZoraActivation(
+  sourceRegistryId: string,
+): FameV4ZoraQuoteLaneActivation {
+  return {
+    status: "active",
+    sourceRegistryId,
+    parityStatus: "passed",
+    routeSimulationStatus: "passed",
+    evidenceId: "route-lab-v4-zora-validation",
+  };
+}
+
+function quoteApiSummary(options: {
+  sourceRegistryId: string;
+  currentBlock: number;
+  maxFreshnessBlocks?: number;
+  diagnostics: FameQuoteApiDiagnosticsSnapshot;
+}): FameRouteLabQuoteApiSummary {
+  return {
+    sourceRegistryId: options.sourceRegistryId,
+    currentBlock: options.currentBlock,
+    maxFreshnessBlocks: options.maxFreshnessBlocks ?? null,
+    diagnostics: options.diagnostics,
+  };
 }
 
 export async function runSnapshotRouteLab(
@@ -219,6 +538,7 @@ export async function runSnapshotRouteLab(
         routerAddress: ROUTER_ADDRESS,
         feePpm: 2_222n,
       },
+      candidateFilter: candidateFilterForRouteLabTarget(options.targetFilter),
       now: new Date("2026-05-13T00:00:00Z"),
       adapter: toAsyncQuoteAdapter(adapter),
     });
@@ -227,6 +547,12 @@ export async function runSnapshotRouteLab(
       status: "not_requested",
       message: "Recorded quote replay does not run live route simulation.",
     };
+    validateRouteLabTargetSelection({
+      entry,
+      quote,
+      filter: options.targetFilter,
+      mode: "recorded",
+    });
 
     rows.push({
       mode: "recorded",
@@ -236,6 +562,10 @@ export async function runSnapshotRouteLab(
       expectedStatus: expectedStatusFor(entry, "recorded"),
       status: quote.status,
       message: displaySafeDiagnosticMessage(quote.message),
+      requestedRouteId: requestedRouteId(options.targetFilter),
+      routeArtifactId: routeArtifactIdForEvidence(quote, options.targetFilter),
+      selectedCandidateId: selectedRouteArtifactId(quote),
+      materializedRouteHash: materializedRouteHash(quote),
       selectedPools: quote.status === "ready" ? quote.poolIds : [],
       quoteContext: quoteContextLabel(quote),
       feeBreakdown:
@@ -269,6 +599,7 @@ export async function runSnapshotRouteLab(
       ),
       optimizer: optimizerSummary(quote),
       indexedPoolState: null,
+      quoteApi: null,
       edgeMatrix,
       protocolCoverage: routeProtocolCoverage(edgeMatrix, quote, simulation),
       simulation,
@@ -279,7 +610,7 @@ export async function runSnapshotRouteLab(
 }
 
 function currentBlockForIndexedState(
-  adapter: Awaited<ReturnType<typeof createLiveLiquidityQuoteAdapter>>,
+  adapter: FameAsyncQuoteAdapter | FameQuoteAdapter,
 ): number | null {
   const context = adapter.quoteContext;
   if (
@@ -352,6 +683,7 @@ export async function runIndexedRouteLab(
         routerAddress: ROUTER_ADDRESS,
         feePpm: 2_222n,
       },
+      candidateFilter: candidateFilterForRouteLabTarget(options.targetFilter),
       now: new Date("2026-05-13T00:00:00Z"),
       adapter,
     });
@@ -360,6 +692,12 @@ export async function runIndexedRouteLab(
       status: "not_requested",
       message: "Indexed route lab does not run live route simulation.",
     };
+    validateRouteLabTargetSelection({
+      entry,
+      quote,
+      filter: options.targetFilter,
+      mode: "indexed",
+    });
 
     rows.push({
       mode: "indexed",
@@ -369,6 +707,10 @@ export async function runIndexedRouteLab(
       expectedStatus: expectedStatusFor(entry, "indexed"),
       status: quote.status,
       message: displaySafeDiagnosticMessage(quote.message),
+      requestedRouteId: requestedRouteId(options.targetFilter),
+      routeArtifactId: routeArtifactIdForEvidence(quote, options.targetFilter),
+      selectedCandidateId: selectedRouteArtifactId(quote),
+      materializedRouteHash: materializedRouteHash(quote),
       selectedPools: quote.status === "ready" ? quote.poolIds : [],
       quoteContext: quoteContextLabel(quote),
       feeBreakdown:
@@ -402,12 +744,170 @@ export async function runIndexedRouteLab(
       ),
       optimizer: optimizerSummary(quote),
       indexedPoolState: indexedPoolStateSummary(indexedState),
+      quoteApi: null,
       edgeMatrix,
       protocolCoverage: routeProtocolCoverage(edgeMatrix, quote, simulation),
       simulation,
       suggestedContractTodo: suggestedTodo(entry, quote),
     });
   }
+  return rows;
+}
+
+export async function runQuoteApiRouteLab(
+  corpus: readonly FameRouteCorpusCase[] = FAME_ROUTE_CORPUS,
+  options: QuoteApiRouteLabOptions,
+): Promise<FameRouteLabRow[]> {
+  const config = getFameSwapConfig();
+  const rpcUrl =
+    process.env.BASE_RPC_URL ?? process.env.NEXT_PUBLIC_BASE_RPC_URL_1;
+  const client = rpcUrl
+    ? createPublicClient({
+        chain: base,
+        transport: http(rpcUrl),
+      })
+    : null;
+  const fallbackAdapter =
+    options.fallbackAdapter ??
+    (client
+      ? await createLiveLiquidityQuoteAdapter({
+          client: {
+            getBlockNumber: () => client.getBlockNumber(),
+            readContract: (request) =>
+              client.readContract(
+                request as Parameters<typeof client.readContract>[0],
+              ) as Promise<unknown>,
+          },
+          chainId: base.id,
+        })
+      : unavailableLiveAsyncQuoteAdapter(
+          "Base RPC is not configured for quote-api route-lab fallback quotes.",
+        ));
+  const currentBlock =
+    options.currentBlock ?? currentBlockForIndexedState(fallbackAdapter);
+  if (currentBlock === null) {
+    throw new Error(
+      "Quote-api route lab requires currentBlock, FAME_POOL_STATE_CURRENT_BLOCK, or BASE_RPC_URL so compact quote freshness is checked against a live Base block.",
+    );
+  }
+  const expectedSourceRegistryId =
+    options.expectedSourceRegistryId ?? famePoolStateRegistrySourceId();
+  const routerAddress = config.routerAddress ?? ROUTER_ADDRESS;
+  const account = options.simulate ? simulationAccount() : null;
+  const rows: FameRouteLabRow[] = [];
+
+  for (const entry of corpus) {
+    const diagnostics = createQuoteApiDiagnosticsRecorder(true);
+    const adapter = createIndexedQuoteApiAdapter({
+      quoteClient: options.quoteClient,
+      fallback: fallbackAdapter,
+      currentBlock,
+      maxFreshnessBlocks: options.maxFreshnessBlocks,
+      expectedSourceRegistryId,
+      v4ZoraQuoteLaneActivation:
+        options.v4ZoraQuoteLaneActivation ??
+        routeLabV4ZoraActivation(expectedSourceRegistryId),
+      diagnostics,
+    });
+    const candidateSet = routeCandidatesForPair(
+      entry.tokenIn,
+      entry.tokenOut,
+      undefined,
+      {
+        budgets: options.candidateBudgets,
+      },
+    );
+    const quote = await quoteFameSwapAsync({
+      tokenIn: token(entry.tokenIn),
+      tokenOut: token(entry.tokenOut),
+      amountIn: entry.amountIn,
+      recipient: RECIPIENT,
+      config: {
+        ...config,
+        routerAddress,
+        defaultSlippageBps:
+          config.defaultSlippageBps ?? DEFAULT_FAME_SWAP_SLIPPAGE_BPS,
+      },
+      readiness: {
+        status: "ready",
+        routerAddress,
+        feePpm: 2_222n,
+      },
+      candidateFilter: candidateFilterForRouteLabTarget(options.targetFilter),
+      now: new Date("2026-05-13T00:00:00Z"),
+      adapter,
+    });
+    const edgeMatrix = routeEdgeMatrix(candidateSet, quote);
+    const simulation = await simulateQuote(
+      quote,
+      options.simulate ? (client as unknown as RouteLabClient | null) : null,
+      account,
+    );
+    validateRouteLabTargetSelection({
+      entry,
+      quote,
+      filter: options.targetFilter,
+      mode: "quote-api",
+    });
+
+    rows.push({
+      mode: "quote-api",
+      id: entry.id,
+      pair: pairLabel(entry),
+      amountIn: entry.amountIn.toString(),
+      expectedStatus: expectedStatusFor(entry, "live"),
+      status: quote.status,
+      message: displaySafeDiagnosticMessage(quote.message),
+      requestedRouteId: requestedRouteId(options.targetFilter),
+      routeArtifactId: routeArtifactIdForEvidence(quote, options.targetFilter),
+      selectedCandidateId: selectedRouteArtifactId(quote),
+      materializedRouteHash: materializedRouteHash(quote),
+      selectedPools: quote.status === "ready" ? quote.poolIds : [],
+      quoteContext: quoteContextLabel(quote),
+      feeBreakdown:
+        quote.status === "ready"
+          ? {
+              routerFeeAmount: quote.routerFeeAmount.toString(),
+              routerFeePpm: quote.feeBreakdown.routerFeePpm.toString(),
+              venueFeesIncluded: quote.feeBreakdown.venueFeesIncluded,
+              maxLegMarketImpactBps:
+                quote.feeBreakdown.marketImpact.maxLegMarketImpactBps,
+              computablePriceImpactLegs:
+                quote.feeBreakdown.marketImpact.computableLegs,
+            }
+          : {
+              routerFeeAmount: null,
+              routerFeePpm: null,
+              venueFeesIncluded: null,
+              maxLegMarketImpactBps: null,
+              computablePriceImpactLegs: null,
+            },
+      rejectedCandidates:
+        "rejectedCandidates" in quote
+          ? quote.rejectedCandidates.map((candidate) => ({
+              candidateId: candidate.candidateId,
+              reason: candidate.reason,
+              message: displaySafeDiagnosticMessage(candidate.message),
+            }))
+          : [],
+      candidateGenerationDiagnostics: candidateGenerationDiagnostics(
+        candidateSet.rejected,
+      ),
+      optimizer: optimizerSummary(quote),
+      indexedPoolState: null,
+      quoteApi: quoteApiSummary({
+        sourceRegistryId: expectedSourceRegistryId,
+        currentBlock,
+        maxFreshnessBlocks: options.maxFreshnessBlocks,
+        diagnostics: diagnostics.snapshot(),
+      }),
+      edgeMatrix,
+      protocolCoverage: routeProtocolCoverage(edgeMatrix, quote, simulation),
+      simulation,
+      suggestedContractTodo: suggestedTodo(entry, quote),
+    });
+  }
+
   return rows;
 }
 
@@ -835,6 +1335,7 @@ export async function runRouteLab(
         feePpm: 2_222n,
       },
       optimizerMode: "disabled",
+      candidateFilter: candidateFilterForRouteLabTarget(options.targetFilter),
       now: new Date("2026-05-13T00:00:00Z"),
       adapter: toAsyncQuoteAdapter(adapter),
     });
@@ -843,6 +1344,12 @@ export async function runRouteLab(
       status: "not_requested",
       message: "Deterministic route lab does not run live route simulation.",
     };
+    validateRouteLabTargetSelection({
+      entry,
+      quote,
+      filter: options.targetFilter,
+      mode: "deterministic",
+    });
 
     rows.push({
       mode: "deterministic",
@@ -852,6 +1359,10 @@ export async function runRouteLab(
       expectedStatus: expectedStatusFor(entry, "deterministic"),
       status: quote.status,
       message: displaySafeDiagnosticMessage(quote.message),
+      requestedRouteId: requestedRouteId(options.targetFilter),
+      routeArtifactId: routeArtifactIdForEvidence(quote, options.targetFilter),
+      selectedCandidateId: selectedRouteArtifactId(quote),
+      materializedRouteHash: materializedRouteHash(quote),
       selectedPools: quote.status === "ready" ? quote.poolIds : [],
       quoteContext: quoteContextLabel(quote),
       feeBreakdown:
@@ -885,6 +1396,7 @@ export async function runRouteLab(
       ),
       optimizer: optimizerSummary(quote),
       indexedPoolState: null,
+      quoteApi: null,
       edgeMatrix,
       protocolCoverage: routeProtocolCoverage(edgeMatrix, quote, simulation),
       simulation,
@@ -951,6 +1463,7 @@ export async function runLiveRouteLab(
         routerAddress,
         feePpm: 2_222n,
       },
+      candidateFilter: candidateFilterForRouteLabTarget(options.targetFilter),
       now: new Date("2026-05-13T00:00:00Z"),
       adapter,
     });
@@ -960,6 +1473,12 @@ export async function runLiveRouteLab(
       options.simulate ? (client as unknown as RouteLabClient | null) : null,
       account,
     );
+    validateRouteLabTargetSelection({
+      entry,
+      quote,
+      filter: options.targetFilter,
+      mode: "live",
+    });
 
     rows.push({
       mode: "live",
@@ -969,6 +1488,10 @@ export async function runLiveRouteLab(
       expectedStatus: expectedStatusFor(entry, "live"),
       status: quote.status,
       message: displaySafeDiagnosticMessage(quote.message),
+      requestedRouteId: requestedRouteId(options.targetFilter),
+      routeArtifactId: routeArtifactIdForEvidence(quote, options.targetFilter),
+      selectedCandidateId: selectedRouteArtifactId(quote),
+      materializedRouteHash: materializedRouteHash(quote),
       selectedPools: quote.status === "ready" ? quote.poolIds : [],
       quoteContext: quoteContextLabel(quote),
       feeBreakdown:
@@ -1002,6 +1525,7 @@ export async function runLiveRouteLab(
       ),
       optimizer: optimizerSummary(quote),
       indexedPoolState: null,
+      quoteApi: null,
       edgeMatrix,
       protocolCoverage: routeProtocolCoverage(edgeMatrix, quote, simulation),
       simulation,
@@ -1026,6 +1550,10 @@ export function formatRouteLabMarkdown(
       `- Amount in: ${row.amountIn}`,
       `- Status: ${row.status}`,
       `- Expected: ${row.expectedStatus}`,
+      `- Requested route: ${row.requestedRouteId ?? "n/a"}`,
+      `- Selected route: ${row.routeArtifactId ?? "n/a"}`,
+      `- Selected candidate: ${row.selectedCandidateId ?? "n/a"}`,
+      `- Materialized route hash: ${row.materializedRouteHash ?? "n/a"}`,
       `- Selected pools: ${row.selectedPools.join(", ") || "none"}`,
       `- Quote context: ${row.quoteContext ?? "n/a"}`,
       `- Router fee amount: ${row.feeBreakdown.routerFeeAmount ?? "n/a"}`,
@@ -1042,6 +1570,7 @@ export function formatRouteLabMarkdown(
       `- Candidate generation diagnostics: ${row.candidateGenerationDiagnostics.length}`,
       `- Optimizer: ${optimizerSummaryLine(row.optimizer)}`,
       `- Indexed pool state: ${indexedPoolStateSummaryLine(row.indexedPoolState)}`,
+      `- Quote API: ${quoteApiSummaryLine(row.quoteApi)}`,
       `- Edge matrix: ${edgeMatrixSummary(row.edgeMatrix)}`,
       `- Protocol coverage: ${protocolCoverageSummary(row.protocolCoverage)}`,
       `- Simulation: ${
@@ -1110,6 +1639,22 @@ function indexedPoolStateSummaryLine(
   ]
     .filter((part): part is string => part !== null)
     .join(", ");
+}
+
+function quoteApiSummaryLine(
+  quoteApi: FameRouteLabRow["quoteApi"],
+): string {
+  if (!quoteApi) return "not used";
+  const diagnostics = quoteApi.diagnostics;
+  return [
+    `registry ${quoteApi.sourceRegistryId}`,
+    `block ${quoteApi.currentBlock.toString()}`,
+    `used ${diagnostics.usedCount}`,
+    `fallback ${diagnostics.fallbackCount}`,
+    `batch failures ${diagnostics.batchFailureCount}`,
+    `quoted ${diagnostics.statusCounts.quoted}`,
+    `unavailable ${diagnostics.statusCounts.unavailable}`,
+  ].join(", ");
 }
 
 function formatOptimizerMarkdown(
@@ -1273,6 +1818,40 @@ function shouldRunCli(): boolean {
   return process.argv[1]?.endsWith("fame-swap-route-lab.ts") ?? false;
 }
 
+function cliValue(args: readonly string[], name: string): string | undefined {
+  const prefix = `${name}=`;
+  const inline = args.find((arg) => arg.startsWith(prefix));
+  if (inline) return inline.slice(prefix.length);
+  const index = args.indexOf(name);
+  if (index === -1) return undefined;
+  const value = args[index + 1];
+  return value && !value.startsWith("--") ? value : undefined;
+}
+
+function cliAddress(
+  args: readonly string[],
+  name: string,
+): Address | undefined {
+  const value = cliValue(args, name);
+  if (value === undefined) return undefined;
+  if (!isAddress(value)) {
+    throw new Error(`${name} must be an address.`);
+  }
+  return value as Address;
+}
+
+function routeLabTargetFilterFromCliArgs(
+  args: readonly string[],
+): FameRouteLabTargetFilter {
+  return {
+    caseId: cliValue(args, "--case"),
+    routeId: cliValue(args, "--route"),
+    poolId: cliValue(args, "--pool"),
+    tokenIn: cliAddress(args, "--token-in"),
+    tokenOut: cliAddress(args, "--token-out"),
+  };
+}
+
 function localOrTestPoolApiBase(url: URL): boolean {
   return (
     process.env.NODE_ENV === "test" ||
@@ -1323,6 +1902,16 @@ export function poolStateEndpointUrlFromEnv(): string | undefined {
   return url.toString();
 }
 
+export function poolQuoteEndpointUrlFromEnv(): string | undefined {
+  const url = poolApiBaseUrlFromEnv();
+  if (!url) return undefined;
+  const basePath = url.pathname.replace(/\/+$/u, "");
+  url.pathname = `${basePath}/fame/pool-quotes`;
+  url.search = "";
+  url.hash = "";
+  return url.toString();
+}
+
 function routeLabIndexedPoolStateClientFromEnv(): FameIndexedPoolStateClient {
   const endpointUrl = poolStateEndpointUrlFromEnv();
   const serviceToken = process.env.FAME_POOL_STATE_SERVICE_TOKEN;
@@ -1335,6 +1924,21 @@ function routeLabIndexedPoolStateClientFromEnv(): FameIndexedPoolStateClient {
     endpointUrl,
     serviceToken,
     timeoutMs: optionalSafeIntegerEnv("FAME_POOL_STATE_TIMEOUT_MS"),
+  });
+}
+
+function routeLabQuoteApiClientFromEnv(): FamePoolQuoteClient {
+  const endpointUrl = poolQuoteEndpointUrlFromEnv();
+  const serviceToken = process.env.FAME_POOL_STATE_SERVICE_TOKEN;
+  if (!endpointUrl || !serviceToken) {
+    throw new Error(
+      "Quote-api route lab requires FAME_POOL_API_URL and FAME_POOL_STATE_SERVICE_TOKEN.",
+    );
+  }
+  return createIndexedQuoteApiClient({
+    endpointUrl,
+    serviceToken,
+    timeoutMs: optionalSafeIntegerEnv("FAME_POOL_QUOTE_TIMEOUT_MS"),
   });
 }
 
@@ -1373,22 +1977,40 @@ async function routeLabIndexedCurrentBlockFromEnv(): Promise<number> {
 
 if (shouldRunCli()) {
   const run = async () => {
-    const rows = process.argv.includes("--live")
-      ? await runLiveRouteLab(undefined, {
-          simulate: process.argv.includes("--simulate"),
+    const args = process.argv.slice(2);
+    const targetFilter = routeLabTargetFilterFromCliArgs(args);
+    const corpus = filterRouteLabCorpus(FAME_ROUTE_CORPUS, targetFilter);
+    const runQuoteApi =
+      args.includes("--quote-api") ||
+      (args.includes("--indexed") && args.includes("--simulate"));
+    const rows = runQuoteApi
+      ? await runQuoteApiRouteLab(corpus, {
+          quoteClient: routeLabQuoteApiClientFromEnv(),
+          currentBlock: await routeLabIndexedCurrentBlockFromEnv(),
+          maxFreshnessBlocks: optionalSafeIntegerEnv(
+            "FAME_POOL_QUOTE_MAX_FRESHNESS_BLOCKS",
+          ),
+          targetFilter,
+          simulate: args.includes("--simulate"),
         })
-      : process.argv.includes("--indexed")
-        ? await runIndexedRouteLab(undefined, {
+      : args.includes("--live")
+        ? await runLiveRouteLab(corpus, {
+            simulate: args.includes("--simulate"),
+            targetFilter,
+          })
+        : args.includes("--indexed")
+        ? await runIndexedRouteLab(corpus, {
             poolStateClient: routeLabIndexedPoolStateClientFromEnv(),
             currentBlock: await routeLabIndexedCurrentBlockFromEnv(),
             maxFreshnessBlocks: optionalSafeIntegerEnv(
               "FAME_POOL_STATE_MAX_FRESHNESS_BLOCKS",
             ),
+            targetFilter,
           })
-        : process.argv.includes("--deterministic")
-          ? await runRouteLab()
-          : await runSnapshotRouteLab();
-    if (process.argv.includes("--markdown")) {
+        : args.includes("--deterministic")
+          ? await runRouteLab(corpus, { targetFilter })
+          : await runSnapshotRouteLab(corpus, { targetFilter });
+    if (args.includes("--markdown")) {
       console.log(formatRouteLabMarkdown(rows));
     } else {
       console.log(JSON.stringify(rows, null, 2));

--- a/scripts/fame-swap-route-lab.ts
+++ b/scripts/fame-swap-route-lab.ts
@@ -96,6 +96,7 @@ const ROUTER_ADDRESS =
   "0x0000000000000000000000000000000000000009" as const satisfies Address;
 const RECIPIENT =
   "0x0000000000000000000000000000000000000abc" as const satisfies Address;
+const FIXED_ROUTE_LAB_NOW = new Date("2026-05-13T00:00:00Z");
 
 export type FameRouteLabSelectedQuoteSourceKind =
   | "compact-indexed"
@@ -255,6 +256,7 @@ interface RouteLabClient {
 
 interface RouteLabOptions {
   candidateBudgets?: Partial<FameRouteCandidateBudgets>;
+  now?: Date;
   requestedRouteId?: string;
   targetFilter?: FameRouteLabTargetFilter;
 }
@@ -541,6 +543,13 @@ function routeLabV4ZoraActivation(
   };
 }
 
+function routeLabQuoteNow(
+  options: RouteLabOptions & { simulate?: boolean },
+): Date {
+  if (options.now) return options.now;
+  return options.simulate ? new Date() : FIXED_ROUTE_LAB_NOW;
+}
+
 function quoteApiSummary(options: {
   sourceRegistryId: string;
   currentBlock: number;
@@ -588,7 +597,7 @@ export async function runSnapshotRouteLab(
       },
       requestedRouteId: options.requestedRouteId,
       candidateFilter: candidateFilterForRouteLabTarget(options.targetFilter),
-      now: new Date("2026-05-13T00:00:00Z"),
+      now: routeLabQuoteNow(options),
       adapter: toAsyncQuoteAdapter(adapter),
     });
     const edgeMatrix = routeEdgeMatrix(candidateSet, quote);
@@ -781,7 +790,7 @@ export async function runIndexedRouteLab(
       },
       requestedRouteId: options.requestedRouteId,
       candidateFilter: candidateFilterForRouteLabTarget(options.targetFilter),
-      now: new Date("2026-05-13T00:00:00Z"),
+      now: routeLabQuoteNow(options),
       adapter,
     });
     const edgeMatrix = routeEdgeMatrix(candidateSet, quote);
@@ -939,7 +948,7 @@ export async function runQuoteApiRouteLab(
       },
       requestedRouteId: options.requestedRouteId,
       candidateFilter: candidateFilterForRouteLabTarget(options.targetFilter),
-      now: new Date("2026-05-13T00:00:00Z"),
+      now: routeLabQuoteNow(options),
       adapter,
     });
     const edgeMatrix = routeEdgeMatrix(candidateSet, quote);
@@ -1502,7 +1511,7 @@ export async function runRouteLab(
       optimizerMode: "disabled",
       requestedRouteId: options.requestedRouteId,
       candidateFilter: candidateFilterForRouteLabTarget(options.targetFilter),
-      now: new Date("2026-05-13T00:00:00Z"),
+      now: routeLabQuoteNow(options),
       adapter: toAsyncQuoteAdapter(adapter),
     });
     const edgeMatrix = routeEdgeMatrix(candidateSet, quote);
@@ -1639,7 +1648,7 @@ export async function runLiveRouteLab(
       },
       requestedRouteId: options.requestedRouteId,
       candidateFilter: candidateFilterForRouteLabTarget(options.targetFilter),
-      now: new Date("2026-05-13T00:00:00Z"),
+      now: routeLabQuoteNow(options),
       adapter,
     });
     const edgeMatrix = routeEdgeMatrix(candidateSet, quote);

--- a/scripts/fame-swap-route-lab.ts
+++ b/scripts/fame-swap-route-lab.ts
@@ -45,12 +45,19 @@ import { toAsyncQuoteAdapter } from "../src/features/fame-swap/solver/optimizer/
 import {
   famePoolStateRegistryPoolIdsForPair,
   famePoolStateRegistrySourceId,
+  famePoolSupportsCompactQuote,
 } from "../src/features/fame-swap/solver/poolStateRegistry";
+import {
+  FAME_SELECTED_CL_ACTIVATION_CANDIDATE,
+  FAME_SELECTED_LIVE_ROUTE_DEPENDENCY,
+} from "../src/features/fame-swap/solver/poolActivationLedger";
+import type { FameLegQuote } from "../src/features/fame-swap/solver/quotes/adapters";
 import {
   corpusTokenLabel,
   FAME_ROUTE_CORPUS,
   type FameRouteCorpusCase,
 } from "../src/features/fame-swap/solver/routeCorpus";
+import { routeArtifactById } from "../src/features/fame-swap/solver/artifacts";
 import type {
   FameSwapExecutableQuote,
   FameSwapQuote,
@@ -64,11 +71,49 @@ import {
   DEFAULT_FAME_SWAP_SLIPPAGE_BPS,
 } from "../src/features/fame-swap/solver/slippage";
 import { tokenForAddress } from "../src/features/fame-swap/tokens";
+import {
+  displaySafeDiagnosticMessage,
+  redactSensitiveDiagnosticText,
+} from "../src/features/fame-swap/solver/diagnostics";
 
 const ROUTER_ADDRESS =
   "0x0000000000000000000000000000000000000009" as const satisfies Address;
 const RECIPIENT =
   "0x0000000000000000000000000000000000000abc" as const satisfies Address;
+
+export type FameRouteLabSelectedQuoteSourceKind =
+  | "compact-indexed"
+  | "raw-replay-indexed"
+  | "indexed"
+  | "live"
+  | "fork"
+  | "snapshot"
+  | "deterministic-test"
+  | "other";
+
+export interface FameRouteLabSelectedQuoteSource {
+  poolId: string;
+  source: FameRouteLabSelectedQuoteSourceKind;
+  tokenIn: Address;
+  tokenOut: Address;
+  amountIn: string;
+  quoteContextSource: string | null;
+  evidenceId: string | null;
+}
+
+export interface FameRouteLabSelectedActivationSummary {
+  selectedPoolId: typeof FAME_SELECTED_CL_ACTIVATION_CANDIDATE;
+  liveDependencyPoolId: typeof FAME_SELECTED_LIVE_ROUTE_DEPENDENCY;
+  selectedPoolSource: FameRouteLabSelectedQuoteSourceKind | "absent";
+  liveDependencySource: FameRouteLabSelectedQuoteSourceKind | "absent";
+  outcome:
+    | "compact_quote_with_live_dependency"
+    | "raw_replay_with_live_dependency"
+    | "compact_quote_without_live_dependency"
+    | "raw_replay_without_live_dependency"
+    | "selected_pool_live_fallback"
+    | "live_dependency_without_selected_pool";
+}
 
 export interface FameRouteLabRow {
   mode: "deterministic" | "recorded" | "indexed" | "live";
@@ -77,8 +122,12 @@ export interface FameRouteLabRow {
   amountIn: string;
   expectedStatus: string;
   status: string;
+  requestedRouteId: string | null;
+  routeArtifactId: string | null;
   message: string;
   selectedPools: string[];
+  selectedQuoteSources: FameRouteLabSelectedQuoteSource[];
+  selectedActivation: FameRouteLabSelectedActivationSummary | null;
   quoteContext: string | null;
   feeBreakdown: {
     routerFeeAmount: string | null;
@@ -180,6 +229,7 @@ interface RouteLabClient {
 
 interface RouteLabOptions {
   candidateBudgets?: Partial<FameRouteCandidateBudgets>;
+  requestedRouteId?: string;
 }
 
 interface IndexedRouteLabOptions extends RouteLabOptions {
@@ -193,6 +243,7 @@ export async function runSnapshotRouteLab(
   corpus: readonly FameRouteCorpusCase[] = FAME_ROUTE_CORPUS,
   options: RouteLabOptions = {},
 ): Promise<FameRouteLabRow[]> {
+  assertRouteLabRequestedRouteArtifact(options.requestedRouteId);
   const adapter = createSnapshotQuoteAdapter();
   const rows: FameRouteLabRow[] = [];
   for (const entry of corpus) {
@@ -219,6 +270,7 @@ export async function runSnapshotRouteLab(
         routerAddress: ROUTER_ADDRESS,
         feePpm: 2_222n,
       },
+      requestedRouteId: options.requestedRouteId,
       now: new Date("2026-05-13T00:00:00Z"),
       adapter: toAsyncQuoteAdapter(adapter),
     });
@@ -235,8 +287,12 @@ export async function runSnapshotRouteLab(
       amountIn: entry.amountIn.toString(),
       expectedStatus: expectedStatusFor(entry, "recorded"),
       status: quote.status,
+      requestedRouteId: options.requestedRouteId ?? null,
+      routeArtifactId: quote.status === "ready" ? quote.routeArtifactId : null,
       message: displaySafeDiagnosticMessage(quote.message),
       selectedPools: quote.status === "ready" ? quote.poolIds : [],
+      selectedQuoteSources: selectedQuoteSources(quote),
+      selectedActivation: selectedActivationSummary(quote),
       quoteContext: quoteContextLabel(quote),
       feeBreakdown:
         quote.status === "ready"
@@ -278,6 +334,45 @@ export async function runSnapshotRouteLab(
   return rows;
 }
 
+function routeLabIndexedPoolIdsForRequest(
+  entry: FameRouteCorpusCase,
+  requestedRouteId: string | undefined,
+): string[] {
+  const pairPoolIds = famePoolStateRegistryPoolIdsForPair(
+    entry.tokenIn,
+    entry.tokenOut,
+  );
+  if (!requestedRouteId) return pairPoolIds;
+
+  const artifact = routeArtifactById(requestedRouteId);
+  if (!artifact) {
+    throw new Error(
+      `Route lab --route requires a pinned route artifact id; received ${requestedRouteId}.`,
+    );
+  }
+  if (
+    !sameRouteAddress(entry.tokenIn, artifact.route.tokenIn) ||
+    !sameRouteAddress(entry.tokenOut, artifact.route.tokenOut)
+  ) {
+    return [];
+  }
+
+  return artifact.poolIds.filter((poolId) =>
+    famePoolSupportsCompactQuote(poolId),
+  );
+}
+
+function assertRouteLabRequestedRouteArtifact(
+  requestedRouteId: string | undefined,
+) {
+  if (!requestedRouteId) return;
+  if (!routeArtifactById(requestedRouteId)) {
+    throw new Error(
+      `Route lab --route requires a pinned route artifact id; received ${requestedRouteId}.`,
+    );
+  }
+}
+
 function currentBlockForIndexedState(
   adapter: Awaited<ReturnType<typeof createLiveLiquidityQuoteAdapter>>,
 ): number | null {
@@ -296,6 +391,7 @@ export async function runIndexedRouteLab(
   corpus: readonly FameRouteCorpusCase[] = FAME_ROUTE_CORPUS,
   options: IndexedRouteLabOptions,
 ): Promise<FameRouteLabRow[]> {
+  assertRouteLabRequestedRouteArtifact(options.requestedRouteId);
   const fallbackAdapter =
     options.fallbackAdapter ??
     toAsyncQuoteAdapter(createSnapshotQuoteAdapter());
@@ -321,9 +417,9 @@ export async function runIndexedRouteLab(
       currentBlock,
       maxFreshnessBlocks: options.maxFreshnessBlocks,
       stateSurfaces: ["cl-replay-v1"],
-      poolIds: famePoolStateRegistryPoolIdsForPair(
-        entry.tokenIn,
-        entry.tokenOut,
+      poolIds: routeLabIndexedPoolIdsForRequest(
+        entry,
+        options.requestedRouteId,
       ),
     });
     const reserveAdapter = createIndexedReserveQuoteAdapter({
@@ -335,7 +431,7 @@ export async function runIndexedRouteLab(
       indexedState,
       fallback: reserveAdapter,
       expectedSourceRegistryId,
-      mode: "shadow",
+      mode: "local",
     });
     const quote = await quoteFameSwapAsync({
       tokenIn: token(entry.tokenIn),
@@ -352,6 +448,7 @@ export async function runIndexedRouteLab(
         routerAddress: ROUTER_ADDRESS,
         feePpm: 2_222n,
       },
+      requestedRouteId: options.requestedRouteId,
       now: new Date("2026-05-13T00:00:00Z"),
       adapter,
     });
@@ -368,8 +465,12 @@ export async function runIndexedRouteLab(
       amountIn: entry.amountIn.toString(),
       expectedStatus: expectedStatusFor(entry, "indexed"),
       status: quote.status,
+      requestedRouteId: options.requestedRouteId ?? null,
+      routeArtifactId: quote.status === "ready" ? quote.routeArtifactId : null,
       message: displaySafeDiagnosticMessage(quote.message),
       selectedPools: quote.status === "ready" ? quote.poolIds : [],
+      selectedQuoteSources: selectedQuoteSources(quote),
+      selectedActivation: selectedActivationSummary(quote),
       quoteContext: quoteContextLabel(quote),
       feeBreakdown:
         quote.status === "ready"
@@ -424,6 +525,84 @@ function quoteContextLabel(quote: FameSwapQuote): string | null {
     case "deterministic_test":
       return `deterministic-test:${quote.quoteContext.profileId}`;
   }
+}
+
+function selectedQuoteEvidenceId(leg: FameLegQuote): string | null {
+  if (leg.indexedEvidence?.evidenceId) return leg.indexedEvidence.evidenceId;
+  const snapshotMatch = /\bsnapshot\s+([A-Za-z0-9_.:-]+)/u.exec(leg.evidence);
+  if (snapshotMatch?.[1]) return snapshotMatch[1];
+  const blockMatch = /\bobserved through block\s+([0-9]+)/u.exec(leg.evidence);
+  if (blockMatch?.[1]) return blockMatch[1];
+  return null;
+}
+
+function selectedQuoteSourceKind(
+  leg: FameLegQuote,
+): FameRouteLabSelectedQuoteSourceKind {
+  const source = leg.quoteContext?.source;
+  if (source === "indexed") {
+    if (leg.indexedEvidence?.kind === "compact-quote") return "compact-indexed";
+    if (leg.indexedEvidence?.kind === "raw-replay") return "raw-replay-indexed";
+    return "indexed";
+  }
+  if (source === "live") return "live";
+  if (source === "fork") return "fork";
+  if (source === "snapshot") return "snapshot";
+  if (source === "deterministic_test") return "deterministic-test";
+  return "other";
+}
+
+function selectedQuoteSources(
+  quote: FameSwapQuote,
+): FameRouteLabSelectedQuoteSource[] {
+  if (quote.status !== "ready") return [];
+  return quote.feeBreakdown.legs.map((leg) => ({
+    poolId: leg.poolId,
+    source: selectedQuoteSourceKind(leg),
+    tokenIn: leg.tokenIn,
+    tokenOut: leg.tokenOut,
+    amountIn: leg.amountIn.toString(),
+    quoteContextSource: leg.quoteContext?.source ?? null,
+    evidenceId: selectedQuoteEvidenceId(leg),
+  }));
+}
+
+function selectedActivationSummary(
+  quote: FameSwapQuote,
+): FameRouteLabSelectedActivationSummary | null {
+  const sources = selectedQuoteSources(quote);
+  const selectedPool = sources.find(
+    (leg) => leg.poolId === FAME_SELECTED_CL_ACTIVATION_CANDIDATE,
+  );
+  const liveDependency = sources.find(
+    (leg) => leg.poolId === FAME_SELECTED_LIVE_ROUTE_DEPENDENCY,
+  );
+  if (!selectedPool && !liveDependency) return null;
+
+  const selectedPoolSource = selectedPool?.source ?? "absent";
+  const liveDependencySource = liveDependency?.source ?? "absent";
+  const dependencyIsLive =
+    liveDependencySource === "live" || liveDependencySource === "fork";
+  const outcome =
+    selectedPoolSource === "compact-indexed" && dependencyIsLive
+      ? "compact_quote_with_live_dependency"
+      : selectedPoolSource === "raw-replay-indexed" && dependencyIsLive
+        ? "raw_replay_with_live_dependency"
+        : selectedPoolSource === "compact-indexed"
+          ? "compact_quote_without_live_dependency"
+          : selectedPoolSource === "raw-replay-indexed"
+            ? "raw_replay_without_live_dependency"
+            : selectedPool
+              ? "selected_pool_live_fallback"
+              : "live_dependency_without_selected_pool";
+
+  return {
+    selectedPoolId: FAME_SELECTED_CL_ACTIVATION_CANDIDATE,
+    liveDependencyPoolId: FAME_SELECTED_LIVE_ROUTE_DEPENDENCY,
+    selectedPoolSource,
+    liveDependencySource,
+    outcome,
+  };
 }
 
 function routeEdgeMatrix(
@@ -579,34 +758,8 @@ function pairLabel(entry: FameRouteCorpusCase): string {
   return `${corpusTokenLabel(entry.tokenIn)}->${corpusTokenLabel(entry.tokenOut)}`;
 }
 
-function redactSensitiveDiagnosticText(value: string): string {
-  return value
-    .replace(/(?:https?|wss?):\/\/\S+/g, "[redacted-url]")
-    .replace(/\b(?:bearer|token)\s+[a-z0-9._~+/=-]+/gi, "[redacted-secret]")
-    .replace(/0x[a-fA-F0-9]{64,}/g, "[redacted-hex]");
-}
-
 function displaySafeAccountLabel(address: Address): string {
   return `${address.slice(0, 6)}...${address.slice(-4)}`;
-}
-
-function displaySafeDiagnosticMessage(
-  value: unknown,
-  fallback = "Route diagnostic unavailable.",
-): string {
-  const raw = value instanceof Error ? value.message : String(value);
-  return redactSensitiveDiagnosticText(
-    raw
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .find(
-        (line) =>
-          line.length > 0 &&
-          !/\b(request body|calldata|approval|swap request|private key|signer|authorization|api[-_ ]?key)\b|(?:^|\s)secret(?:[-_ ]?(?:key|token))?\s*[:=]/i.test(
-            line,
-          ),
-      ) ?? fallback,
-  );
 }
 
 function displaySafeErrorMessage(error: unknown): string {
@@ -808,6 +961,7 @@ export async function runRouteLab(
   corpus: readonly FameRouteCorpusCase[] = FAME_ROUTE_CORPUS,
   options: RouteLabOptions = {},
 ): Promise<FameRouteLabRow[]> {
+  assertRouteLabRequestedRouteArtifact(options.requestedRouteId);
   const adapter = createDeterministicQuoteAdapter();
   const rows: FameRouteLabRow[] = [];
   for (const entry of corpus) {
@@ -835,6 +989,7 @@ export async function runRouteLab(
         feePpm: 2_222n,
       },
       optimizerMode: "disabled",
+      requestedRouteId: options.requestedRouteId,
       now: new Date("2026-05-13T00:00:00Z"),
       adapter: toAsyncQuoteAdapter(adapter),
     });
@@ -851,8 +1006,12 @@ export async function runRouteLab(
       amountIn: entry.amountIn.toString(),
       expectedStatus: expectedStatusFor(entry, "deterministic"),
       status: quote.status,
+      requestedRouteId: options.requestedRouteId ?? null,
+      routeArtifactId: quote.status === "ready" ? quote.routeArtifactId : null,
       message: displaySafeDiagnosticMessage(quote.message),
       selectedPools: quote.status === "ready" ? quote.poolIds : [],
+      selectedQuoteSources: selectedQuoteSources(quote),
+      selectedActivation: selectedActivationSummary(quote),
       quoteContext: quoteContextLabel(quote),
       feeBreakdown:
         quote.status === "ready"
@@ -898,6 +1057,7 @@ export async function runLiveRouteLab(
   corpus: readonly FameRouteCorpusCase[] = FAME_ROUTE_CORPUS,
   options: RouteLabOptions & { simulate?: boolean } = {},
 ): Promise<FameRouteLabRow[]> {
+  assertRouteLabRequestedRouteArtifact(options.requestedRouteId);
   const config = getFameSwapConfig();
   const rpcUrl =
     process.env.BASE_RPC_URL ?? process.env.NEXT_PUBLIC_BASE_RPC_URL_1;
@@ -951,6 +1111,7 @@ export async function runLiveRouteLab(
         routerAddress,
         feePpm: 2_222n,
       },
+      requestedRouteId: options.requestedRouteId,
       now: new Date("2026-05-13T00:00:00Z"),
       adapter,
     });
@@ -968,8 +1129,12 @@ export async function runLiveRouteLab(
       amountIn: entry.amountIn.toString(),
       expectedStatus: expectedStatusFor(entry, "live"),
       status: quote.status,
+      requestedRouteId: options.requestedRouteId ?? null,
+      routeArtifactId: quote.status === "ready" ? quote.routeArtifactId : null,
       message: displaySafeDiagnosticMessage(quote.message),
       selectedPools: quote.status === "ready" ? quote.poolIds : [],
+      selectedQuoteSources: selectedQuoteSources(quote),
+      selectedActivation: selectedActivationSummary(quote),
       quoteContext: quoteContextLabel(quote),
       feeBreakdown:
         quote.status === "ready"
@@ -1027,6 +1192,8 @@ export function formatRouteLabMarkdown(
       `- Status: ${row.status}`,
       `- Expected: ${row.expectedStatus}`,
       `- Selected pools: ${row.selectedPools.join(", ") || "none"}`,
+      `- Selected quote sources: ${selectedQuoteSourcesSummary(row)}`,
+      `- Selected activation: ${selectedActivationSummaryLine(row.selectedActivation)}`,
       `- Quote context: ${row.quoteContext ?? "n/a"}`,
       `- Router fee amount: ${row.feeBreakdown.routerFeeAmount ?? "n/a"}`,
       `- Venue fees included in quotes: ${String(
@@ -1068,6 +1235,24 @@ export function formatRouteLabMarkdown(
         : "",
     ]),
   ].join("\n");
+}
+
+function selectedQuoteSourcesSummary(row: FameRouteLabRow): string {
+  if (row.selectedQuoteSources.length === 0) return "none";
+  return row.selectedQuoteSources
+    .map((entry) => `${entry.poolId} ${entry.source}`)
+    .join("; ");
+}
+
+function selectedActivationSummaryLine(
+  summary: FameRouteLabSelectedActivationSummary | null,
+): string {
+  if (!summary) return "not applicable";
+  return [
+    summary.outcome,
+    `${summary.selectedPoolId} ${summary.selectedPoolSource}`,
+    `${summary.liveDependencyPoolId} ${summary.liveDependencySource}`,
+  ].join(", ");
 }
 
 function optimizerSummaryLine(optimizer: FameRouteLabRow["optimizer"]): string {
@@ -1269,6 +1454,40 @@ function formatProtocolCoverageMarkdown(
   ];
 }
 
+function sameRouteAddress(left: Address, right: Address): boolean {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+function routeLabRequestedRouteIdFromArgs(): string | undefined {
+  const routeArgIndex = process.argv.indexOf("--route");
+  if (routeArgIndex >= 0) {
+    const value = process.argv[routeArgIndex + 1];
+    if (!value) throw new Error("--route requires a route id.");
+    return value;
+  }
+  return process.env.FAME_SWAP_ROUTE_LAB_ROUTE_ID?.trim() || undefined;
+}
+
+function routeLabCorpusForRequestedRoute(
+  corpus: readonly FameRouteCorpusCase[],
+  requestedRouteId: string | undefined,
+): readonly FameRouteCorpusCase[] {
+  if (!requestedRouteId) return corpus;
+  const artifact = routeArtifactById(requestedRouteId);
+  if (!artifact) return corpus;
+  const filtered = corpus.filter(
+    (entry) =>
+      sameRouteAddress(entry.tokenIn, artifact.route.tokenIn) &&
+      sameRouteAddress(entry.tokenOut, artifact.route.tokenOut),
+  );
+  if (filtered.length === 0) {
+    throw new Error(
+      `No route-lab corpus case matches requested route ${requestedRouteId}.`,
+    );
+  }
+  return filtered;
+}
+
 function shouldRunCli(): boolean {
   return process.argv[1]?.endsWith("fame-swap-route-lab.ts") ?? false;
 }
@@ -1345,6 +1564,27 @@ function optionalSafeIntegerEnv(name: string): number | undefined {
   return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : undefined;
 }
 
+async function routeLabIndexedFallbackAdapterFromEnv(): Promise<
+  IndexedRouteLabOptions["fallbackAdapter"] | undefined
+> {
+  const rpcUrl = process.env.BASE_RPC_URL;
+  if (!rpcUrl) return undefined;
+  const client = createPublicClient({
+    chain: base,
+    transport: http(rpcUrl),
+  });
+  return createLiveLiquidityQuoteAdapter({
+    client: {
+      getBlockNumber: () => client.getBlockNumber(),
+      readContract: (request) =>
+        client.readContract(
+          request as Parameters<typeof client.readContract>[0],
+        ) as Promise<unknown>,
+    },
+    chainId: base.id,
+  });
+}
+
 async function routeLabIndexedCurrentBlockFromEnv(): Promise<number> {
   const explicitCurrentBlock = optionalSafeIntegerEnv(
     "FAME_POOL_STATE_CURRENT_BLOCK",
@@ -1373,21 +1613,29 @@ async function routeLabIndexedCurrentBlockFromEnv(): Promise<number> {
 
 if (shouldRunCli()) {
   const run = async () => {
+    const requestedRouteId = routeLabRequestedRouteIdFromArgs();
+    const corpus = routeLabCorpusForRequestedRoute(
+      FAME_ROUTE_CORPUS,
+      requestedRouteId,
+    );
     const rows = process.argv.includes("--live")
-      ? await runLiveRouteLab(undefined, {
+      ? await runLiveRouteLab(corpus, {
+          requestedRouteId,
           simulate: process.argv.includes("--simulate"),
         })
       : process.argv.includes("--indexed")
-        ? await runIndexedRouteLab(undefined, {
+        ? await runIndexedRouteLab(corpus, {
+            requestedRouteId,
             poolStateClient: routeLabIndexedPoolStateClientFromEnv(),
+            fallbackAdapter: await routeLabIndexedFallbackAdapterFromEnv(),
             currentBlock: await routeLabIndexedCurrentBlockFromEnv(),
             maxFreshnessBlocks: optionalSafeIntegerEnv(
               "FAME_POOL_STATE_MAX_FRESHNESS_BLOCKS",
             ),
           })
         : process.argv.includes("--deterministic")
-          ? await runRouteLab()
-          : await runSnapshotRouteLab();
+          ? await runRouteLab(corpus, { requestedRouteId })
+          : await runSnapshotRouteLab(corpus, { requestedRouteId });
     if (process.argv.includes("--markdown")) {
       console.log(formatRouteLabMarkdown(rows));
     } else {

--- a/src/app/[network]/fameus/ChainSelector.tsx
+++ b/src/app/[network]/fameus/ChainSelector.tsx
@@ -14,9 +14,10 @@ import Typography from "@mui/material/Typography";
 import CheckIcon from "@mui/icons-material/CheckCircle";
 import IconButton from "@mui/material/IconButton";
 import Tooltip from "@mui/material/Tooltip";
-import { useChainId, useSwitchChain } from "wagmi";
+import { useSwitchChain } from "wagmi";
 import type { SxProps, TooltipProps } from "@mui/material";
 import { Chain } from "viem";
+import { useAccount } from "@/hooks/useAccount";
 
 export type TChain = Chain & {
   chainImageUrl: string;
@@ -33,7 +34,7 @@ export function decorateChainImageUrl(chain?: Chain): string {
     case 5:
       chainImageUrl = "/images/chains/goerli.png";
       break;
-    case 8543:
+    case 8453:
       chainImageUrl = "/images/chains/base.png";
       break;
     default:
@@ -122,7 +123,7 @@ export const ChainSelector: FC<{
 }> = ({ assetPrefix, sx, tooltipProps }) => {
   const [menuAnchorEl, setMenuAnchorEl] = useState<Element | null>(null);
 
-  const chainId = useChainId();
+  const { chainId } = useAccount();
 
   const { chains, error, switchChain, isPending } = useSwitchChain();
   const handleMenu = useCallback((event: MouseEvent) => {

--- a/src/app/[network]/profile/claim/page.tsx
+++ b/src/app/[network]/profile/claim/page.tsx
@@ -1,9 +1,8 @@
 import { RedirectType, redirect } from "next/navigation";
 import { AppMain } from "@/layouts/AppMain";
 import { ClaimNameForm } from "@/features/naming/components/ClaimNameForm";
+import { LinkButton } from "@/components/LinkButton";
 import Container from "@mui/material/Container";
-import Link from "next/link";
-import Button from "@mui/material/Button";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 
 export default async function ClaimNamePage(
@@ -38,15 +37,14 @@ export default async function ClaimNamePage(
       title="Claim Your Name"
       mobileTitle="Claim"
       headerLeft={
-        <Button
-          component={Link}
+        <LinkButton
           href={`/${network}/~`}
           startIcon={<ArrowBackIcon />}
           size="small"
           sx={{ ml: 2 }}
         >
           All Names
-        </Button>
+        </LinkButton>
       }
     >
       <Container maxWidth="sm" sx={{ py: 4 }}>

--- a/src/app/[network]/profile/edit/[identifier]/layout.tsx
+++ b/src/app/[network]/profile/edit/[identifier]/layout.tsx
@@ -1,9 +1,8 @@
 import type { ReactNode } from "react";
 import { RedirectType, redirect } from "next/navigation";
 import { AppMain } from "@/layouts/AppMain";
+import { LinkButton } from "@/components/LinkButton";
 import Container from "@mui/material/Container";
-import Link from "next/link";
-import Button from "@mui/material/Button";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import {
   resolveNetwork,
@@ -37,15 +36,14 @@ export default async function EditProfileLayout(
       title="Edit Profile"
       mobileTitle="Edit Profile"
       headerLeft={
-        <Button
-          component={Link}
+        <LinkButton
           href={`/${network}/~/${encodeIdentifier(normalize(name))}`}
           startIcon={<ArrowBackIcon />}
           size="small"
           sx={{ ml: 2 }}
         >
           Back to Profile
-        </Button>
+        </LinkButton>
       }
     >
       <Container maxWidth="md" sx={{ py: 4 }}>

--- a/src/app/[network]/~/[identifier]/page.tsx
+++ b/src/app/[network]/~/[identifier]/page.tsx
@@ -1,9 +1,8 @@
 import { RedirectType, redirect } from "next/navigation";
 import { AppMain } from "@/layouts/AppMain";
 import { PublicProfileView } from "@/features/naming/components/PublicProfileView";
+import { LinkButton } from "@/components/LinkButton";
 import Container from "@mui/material/Container";
-import Link from "next/link";
-import Button from "@mui/material/Button";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import {
   resolveNetwork,
@@ -32,15 +31,14 @@ export default async function PublicProfilePage(
       title="Profile"
       mobileTitle="Profile"
       headerLeft={
-        <Button
-          component={Link}
+        <LinkButton
           href={`/${network}/~/`}
           startIcon={<ArrowBackIcon />}
           size="small"
           sx={{ ml: 2 }}
         >
           All Names
-        </Button>
+        </LinkButton>
       }
     >
       <Container maxWidth="md" sx={{ py: 4 }}>

--- a/src/app/api/fame/swap/quote/handler.ts
+++ b/src/app/api/fame/swap/quote/handler.ts
@@ -3,6 +3,7 @@ import { createPublicClient, http, isAddress, type Address } from "viem";
 import { base } from "viem/chains";
 import { FAME_SWAP_ARTIFACT_MANIFEST } from "@/features/fame-swap/artifacts/manifest";
 import { getFameSwapConfig } from "@/features/fame-swap/config";
+import { routeArtifactById } from "@/features/fame-swap/solver/artifacts";
 import { fameRouterAbi } from "@/features/fame-swap/router/abi";
 import {
   quoteFameSwap,
@@ -14,8 +15,15 @@ import {
   famePoolStateRegistrySourceId,
   famePoolSupportsCompactQuote,
 } from "@/features/fame-swap/solver/poolStateRegistry";
+import {
+  FAME_SELECTED_CL_ACTIVATION_CANDIDATE,
+  FAME_SELECTED_LIVE_ROUTE_DEPENDENCY,
+} from "@/features/fame-swap/solver/poolActivationLedger";
 import { serializeFameSwapQuoteResponse } from "@/features/fame-swap/solver/quoteWire";
-import type { FameAsyncQuoteAdapter } from "@/features/fame-swap/solver/quotes/adapters";
+import type {
+  FameAsyncQuoteAdapter,
+  FameLegQuote,
+} from "@/features/fame-swap/solver/quotes/adapters";
 import {
   createIndexedQuoteApiClient,
   type FamePoolQuoteClient,
@@ -38,6 +46,7 @@ import {
 } from "@/features/fame-swap/solver/readiness";
 import { normalizeSlippageBps } from "@/features/fame-swap/solver/slippage";
 import { deadlineMinutesToSeconds } from "@/features/fame-swap/solver/deadline";
+import { displaySafeDiagnosticMessage } from "@/features/fame-swap/solver/diagnostics";
 import { tokenForAddress } from "@/features/fame-swap/tokens";
 import type {
   FameSwapQuote,
@@ -66,6 +75,7 @@ interface ParsedQuoteBody {
   routerAddress?: Address;
   slippageBps?: number;
   deadlineMinutes?: number;
+  routeId?: string;
   includeDebug: boolean;
 }
 
@@ -111,7 +121,13 @@ interface QuoteApiClientConfig {
 
 interface QuoteApiSelectedRouteLegDebug {
   poolId: string;
-  source: "compact_quote" | "live" | "fork" | "snapshot" | "other";
+  source:
+    | "compact_quote"
+    | "raw_replay"
+    | "live"
+    | "fork"
+    | "snapshot"
+    | "other";
   quoteContextSource?: string;
   evidenceId?: string;
   currentBlock?: number;
@@ -119,10 +135,25 @@ interface QuoteApiSelectedRouteLegDebug {
   effectiveMaxFreshnessBlocks?: number;
 }
 
+interface QuoteApiSelectedRouteActivationDebug {
+  selectedPoolId: typeof FAME_SELECTED_CL_ACTIVATION_CANDIDATE;
+  liveDependencyPoolId: typeof FAME_SELECTED_LIVE_ROUTE_DEPENDENCY;
+  selectedPoolSource: QuoteApiSelectedRouteLegDebug["source"] | "absent";
+  liveDependencySource: QuoteApiSelectedRouteLegDebug["source"] | "absent";
+  outcome:
+    | "compact_quote_with_live_dependency"
+    | "raw_replay_with_live_dependency"
+    | "compact_quote_without_live_dependency"
+    | "raw_replay_without_live_dependency"
+    | "selected_pool_live_fallback"
+    | "live_dependency_without_selected_pool";
+}
+
 interface QuoteApiSelectedRouteDebug {
   compactQuoteLegs: number;
   liveLegs: number;
   otherLegs: number;
+  activation?: QuoteApiSelectedRouteActivationDebug;
   legs: QuoteApiSelectedRouteLegDebug[];
 }
 
@@ -208,6 +239,17 @@ function parseQuoteBody(value: unknown): ParsedQuoteBody | string {
     return "amountIn must fit within uint256.";
   }
 
+  if (body.routeId !== undefined) {
+    if (
+      typeof body.routeId !== "string" ||
+      body.routeId.length > 160 ||
+      !/^[A-Za-z0-9_.:-]+$/u.test(body.routeId) ||
+      !routeArtifactById(body.routeId)
+    ) {
+      return "routeId must be a pinned route artifact id.";
+    }
+  }
+
   if (body.recipient !== undefined && body.recipient !== null) {
     if (typeof body.recipient !== "string" || !isAddress(body.recipient)) {
       return "recipient must be an address when provided.";
@@ -244,27 +286,13 @@ function parseQuoteBody(value: unknown): ParsedQuoteBody | string {
       Number.isFinite(body.deadlineMinutes)
         ? body.deadlineMinutes
         : undefined,
+    routeId: typeof body.routeId === "string" ? body.routeId : undefined,
     includeDebug: body.includeDebug === true,
   };
 }
 
 function displaySafeErrorMessage(error: unknown): string {
-  const raw = error instanceof Error ? error.message : String(error);
-  return (
-    raw
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .find(
-        (line) =>
-          line.length > 0 &&
-          !/\b(request body|calldata|approval|swap request|private key|signer|authorization|api[-_ ]?key)\b|(?:^|\s)secret(?:[-_ ]?(?:key|token))?\s*[:=]/i.test(
-            line,
-          ),
-      ) ?? "FAME quote request failed."
-  )
-    .replace(/(?:https?|wss?):\/\/\S+/g, "[redacted-url]")
-    .replace(/\b(?:bearer|token)\s+[a-z0-9._~+/=-]+/gi, "[redacted-secret]")
-    .replace(/0x[a-fA-F0-9]{64,}/g, "[redacted-hex]");
+  return displaySafeDiagnosticMessage(error);
 }
 
 function baseRpcUrl(): string | undefined {
@@ -540,21 +568,64 @@ async function maybeWrapIndexedQuoteAdapter(options: {
 }
 
 function quoteApiSelectedLegSource(
-  source: string | undefined,
+  leg: FameLegQuote,
 ): QuoteApiSelectedRouteLegDebug["source"] {
-  if (source === "indexed") return "compact_quote";
+  const source = leg.quoteContext?.source;
+  if (source === "indexed") {
+    return leg.indexedEvidence?.kind === "raw-replay"
+      ? "raw_replay"
+      : "compact_quote";
+  }
   if (source === "live") return "live";
   if (source === "fork") return "fork";
   if (source === "snapshot") return "snapshot";
   return "other";
 }
 
-function selectedQuoteApiEvidenceId(evidence: string): string | undefined {
-  const snapshotMatch = /\bsnapshot\s+([A-Za-z0-9_.:-]+)/u.exec(evidence);
+function selectedQuoteApiEvidenceId(leg: FameLegQuote): string | undefined {
+  if (leg.indexedEvidence?.evidenceId) return leg.indexedEvidence.evidenceId;
+  const snapshotMatch = /\bsnapshot\s+([A-Za-z0-9_.:-]+)/u.exec(leg.evidence);
   if (snapshotMatch?.[1]) return snapshotMatch[1];
-  const blockMatch = /\bobserved through block\s+([0-9]+)/u.exec(evidence);
+  const blockMatch = /\bobserved through block\s+([0-9]+)/u.exec(leg.evidence);
   if (blockMatch?.[1]) return blockMatch[1];
   return undefined;
+}
+
+function quoteApiSelectedRouteActivationDebug(
+  legs: readonly QuoteApiSelectedRouteLegDebug[],
+): QuoteApiSelectedRouteActivationDebug | undefined {
+  const selectedPool = legs.find(
+    (leg) => leg.poolId === FAME_SELECTED_CL_ACTIVATION_CANDIDATE,
+  );
+  const liveDependency = legs.find(
+    (leg) => leg.poolId === FAME_SELECTED_LIVE_ROUTE_DEPENDENCY,
+  );
+  if (!selectedPool && !liveDependency) return undefined;
+
+  const selectedPoolSource = selectedPool?.source ?? "absent";
+  const liveDependencySource = liveDependency?.source ?? "absent";
+  const liveDependencyIsLive =
+    liveDependencySource === "live" || liveDependencySource === "fork";
+  const outcome =
+    selectedPoolSource === "compact_quote" && liveDependencyIsLive
+      ? "compact_quote_with_live_dependency"
+      : selectedPoolSource === "raw_replay" && liveDependencyIsLive
+        ? "raw_replay_with_live_dependency"
+        : selectedPoolSource === "compact_quote"
+          ? "compact_quote_without_live_dependency"
+          : selectedPoolSource === "raw_replay"
+            ? "raw_replay_without_live_dependency"
+            : selectedPool
+              ? "selected_pool_live_fallback"
+              : "live_dependency_without_selected_pool";
+
+  return {
+    selectedPoolId: FAME_SELECTED_CL_ACTIVATION_CANDIDATE,
+    liveDependencyPoolId: FAME_SELECTED_LIVE_ROUTE_DEPENDENCY,
+    selectedPoolSource,
+    liveDependencySource,
+    outcome,
+  };
 }
 
 function quoteApiSelectedRouteDebug(
@@ -566,7 +637,7 @@ function quoteApiSelectedRouteDebug(
   let liveLegs = 0;
   let otherLegs = 0;
   const legs = quote.feeBreakdown.legs.map((leg) => {
-    const source = quoteApiSelectedLegSource(leg.quoteContext?.source);
+    const source = quoteApiSelectedLegSource(leg);
     if (source === "compact_quote") compactQuoteLegs += 1;
     else if (source === "live" || source === "fork") liveLegs += 1;
     else otherLegs += 1;
@@ -576,8 +647,8 @@ function quoteApiSelectedRouteDebug(
       source,
       quoteContextSource: leg.quoteContext?.source,
       evidenceId:
-        source === "compact_quote"
-          ? selectedQuoteApiEvidenceId(leg.evidence)
+        source === "compact_quote" || source === "raw_replay"
+          ? selectedQuoteApiEvidenceId(leg)
           : undefined,
       currentBlock:
         leg.quoteContext?.source === "indexed"
@@ -593,11 +664,13 @@ function quoteApiSelectedRouteDebug(
           : undefined,
     };
   });
+  const activation = quoteApiSelectedRouteActivationDebug(legs);
 
   return {
     compactQuoteLegs,
     liveLegs,
     otherLegs,
+    ...(activation === undefined ? {} : { activation }),
     legs,
   };
 }
@@ -727,6 +800,14 @@ async function readinessForQuote(routerAddress: Address | null) {
   return readiness;
 }
 
+function localQuoteDebugAllowed(request: NextRequest): boolean {
+  if (process.env.NODE_ENV === "production") return false;
+  const hostname = request.nextUrl.hostname.toLowerCase();
+  return (
+    hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1"
+  );
+}
+
 function publicClientForQuote() {
   const rpcUrl = baseRpcUrl();
   if (!rpcUrl) return null;
@@ -804,6 +885,7 @@ export async function handleFameSwapQuotePost(
       typeof parsedBody.deadlineMinutes === "number"
         ? deadlineMinutesToSeconds(parsedBody.deadlineMinutes)
         : undefined,
+    requestedRouteId: parsedBody.routeId,
   };
 
   let quoteApiDebugOutput: QuoteApiHelperDebug | undefined;
@@ -915,14 +997,21 @@ export async function handleFameSwapQuotePost(
     };
   });
 
-  return json(
-    serializeFameSwapQuoteResponse(quote, {
-      includeDebug: parsedBody.includeDebug,
-      debug: quoteApiDebugOutput
-        ? {
-            quoteApi: quoteApiDebugOutput,
-          }
-        : undefined,
+  const includeLocalDebug =
+    parsedBody.includeDebug && localQuoteDebugAllowed(request);
+
+  return json({
+    ...serializeFameSwapQuoteResponse(quote, {
+      includeDebug: includeLocalDebug,
+      debug:
+        includeLocalDebug && quoteApiDebugOutput
+          ? {
+              quoteApi: quoteApiDebugOutput,
+            }
+          : undefined,
     }),
-  );
+    ...(parsedBody.includeDebug && !includeLocalDebug
+      ? { debugUnavailable: { reason: "local_dev_only" } }
+      : {}),
+  });
 }

--- a/src/app/api/fame/swap/quote/handler.ts
+++ b/src/app/api/fame/swap/quote/handler.ts
@@ -513,7 +513,7 @@ async function maybeWrapIndexedQuoteAdapter(options: {
   const poolIds = famePoolStateRegistryPoolIdsForPair(
     options.tokenIn,
     options.tokenOut,
-  ).filter(famePoolSupportsCompactQuote);
+  ).filter((poolId) => famePoolSupportsCompactQuote(poolId));
   if (poolIds.length === 0) {
     return result(options.adapter, "no_registered_pools", 0);
   }

--- a/src/app/api/fame/swap/quote/route.test.ts
+++ b/src/app/api/fame/swap/quote/route.test.ts
@@ -18,8 +18,13 @@ import type {
 import { handleFameSwapQuotePost } from "./handler";
 import { POST } from "./route";
 
-function request(body: unknown): NextRequest {
-  return new NextRequest("http://localhost/api/fame/swap/quote", {
+const BASEDFLICK = "0x15e012abf9d32cd67fc6cf480ea0e318e9ed5926" as const;
+
+function request(
+  body: unknown,
+  url = "http://localhost/api/fame/swap/quote",
+): NextRequest {
+  return new NextRequest(url, {
     method: "POST",
     body: JSON.stringify(body),
   });
@@ -602,6 +607,106 @@ describe("/api/fame/swap/quote", () => {
     assert.equal(quoteApi.reason, "not_configured");
   });
 
+  it("omits requested debug diagnostics from non-local hosts", async () => {
+    const snapshot = createSnapshotQuoteAdapter();
+    const response = await handleFameSwapQuotePost(
+      request(
+        {
+          tokenIn: WETH,
+          tokenOut: FAME,
+          amountIn: "100000000000000",
+          recipient: "0x0000000000000000000000000000000000000abc",
+          includeDebug: true,
+        },
+        "https://staging.example/api/fame/swap/quote",
+      ),
+      {
+        readinessForQuote: async (routerAddress) => ({
+          status: "ready",
+          routerAddress: routerAddress!,
+          feePpm: 2_222n,
+        }),
+        quoteForRequest: async (quoteRequest) => {
+          const quote = quoteFameSwap({
+            ...quoteRequest,
+            adapter: snapshot,
+          });
+          return quote.status === "ready"
+            ? {
+                ...quote,
+                diagnosticsVisibleByDefault: true,
+              }
+            : quote;
+        },
+        quoteApiClient: null,
+      },
+    );
+    const json: unknown = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.ok(isRecord(json));
+    assert.equal(json.status, "ready");
+    assert.equal("debug" in json, false);
+    assert.deepEqual(json.debugUnavailable, { reason: "local_dev_only" });
+  });
+
+  it("omits requested debug diagnostics outside local dev mode", async () => {
+    const snapshot = createSnapshotQuoteAdapter();
+    const env = process.env as Record<string, string | undefined>;
+    const previousNodeEnv = env.NODE_ENV;
+    env.NODE_ENV = "production";
+
+    try {
+      const response = await handleFameSwapQuotePost(
+        request({
+          tokenIn: WETH,
+          tokenOut: FAME,
+          amountIn: "100000000000000",
+          recipient: "0x0000000000000000000000000000000000000abc",
+          includeDebug: true,
+        }),
+        {
+          readinessForQuote: async (routerAddress) => ({
+            status: "ready",
+            routerAddress: routerAddress!,
+            feePpm: 2_222n,
+          }),
+          quoteAdapterForRequest: async () => ({
+            quoteContext: {
+              source: "live",
+              chainId: 8453,
+              blockNumber: 125n,
+            },
+            async quoteEdge(edgeRequest) {
+              const quote = snapshot.quoteEdge(edgeRequest);
+              return quote.status === "quoted"
+                ? {
+                    ...quote,
+                    context: {
+                      source: "live" as const,
+                      chainId: 8453,
+                      blockNumber: 125n,
+                    },
+                  }
+                : quote;
+            },
+          }),
+          quoteApiClient: null,
+        },
+      );
+      const json: unknown = await response.json();
+
+      assert.equal(response.status, 200);
+      assert.ok(isRecord(json));
+      assert.equal(json.status, "ready");
+      assert.equal("debug" in json, false);
+      assert.deepEqual(json.debugUnavailable, { reason: "local_dev_only" });
+    } finally {
+      if (previousNodeEnv === undefined) delete env.NODE_ENV;
+      else env.NODE_ENV = previousNodeEnv;
+    }
+  });
+
   for (const testCase of [
     {
       name: "timeout",
@@ -847,6 +952,256 @@ describe("/api/fame/swap/quote", () => {
     assert.doesNotMatch(
       JSON.stringify(json),
       /protocolEvidence|reserve0|reserve1/,
+    );
+  });
+
+  it("uses compact selected Slipstream quotes while keeping basedflick/ZORA V4 live", async () => {
+    const deterministic = createDeterministicQuoteAdapter();
+    const quoteRequests: FamePoolQuoteBatchRequest[] = [];
+    const response = await handleFameSwapQuotePost(
+      request({
+        tokenIn: FAME,
+        tokenOut: WETH,
+        amountIn: "31597600141347829",
+        recipient: "0x0000000000000000000000000000000000000abc",
+        includeDebug: true,
+        routeId: "solver-fame-basedflick-zora-weth",
+      }),
+      {
+        readinessForQuote: async (routerAddress) => ({
+          status: "ready",
+          routerAddress: routerAddress!,
+          feePpm: 2_222n,
+        }),
+        quoteAdapterForRequest: async () => ({
+          quoteContext: {
+            source: "live",
+            chainId: 8453,
+            blockNumber: 125n,
+          },
+          async quoteEdge(edgeRequest) {
+            const quote = deterministic.quoteEdge(edgeRequest);
+            return quote.status === "quoted"
+              ? {
+                  ...quote,
+                  context: {
+                    source: "live" as const,
+                    chainId: 8453,
+                    blockNumber: 125n,
+                  },
+                }
+              : quote;
+          },
+        }),
+        quoteApiClient: {
+          async fetchQuotes(quoteRequest) {
+            quoteRequests.push(quoteRequest);
+            return {
+              sourceRegistryId: famePoolStateRegistrySourceId(),
+              currentBlock: quoteRequest.currentBlock,
+              producerMaxFreshnessBlocks: 120,
+              effectiveMaxFreshnessBlocks: 120,
+              quotes: quoteRequest.quotes.map((quote) =>
+                quote.poolId === "slipstream-basedflick-fame"
+                  ? {
+                      status: "quoted" as const,
+                      quoteKind: "cl-quote-v1" as const,
+                      poolId: "slipstream-basedflick-fame",
+                      chainId: 8453,
+                      poolAddress: "0xbd7e5bb5a6251f6dde2cf56afa50ed0c8b4c2cdb",
+                      token0: BASEDFLICK,
+                      token1: FAME,
+                      tokenIn: quote.tokenIn,
+                      tokenOut: quote.tokenOut,
+                      venueFamily: "Slipstream" as const,
+                      tickSpacing: 2000,
+                      amountIn: quote.amountIn,
+                      amountOut: "980100000232613992",
+                      sqrtPriceX96: "79228162514264337593543950",
+                      sqrtPriceX96After: "79228162514264337593543949",
+                      tick: -138163,
+                      liquidity: "1000000000000000000000000000",
+                      fee: "10000",
+                      feeSource: "pool-fee" as const,
+                      observedThroughBlock: 124,
+                      blockHash:
+                        "0x1111111111111111111111111111111111111111111111111111111111111111",
+                      parentHash:
+                        "0x2222222222222222222222222222222222222222222222222222222222222222",
+                      snapshotId: "unit-selected-candidate",
+                      stateHash:
+                        "0x3333333333333333333333333333333333333333333333333333333333333333",
+                      source: "slipstream-pool-state" as const,
+                      sourceRegistryId: famePoolStateRegistrySourceId(),
+                      maxFreshnessBlocks: 120,
+                    }
+                  : {
+                      status: "unavailable" as const,
+                      requested: quote,
+                      reason: "missing-indexed-state" as const,
+                    },
+              ),
+            };
+          },
+        },
+      },
+    );
+    const json: unknown = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.ok(isRecord(json));
+    assert.equal(json.status, "ready");
+    assert.equal(json.routeArtifactId, "solver-fame-basedflick-zora-weth");
+    assert.equal(json.routeSource, "artifact");
+    assert.ok(
+      quoteRequests.some((batch) =>
+        batch.quotes.some(
+          (quote) => quote.poolId === "slipstream-basedflick-fame",
+        ),
+      ),
+    );
+    assert.equal(
+      quoteRequests.some((batch) =>
+        batch.quotes.some(
+          (quote) => quote.poolId === "uniswap-v4-basedflick-zora",
+        ),
+      ),
+      false,
+    );
+    assert.doesNotMatch(
+      JSON.stringify(quoteRequests),
+      /bitmapWords|initializedTicks|stateSurfaces/,
+    );
+
+    const debug = json.debug;
+    assert.ok(isRecord(debug));
+    const quoteApi = debug.quoteApi;
+    assert.ok(isRecord(quoteApi));
+    assert.ok(typeof quoteApi.usedCount === "number" && quoteApi.usedCount > 0);
+    const selectedRoute = quoteApi.selectedRoute;
+    assert.ok(isRecord(selectedRoute));
+    const activation = selectedRoute.activation;
+    assert.ok(isRecord(activation));
+    assert.equal(activation.outcome, "compact_quote_with_live_dependency");
+    assert.equal(activation.selectedPoolSource, "compact_quote");
+    assert.equal(activation.liveDependencySource, "live");
+    const legs = selectedRoute.legs;
+    assert.ok(Array.isArray(legs));
+    assert.ok(
+      legs.some(
+        (leg) =>
+          isRecord(leg) &&
+          leg.poolId === "slipstream-basedflick-fame" &&
+          leg.source === "compact_quote",
+      ),
+    );
+    assert.ok(
+      legs.some(
+        (leg) =>
+          isRecord(leg) &&
+          leg.poolId === "uniswap-v4-basedflick-zora" &&
+          leg.source === "live",
+      ),
+    );
+  });
+
+  it("reports raw replay selected Slipstream attribution only in debug output", async () => {
+    const deterministic = createDeterministicQuoteAdapter();
+    const response = await handleFameSwapQuotePost(
+      request({
+        tokenIn: FAME,
+        tokenOut: WETH,
+        amountIn: "31597600141347829",
+        recipient: "0x0000000000000000000000000000000000000abc",
+        includeDebug: true,
+        routeId: "solver-fame-basedflick-zora-weth",
+      }),
+      {
+        readinessForQuote: async (routerAddress) => ({
+          status: "ready",
+          routerAddress: routerAddress!,
+          feePpm: 2_222n,
+        }),
+        quoteAdapterForRequest: async () => ({
+          quoteContext: {
+            source: "live",
+            chainId: 8453,
+            blockNumber: 125n,
+          },
+          async quoteEdge(edgeRequest) {
+            const quote = deterministic.quoteEdge(edgeRequest);
+            if (quote.status !== "quoted") return quote;
+            if (edgeRequest.edge.poolId === "slipstream-basedflick-fame") {
+              return {
+                ...quote,
+                context: {
+                  source: "indexed" as const,
+                  chainId: 8453,
+                  currentBlock: 125,
+                  sourceRegistryId: famePoolStateRegistrySourceId(),
+                  effectiveMaxFreshnessBlocks: 120,
+                  statusCounts: {
+                    fresh: 1,
+                    stale: 0,
+                    unknown: 0,
+                    unsupported: 0,
+                  },
+                },
+                evidence:
+                  "indexed Slipstream CL replay for slipstream-basedflick-fame snapshot unit-selected-candidate",
+                indexedEvidence: {
+                  source: "indexed" as const,
+                  kind: "raw-replay" as const,
+                  quoteKind: "cl-replay-v1" as const,
+                  evidenceId: "unit-selected-candidate",
+                  poolId: "slipstream-basedflick-fame",
+                },
+              };
+            }
+            return {
+              ...quote,
+              context: {
+                source: "live" as const,
+                chainId: 8453,
+                blockNumber: 125n,
+              },
+            };
+          },
+        }),
+        quoteApiClient: null,
+      },
+    );
+    const json: unknown = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.ok(isRecord(json));
+    assert.equal(json.status, "ready");
+    assert.doesNotMatch(
+      JSON.stringify(json.feeBreakdown),
+      /indexedEvidence|protocolEvidence|bitmapWords|initializedTicks/,
+    );
+
+    const debug = json.debug;
+    assert.ok(isRecord(debug));
+    const quoteApi = debug.quoteApi;
+    assert.ok(isRecord(quoteApi));
+    const selectedRoute = quoteApi.selectedRoute;
+    assert.ok(isRecord(selectedRoute));
+    const activation = selectedRoute.activation;
+    assert.ok(isRecord(activation));
+    assert.equal(activation.outcome, "raw_replay_with_live_dependency");
+    assert.equal(activation.selectedPoolSource, "raw_replay");
+    assert.equal(activation.liveDependencySource, "live");
+    const legs = selectedRoute.legs;
+    assert.ok(Array.isArray(legs));
+    assert.ok(
+      legs.some(
+        (leg) =>
+          isRecord(leg) &&
+          leg.poolId === "slipstream-basedflick-fame" &&
+          leg.source === "raw_replay" &&
+          leg.evidenceId === "unit-selected-candidate",
+      ),
     );
   });
 
@@ -1300,7 +1655,7 @@ describe("/api/fame/swap/quote", () => {
           quoteApiClient: {
             async fetchQuotes() {
               throw new Error(
-                "FAME pool quote request failed with status 503. https://unit.example/super-secret",
+                'FAME pool quote request failed with status 503.\nraw response {"access_token":"unit-secret"}\nhttps://unit.example/super-secret',
               );
             },
           },
@@ -1320,7 +1675,10 @@ describe("/api/fame/swap/quote", () => {
       assert.equal(quoteApi.batchFailureCount, quoteApi.edgeCount);
       assert.equal(warnLog.events[0]?.event, "fame-pool-quote-api-unavailable");
       assert.equal(warnLog.events[0]?.reason, "quote_api_batch_failed");
-      assert.doesNotMatch(JSON.stringify(json), /unit\.example|super-secret/);
+      assert.doesNotMatch(
+        JSON.stringify(json),
+        /unit\.example|super-secret|unit-secret|raw response/,
+      );
     } finally {
       warnLog.restore();
     }
@@ -1340,6 +1698,38 @@ describe("/api/fame/swap/quote", () => {
 
     assert.equal(response.status, 400);
     assert.match(json.error, /routerAddress overrides/);
+  });
+
+  it("rejects malformed requested route ids before liquidity reads", async () => {
+    const response = await POST(
+      request({
+        tokenIn: USDC,
+        tokenOut: FAME,
+        amountIn: "5000000",
+        recipient: "0x0000000000000000000000000000000000000abc",
+        routeId: "solver fame/basedflick",
+      }),
+    );
+    const json = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.match(json.error, /routeId/);
+  });
+
+  it("rejects generated requested route ids on the public API", async () => {
+    const response = await POST(
+      request({
+        tokenIn: WETH,
+        tokenOut: FAME,
+        amountIn: "100000000000000",
+        recipient: "0x0000000000000000000000000000000000000abc",
+        routeId: "solver-single_path-uniswap-v2-fame-direct",
+      }),
+    );
+    const json = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.match(json.error, /pinned route artifact/);
   });
 
   it("rejects unbounded raw amounts before liquidity reads", async () => {

--- a/src/app/fame/creator/ChainSelector.tsx
+++ b/src/app/fame/creator/ChainSelector.tsx
@@ -14,9 +14,10 @@ import Typography from "@mui/material/Typography";
 import CheckIcon from "@mui/icons-material/CheckCircle";
 import IconButton from "@mui/material/IconButton";
 import Tooltip from "@mui/material/Tooltip";
-import { useChainId, useSwitchChain } from "wagmi";
+import { useSwitchChain } from "wagmi";
 import type { SxProps, TooltipProps } from "@mui/material";
 import { Chain } from "viem";
+import { useAccount } from "@/hooks/useAccount";
 
 export type TChain = Chain & {
   chainImageUrl: string;
@@ -33,7 +34,7 @@ export function decorateChainImageUrl(chain?: Chain): string {
     case 5:
       chainImageUrl = "/images/chains/goerli.png";
       break;
-    case 8543:
+    case 8453:
       chainImageUrl = "/images/chains/base.png";
       break;
     default:
@@ -122,7 +123,7 @@ export const ChainSelector: FC<{
 }> = ({ assetPrefix, sx, tooltipProps }) => {
   const [menuAnchorEl, setMenuAnchorEl] = useState<Element | null>(null);
 
-  const chainId = useChainId();
+  const { chainId } = useAccount();
 
   const { chains, error, switchChain, isPending } = useSwitchChain();
   const handleMenu = useCallback((event: MouseEvent) => {

--- a/src/app/fame/creator/on-boarding/RedirectWhenConnected.tsx
+++ b/src/app/fame/creator/on-boarding/RedirectWhenConnected.tsx
@@ -2,19 +2,8 @@
 
 import { FC, useEffect, useState } from "react";
 import { useAccount } from "@/hooks/useAccount";
-import { useChainId, useSwitchChain } from "wagmi";
+import { useSwitchChain } from "wagmi";
 import { useRouter, usePathname } from "next/navigation";
-
-function chainIdToChainName(chainId: number) {
-  switch (chainId) {
-    case 11155111:
-      return "sepolia";
-    case 8453:
-      return "base";
-    case 1:
-      return "mainnet";
-  }
-}
 
 export const RedirectWhenConnected: FC<{
   pathPrefix: string;
@@ -24,8 +13,7 @@ export const RedirectWhenConnected: FC<{
   const [targetChainId, setTargetChainId] = useState<number | undefined>(
     toChain,
   );
-  const { isConnected, address } = useAccount();
-  const chainId = useChainId();
+  const { isConnected, address, chainId: connectedChainId } = useAccount();
   const { chains, switchChainAsync, isSuccess, isPending } = useSwitchChain({
     mutation: {
       onMutate(variables) {
@@ -47,7 +35,7 @@ export const RedirectWhenConnected: FC<{
       targetChainId &&
       chain &&
       !isSuccess &&
-      targetChainId !== chainId &&
+      targetChainId !== connectedChainId &&
       address
     ) {
       console.log("switching chain", targetChainId);
@@ -63,7 +51,7 @@ export const RedirectWhenConnected: FC<{
     targetChainId,
     chain,
     isSuccess,
-    chainId,
+    connectedChainId,
     switchChainAsync,
     router,
     pathPrefix,
@@ -74,8 +62,15 @@ export const RedirectWhenConnected: FC<{
 
   useEffect(() => {
     const possiblePath = `${pathPrefix ? pathPrefix + "/" : ""}${address}${pathPostfix ? "/" + pathPostfix : ""}`;
-    if (isConnected && address && pathname !== possiblePath) {
-      console.log(`redirecting to ${possiblePath} with chainId ${chainId}`);
+    if (
+      isConnected &&
+      address &&
+      connectedChainId === toChain &&
+      pathname !== possiblePath
+    ) {
+      console.log(
+        `redirecting to ${possiblePath} with chainId ${connectedChainId}`,
+      );
       router.replace(possiblePath);
     }
   }, [
@@ -84,7 +79,8 @@ export const RedirectWhenConnected: FC<{
     pathname,
     pathPrefix,
     router,
-    chainId,
+    connectedChainId,
+    toChain,
     pathPostfix,
   ]);
 

--- a/src/app/fame/creator/on-boarding/page.tsx
+++ b/src/app/fame/creator/on-boarding/page.tsx
@@ -2,24 +2,22 @@
 import { AppMain } from "@/layouts/AppMain";
 import { ChainSelector } from "../ChainSelector";
 import { useAccount } from "@/hooks/useAccount";
-import { useChainId } from "wagmi";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { base } from "viem/chains";
 import { ConnectKitButton } from "connectkit";
 
 export default function OnBoardingPage() {
-  const { isConnected } = useAccount();
-  const chainId = useChainId();
+  const { isConnected, chainId: connectedChainId } = useAccount();
   const router = useRouter();
 
   useEffect(() => {
-    if (isConnected && chainId === base.id) {
+    if (isConnected && connectedChainId === base.id) {
       router.push("/fame/creator");
     }
-  }, [isConnected, chainId, router]);
+  }, [isConnected, connectedChainId, router]);
 
-  const isOnCorrectNetwork = chainId === base.id;
+  const isOnCorrectNetwork = isConnected && connectedChainId === base.id;
 
   return (
     <AppMain title="Connect Wallet" mobileTitle="" isDao headerRight={<ChainSelector />}>

--- a/src/app/schwing/wrap/ChainSelector.tsx
+++ b/src/app/schwing/wrap/ChainSelector.tsx
@@ -14,9 +14,10 @@ import Typography from "@mui/material/Typography";
 import CheckIcon from "@mui/icons-material/CheckCircle";
 import IconButton from "@mui/material/IconButton";
 import Tooltip from "@mui/material/Tooltip";
-import { useChainId, useSwitchChain } from "wagmi";
+import { useSwitchChain } from "wagmi";
 import type { SxProps, TooltipProps } from "@mui/material";
 import { Chain } from "viem";
+import { useAccount } from "@/hooks/useAccount";
 
 export type TChain = Chain & {
   chainImageUrl: string;
@@ -33,7 +34,7 @@ export function decorateChainImageUrl(chain?: Chain): string {
     case 5:
       chainImageUrl = "/images/chains/goerli.png";
       break;
-    case 8543:
+    case 8453:
       chainImageUrl = "/images/chains/base.png";
       break;
     default:
@@ -122,7 +123,7 @@ export const ChainSelector: FC<{
 }> = ({ assetPrefix, sx, tooltipProps }) => {
   const [menuAnchorEl, setMenuAnchorEl] = useState<Element | null>(null);
 
-  const chainId = useChainId();
+  const { chainId } = useAccount();
 
   const { chains, error, switchChain, isPending } = useSwitchChain();
   const handleMenu = useCallback((event: MouseEvent) => {

--- a/src/app/schwing/wrap/RedirectWhenConnected.tsx
+++ b/src/app/schwing/wrap/RedirectWhenConnected.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { FC, useEffect } from "react";
-import { useChainId } from "wagmi";
 import { useAccount } from "@/hooks/useAccount";
 import { useRouter, usePathname } from "next/navigation";
 
@@ -10,7 +9,6 @@ export const RedirectWhenConnected: FC<{
   pathPostfix?: string;
 }> = ({ pathPrefix, pathPostfix }) => {
   const { isConnected, address } = useAccount();
-  const chainId = useChainId();
   const router = useRouter();
   const pathname = usePathname();
 
@@ -25,7 +23,6 @@ export const RedirectWhenConnected: FC<{
     pathname,
     pathPrefix,
     router,
-    chainId,
     pathPostfix,
   ]);
 

--- a/src/app/~/blu/funknlove/gated/RedirectWhenConnected.tsx
+++ b/src/app/~/blu/funknlove/gated/RedirectWhenConnected.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { FC, useEffect, useState } from "react";
-import { useChainId, useSwitchChain } from "wagmi";
+import { useSwitchChain } from "wagmi";
 import { useAccount } from "@/hooks/useAccount";
 import { useRouter, usePathname } from "next/navigation";
 import { useSIWE } from "connectkit";
@@ -14,10 +14,9 @@ export const RedirectWhenConnected: FC<{
   const [targetChainId, setTargetChainId] = useState<number | undefined>(
     toChain,
   );
-  const { isConnected, address } = useAccount();
+  const { isConnected, address, chainId: connectedChainId } = useAccount();
   const { isSignedIn } = useSIWE();
 
-  const chainId = useChainId();
   const { chains, switchChainAsync, isSuccess, isPending } = useSwitchChain({
     mutation: {
       onMutate(variables) {
@@ -39,7 +38,7 @@ export const RedirectWhenConnected: FC<{
       targetChainId &&
       chain &&
       !isSuccess &&
-      targetChainId !== chainId &&
+      targetChainId !== connectedChainId &&
       address &&
       isSignedIn
     ) {
@@ -55,7 +54,7 @@ export const RedirectWhenConnected: FC<{
     targetChainId,
     chain,
     isSuccess,
-    chainId,
+    connectedChainId,
     switchChainAsync,
     router,
     pathPrefix,
@@ -67,7 +66,13 @@ export const RedirectWhenConnected: FC<{
 
   useEffect(() => {
     const possiblePath = `${pathPrefix ? pathPrefix + "/" : ""}${address}${pathPostfix ? "/" + pathPostfix : ""}`;
-    if (isConnected && address && pathname !== possiblePath && isSignedIn) {
+    if (
+      isConnected &&
+      address &&
+      connectedChainId === toChain &&
+      pathname !== possiblePath &&
+      isSignedIn
+    ) {
       router.replace(possiblePath);
     }
   }, [
@@ -76,7 +81,8 @@ export const RedirectWhenConnected: FC<{
     pathname,
     pathPrefix,
     router,
-    chainId,
+    connectedChainId,
+    toChain,
     pathPostfix,
     isSignedIn,
   ]);

--- a/src/app/~/jilly/lingerie-dreams/gated/RedirectWhenConnected.tsx
+++ b/src/app/~/jilly/lingerie-dreams/gated/RedirectWhenConnected.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { FC, useEffect, useState } from "react";
-import { useChainId, useSwitchChain } from "wagmi";
+import { useSwitchChain } from "wagmi";
 import { useAccount } from "@/hooks/useAccount";
 import { useRouter, usePathname } from "next/navigation";
 import { useSIWE } from "connectkit";
@@ -14,10 +14,9 @@ export const RedirectWhenConnected: FC<{
   const [targetChainId, setTargetChainId] = useState<number | undefined>(
     toChain,
   );
-  const { isConnected, address } = useAccount();
+  const { isConnected, address, chainId: connectedChainId } = useAccount();
   const { isSignedIn } = useSIWE();
 
-  const chainId = useChainId();
   const { chains, switchChainAsync, isSuccess, isPending } = useSwitchChain({
     mutation: {
       onMutate(variables) {
@@ -39,7 +38,7 @@ export const RedirectWhenConnected: FC<{
       targetChainId &&
       chain &&
       !isSuccess &&
-      targetChainId !== chainId &&
+      targetChainId !== connectedChainId &&
       address &&
       isSignedIn
     ) {
@@ -55,7 +54,7 @@ export const RedirectWhenConnected: FC<{
     targetChainId,
     chain,
     isSuccess,
-    chainId,
+    connectedChainId,
     switchChainAsync,
     router,
     pathPrefix,
@@ -67,7 +66,13 @@ export const RedirectWhenConnected: FC<{
 
   useEffect(() => {
     const possiblePath = `${pathPrefix ? pathPrefix + "/" : ""}${address}${pathPostfix ? "/" + pathPostfix : ""}`;
-    if (isConnected && address && pathname !== possiblePath && isSignedIn) {
+    if (
+      isConnected &&
+      address &&
+      connectedChainId === toChain &&
+      pathname !== possiblePath &&
+      isSignedIn
+    ) {
       router.replace(possiblePath);
     }
   }, [
@@ -76,7 +81,8 @@ export const RedirectWhenConnected: FC<{
     pathname,
     pathPrefix,
     router,
-    chainId,
+    connectedChainId,
+    toChain,
     pathPostfix,
     isSignedIn,
   ]);

--- a/src/components/IrysUploaderWidget.tsx
+++ b/src/components/IrysUploaderWidget.tsx
@@ -9,7 +9,7 @@ import React, {
 } from "react";
 import { useDropzone } from "react-dropzone";
 import { useAccount } from "@/hooks/useAccount";
-import { useWalletClient, usePublicClient, useChainId } from "wagmi";
+import { useWalletClient, usePublicClient } from "wagmi";
 import { getIrysUploader } from "@/service/irys_client";
 import { formatEther } from "viem";
 
@@ -68,8 +68,7 @@ export const IrysUploaderWidget: React.FC<IrysUploaderWidgetProps> = ({
   onComplete,
   initialFile = null,
 }) => {
-  const { address, isConnected, chain } = useAccount();
-  const chainId = useChainId();
+  const { address, isConnected, chain, chainId } = useAccount();
   const { data: walletClient } = useWalletClient();
   const publicClient = usePublicClient();
   const [uploader, setUploader] = useState<any | null>(null);

--- a/src/components/LinkButton.tsx
+++ b/src/components/LinkButton.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { forwardRef } from "react";
+import NextLink from "next/link";
+import Button, { type ButtonProps } from "@mui/material/Button";
+
+type LinkButtonProps = Omit<
+  ButtonProps<typeof NextLink>,
+  "component" | "href"
+> & {
+  href: string;
+};
+
+export const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps>(
+  function LinkButton({ href, ...props }, ref) {
+    return <Button component={NextLink} ref={ref} href={href} {...props} />;
+  },
+);
+
+LinkButton.displayName = "LinkButton";

--- a/src/components/MetadataIrysUploader.tsx
+++ b/src/components/MetadataIrysUploader.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import React, { useCallback, useMemo, useState } from "react";
-import { useWalletClient, usePublicClient, useChainId } from "wagmi";
+import React, { useCallback, useState } from "react";
+import { useWalletClient, usePublicClient } from "wagmi";
 import IrysUploaderWidget from "@/components/IrysUploaderWidget";
 import { getIrysUploader } from "@/service/irys_client";
 import { useAccount } from "@/hooks/useAccount";
@@ -34,8 +34,7 @@ export const MetadataIrysUploader: React.FC<MetadataIrysUploaderProps> = ({
   onComplete,
   label = "Metadata Upload",
 }) => {
-  const { isConnected, chain } = useAccount();
-  const chainId = useChainId();
+  const { isConnected, chain, chainId } = useAccount();
   const { data: walletClient } = useWalletClient();
   const publicClient = usePublicClient();
   const [step, setStep] = useState<"image" | "metadata" | "done">("image");

--- a/src/features/customize/components/SocialShare.tsx
+++ b/src/features/customize/components/SocialShare.tsx
@@ -12,7 +12,6 @@ import CardActions from "@mui/material/CardActions";
 import Typography from "@mui/material/Typography";
 import Dialog from "@mui/material/Dialog";
 import { mainnet } from "viem/chains";
-import { useChainId, useSwitchChain } from "wagmi";
 import Skeleton from "@mui/material/Skeleton";
 import RocketLaunchIcon from "@mui/icons-material/RocketLaunch";
 import CircularProgress from "@mui/material/CircularProgress";
@@ -63,10 +62,9 @@ export const SocialShare: FC<{
   textProvider,
   onClose,
 }) => {
-  const { isSignedIn, signIn } = useAccount();
-  const chainId = useChainId();
+  const { isSignedIn, signIn, chainId: connectedChainId } = useAccount();
   const network =
-    propsNetwork ?? chainId === mainnet.id ? "mainnet" : "sepolia";
+    propsNetwork ?? (connectedChainId === mainnet.id ? "mainnet" : "sepolia");
   const imgUrl = `${process.env.NEXT_PUBLIC_BASE_URL}/${network}/og/token/${tokenId}`;
   const shareUrl = `${process.env.NEXT_PUBLIC_BASE_URL}/${network}/token/${tokenId}`;
 

--- a/src/features/customize/components/TokenDetails.tsx
+++ b/src/features/customize/components/TokenDetails.tsx
@@ -13,7 +13,7 @@ import Button from "@mui/material/Button";
 import { IMetadata, defaultDescription, imageUrl } from "@/utils/metadata";
 import { useUpdateMetadata } from "../hooks/useUpdateMetadata";
 import { useAccount } from "@/hooks/useAccount";
-import { useChainId, useSwitchChain, useWriteContract } from "wagmi";
+import { useSwitchChain, useWriteContract } from "wagmi";
 import { useChainContracts } from "@/hooks/useChainContracts";
 import { TransactionsModal } from "@/features/wrap/components/TransactionsModal";
 import { useNotifications } from "@/features/notifications/Context";
@@ -24,6 +24,7 @@ import BackIcon from "@mui/icons-material/ArrowBack";
 import { ServiceModal } from "./ServiceModal";
 import { SocialShareDialog } from "./SocialShare";
 import { mainnet } from "viem/chains";
+import { needsConnectedChainSwitch } from "@/utils/connectedChain";
 
 const EditableNameAndDescription: FC<{
   initialName: string;
@@ -138,7 +139,7 @@ export const TokenDetails: FC<{
   tokenId: number;
   network?: "mainnet" | "sepolia";
 }> = ({ metadata, tokenId, network }) => {
-  const { chain } = useAccount();
+  const { isConnected, chainId: connectedChainId } = useAccount();
   const { refresh, push } = useRouter();
   const { addNotification } = useNotifications();
 
@@ -148,13 +149,12 @@ export const TokenDetails: FC<{
   );
   const { mutateAsync, isPending } = useUpdateMetadata(network ?? "mainnet");
   const { namedLadyRendererAbi, namedLadyRendererAddress } =
-    useChainContracts();
+    useChainContracts(mainnet.id);
   const { mutateAsync: writeContractAsync } = useWriteContract();
   const symbol = useMemo(() => {
     return metadata.name.replace(/\s+/g, "").toUpperCase();
   }, [metadata.name]);
 
-  const chainId = useChainId();
   const { mutateAsync: switchChainAsync } = useSwitchChain();
 
   const initialDescription = useMemo(() => {
@@ -185,6 +185,7 @@ export const TokenDetails: FC<{
         const tx = await writeContractAsync({
           abi: namedLadyRendererAbi,
           address: namedLadyRendererAddress,
+          chainId: mainnet.id,
           functionName: "setTokenUri",
           args: [BigInt(tokenId), uri, finalSignature],
         });
@@ -213,15 +214,18 @@ export const TokenDetails: FC<{
 
   const onSubmit = useCallback(
     async (name: string, description: string) => {
-      if (chainId === mainnet.id) {
-        return await doSubmit(name, description);
-      } else {
-        return await switchChainAsync({ chainId: mainnet.id }).then(() =>
-          doSubmit(name, description),
-        );
+      if (
+        needsConnectedChainSwitch({
+          isConnected,
+          connectedChainId,
+          targetChainId: mainnet.id,
+        })
+      ) {
+        await switchChainAsync({ chainId: mainnet.id });
       }
+      return await doSubmit(name, description);
     },
-    [doSubmit, switchChainAsync, chainId],
+    [connectedChainId, doSubmit, isConnected, switchChainAsync],
   );
 
   const pendingTransactions = useMemo(

--- a/src/features/customize/hooks/useLaunchZoraCoin.ts
+++ b/src/features/customize/hooks/useLaunchZoraCoin.ts
@@ -1,15 +1,9 @@
 "use client";
 
 import { useMutation } from "@tanstack/react-query";
-import {
-  useChainId,
-  useSwitchChain,
-  useWriteContract,
-} from "wagmi";
-import {
-  zeroAddress,
-} from "viem";
-import { base, mainnet } from "viem/chains";
+import { useSwitchChain, useWriteContract } from "wagmi";
+import { zeroAddress } from "viem";
+import { base } from "viem/chains";
 import { useAccount } from "@/hooks/useAccount";
 import { Transaction } from "@/features/wrap/types";
 import {
@@ -22,6 +16,7 @@ import {
   baseCommunityMultiSigAddress,
 } from "@/features/fame/contract";
 import { useCallback } from "react";
+import { needsConnectedChainSwitch } from "@/utils/connectedChain";
 
 type LaunchParams = {
   tokenId: bigint | number;
@@ -41,8 +36,13 @@ type LaunchParams = {
 export function useLaunchZoraCoin() {
   // console.log("useLaunchZoraCoin", data);
   // console.log("dopplerData", dopplerData);
-  const chainId = useChainId();
-  const { address, isSignedIn, signIn } = useAccount();
+  const {
+    address,
+    isConnected,
+    isSignedIn,
+    signIn,
+    chainId: connectedChainId,
+  } = useAccount();
   const { mutateAsync: switchChainAsync } = useSwitchChain();
 
   const { mutateAsync: deploy } = useWriteContract();
@@ -116,14 +116,17 @@ export function useLaunchZoraCoin() {
         }
       }
 
-      let promise =
-        chainId === base.id
-          ? deployCoin({ tokenId, symbol, name })
-          : switchChainAsync({ chainId: base.id }).then(() =>
-              deployCoin({ tokenId, symbol, name }),
-            );
+      if (
+        needsConnectedChainSwitch({
+          isConnected,
+          connectedChainId,
+          targetChainId: base.id,
+        })
+      ) {
+        await switchChainAsync({ chainId: base.id });
+      }
 
-      return await promise;
+      return await deployCoin({ tokenId, symbol, name });
     },
   });
 }

--- a/src/features/fame-swap/components/FameSwapWidget.tsx
+++ b/src/features/fame-swap/components/FameSwapWidget.tsx
@@ -17,7 +17,7 @@ import type { FC, SyntheticEvent } from "react";
 import { useCallback, useMemo, useState } from "react";
 import { parseUnits } from "viem";
 import { base } from "viem/chains";
-import { useChainId, useSwitchChain } from "wagmi";
+import { useSwitchChain } from "wagmi";
 import { useAccount } from "@/hooks/useAccount";
 import { getFameSwapConfig } from "../config";
 import { useFameSwapBalance } from "../hooks/useFameSwapBalance";
@@ -200,8 +200,7 @@ const AlertErrorLine: FC<{ error: Error }> = ({ error }) => {
 };
 
 export const FameSwapWidget: FC<FameSwapWidgetProps> = ({ mode = "full" }) => {
-  const { address, isConnected } = useAccount();
-  const chainId = useChainId();
+  const { address, isConnected, chainId: connectedChainId } = useAccount();
   const {
     switchChainAsync,
     isPending: isSwitchingChain,
@@ -218,7 +217,7 @@ export const FameSwapWidget: FC<FameSwapWidgetProps> = ({ mode = "full" }) => {
   );
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const compact = mode === "compact";
-  const onBase = chainId === base.id;
+  const onBase = isConnected && connectedChainId === base.id;
   const pair = useMemo(() => deriveFameSwapPair(trade), [trade]);
   const inputBalance = useFameSwapBalance(address, pair.inputToken);
   const config = useMemo(

--- a/src/features/fame-swap/solver/amountSolver.test.ts
+++ b/src/features/fame-swap/solver/amountSolver.test.ts
@@ -2,11 +2,9 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { decodeAbiParameters } from "viem";
 import { FAME_SWAP_ARTIFACT_MANIFEST } from "../artifacts/manifest";
+import { routeArtifactById } from "./artifacts";
 import { FAME, NATIVE_ETH, USDC, WETH, tokenForAddress } from "../tokens";
-import {
-  solveFameSwapAmount,
-  solveFameSwapAmountAsync,
-} from "./amountSolver";
+import { solveFameSwapAmount, solveFameSwapAmountAsync } from "./amountSolver";
 import type { FameQuoteAdapter } from "./quotes/adapters";
 import { createDeterministicQuoteAdapter } from "./quotes/deterministicAdapter";
 import { toAsyncQuoteAdapter } from "./optimizer/quoteRunAdapter";
@@ -28,7 +26,9 @@ function assertSameAddress(actual: string | undefined, expected: string) {
   assert.equal(actual?.toLowerCase(), expected.toLowerCase());
 }
 
-function token(address: typeof FAME | typeof USDC | typeof WETH | typeof NATIVE_ETH) {
+function token(
+  address: typeof FAME | typeof USDC | typeof WETH | typeof NATIVE_ETH,
+) {
   const result = tokenForAddress(address);
   assert.ok(result);
   return result;
@@ -54,7 +54,10 @@ describe("FAME amount-aware solver", () => {
       assert.equal(result.route.tokenOut, FAME);
       assert.equal(result.route.amountIn, 800_000n);
       assert.equal(result.route.recipient, recipient);
-      assert.equal(result.route.minAmountOutAfterFee, result.plan.protectedAmountOut);
+      assert.equal(
+        result.route.minAmountOutAfterFee,
+        result.plan.protectedAmountOut,
+      );
       assert.ok(result.poolIds.includes("scale-equalizer-usdc-frxusd"));
       assert.ok(result.poolIds.includes("slipstream-usdc-frxusd"));
       assert.ok(result.poolIds.includes("scale-equalizer-frxusd-fame"));
@@ -80,7 +83,10 @@ describe("FAME amount-aware solver", () => {
     if (result.status === "ready") {
       const v4Leg = result.route.legs.find((leg) => leg.venue === "UniswapV4");
       assert.ok(v4Leg);
-      const [payload] = decodeAbiParameters(universalRouterV4PayloadAbi, v4Leg.data);
+      const [payload] = decodeAbiParameters(
+        universalRouterV4PayloadAbi,
+        v4Leg.data,
+      );
       assert.equal(payload.recipient, routerAddress);
       if (v4Leg.amountMode === "All") {
         assert.equal(payload.amountIn, 0n);
@@ -98,7 +104,9 @@ describe("FAME amount-aware solver", () => {
         return {
           status: "quoted",
           amountIn: request.amountIn,
-          amountOut: favorsWethFame ? request.amountIn * 1_000_000n : request.amountIn,
+          amountOut: favorsWethFame
+            ? request.amountIn * 1_000_000n
+            : request.amountIn,
           capacityIn: null,
           fee: request.edge.fee,
           evidence: "unit test native wrap route quote evidence",
@@ -318,6 +326,84 @@ describe("FAME amount-aware solver", () => {
       );
       assert.equal(result.route.legs[0]?.amount, 500_000_000_000_000n);
       assert.equal(result.route.legs[1]?.amount, 0n);
+    }
+  });
+
+  it("honors a requested artifact route and skips optimizer selection", async () => {
+    const routeId = "solver-fame-basedflick-zora-weth";
+    const artifact = routeArtifactById(routeId);
+    assert.ok(artifact);
+
+    const result = await solveFameSwapAmountAsync({
+      tokenIn: token(FAME),
+      tokenOut: token(WETH),
+      amountIn: BigInt(artifact.route.amountIn),
+      routerAddress,
+      recipient,
+      deadline,
+      feePpm: 2_222n,
+      slippageBps: DEFAULT_FAME_SWAP_SLIPPAGE_BPS,
+      adapter: toAsyncQuoteAdapter(createDeterministicQuoteAdapter()),
+      optimizerMode: "select",
+      requestedRouteId: routeId,
+    });
+
+    assert.equal(result.status, "ready");
+    if (result.status === "ready") {
+      assert.equal(result.routeArtifactId, routeId);
+      assert.equal(result.routeSource, "artifact");
+      assert.deepEqual(result.poolIds, artifact.poolIds);
+      assert.equal(result.optimizerEvidence, undefined);
+      assert.equal(result.optimizerSummary, undefined);
+    }
+  });
+
+  it("pins requested split artifact routes to their exact allocation", async () => {
+    const routeId = "solver-weth-split-fame";
+    const artifact = routeArtifactById(routeId);
+    assert.ok(artifact);
+
+    const result = await solveFameSwapAmountAsync({
+      tokenIn: token(WETH),
+      tokenOut: token(FAME),
+      amountIn: BigInt(artifact.route.amountIn),
+      routerAddress,
+      recipient,
+      deadline,
+      feePpm: 2_222n,
+      slippageBps: DEFAULT_FAME_SWAP_SLIPPAGE_BPS,
+      adapter: toAsyncQuoteAdapter(createDeterministicQuoteAdapter()),
+      optimizerMode: "select",
+      requestedRouteId: routeId,
+    });
+
+    assert.equal(result.status, "ready");
+    if (result.status === "ready") {
+      assert.equal(result.routeArtifactId, routeId);
+      assert.equal(result.routeSource, "artifact");
+      assert.deepEqual(result.poolIds, artifact.poolIds);
+      assert.equal(result.routeDisplay[0]?.allocationBps, 5_000);
+      assert.equal(result.routeDisplay[1]?.allocationBps, 5_000);
+    }
+  });
+
+  it("fails closed when a requested artifact route does not match the pair", () => {
+    const result = solveFameSwapAmount({
+      tokenIn: token(WETH),
+      tokenOut: token(FAME),
+      amountIn: 100_000_000_000_000n,
+      routerAddress,
+      recipient,
+      deadline,
+      feePpm: 2_222n,
+      slippageBps: DEFAULT_FAME_SWAP_SLIPPAGE_BPS,
+      adapter: createDeterministicQuoteAdapter(),
+      requestedRouteId: "solver-fame-basedflick-zora-weth",
+    });
+
+    assert.equal(result.status, "no_safe_route");
+    if (result.status === "no_safe_route") {
+      assert.match(result.message, /artifact token pair does not match/);
     }
   });
 

--- a/src/features/fame-swap/solver/amountSolver.ts
+++ b/src/features/fame-swap/solver/amountSolver.ts
@@ -7,8 +7,17 @@ import {
   type FameRouteCapabilities,
 } from "../router/types";
 import { tokenForAddress, type FameSwapToken } from "../tokens";
+import { routeArtifactById } from "./artifacts";
 import { routeCandidatesForPair } from "./graph/candidates";
-import type { FameSwapOptimizerSummary, FameSwapRouteDisplayLeg } from "./types";
+import type {
+  FameRouteCandidate,
+  FameRouteCandidateRejected,
+  FameRouteCandidateSet,
+} from "./graph/routePlan";
+import type {
+  FameSwapOptimizerSummary,
+  FameSwapRouteDisplayLeg,
+} from "./types";
 import type {
   FameAsyncQuoteAdapter,
   FameCandidateRejection,
@@ -31,6 +40,7 @@ export type FameAmountSolverResult =
   | {
       status: "ready";
       routeArtifactId: string;
+      routeSource: "artifact" | "generated";
       route: FameRoute;
       abiEncodedRoute: Hex;
       routeHash: Hex;
@@ -59,6 +69,7 @@ export interface FameAmountSolverRequest {
   feePpm: bigint;
   slippageBps: number;
   adapter?: FameQuoteAdapter;
+  requestedRouteId?: string;
 }
 
 export interface FameAsyncAmountSolverRequest
@@ -66,6 +77,154 @@ export interface FameAsyncAmountSolverRequest
   adapter: FameAsyncQuoteAdapter;
   optimizerMode?: FameOptimizerMode;
   optimizerBudgets?: Partial<FameOptimizerBudgets>;
+}
+
+function sameAddress(left: Address, right: Address): boolean {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+function candidatePoolIds(candidate: FameRouteCandidate): string[] {
+  return candidate.legs.map((leg) => leg.edge.poolId);
+}
+
+function samePoolPath(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((poolId, index) => poolId === right[index])
+  );
+}
+
+function allocationBpsForExactLeg(
+  amountIn: bigint,
+  legAmount: string,
+): number | null {
+  const amount = BigInt(legAmount);
+  const numerator = amount * 10_000n;
+  if (amountIn <= 0n || numerator % amountIn !== 0n) return null;
+  const allocation = numerator / amountIn;
+  return allocation >= 0n && allocation <= 10_000n ? Number(allocation) : null;
+}
+
+function requestedArtifactKind(
+  artifact: NonNullable<ReturnType<typeof routeArtifactById>>,
+): FameRouteCandidate["kind"] {
+  const allocatedLegs = artifact.route.legs.filter(
+    (leg) =>
+      leg.amountMode === "Exact" &&
+      BigInt(leg.amount) < BigInt(artifact.route.amountIn),
+  ).length;
+  if (allocatedLegs === 0) return "single_path";
+  return artifact.route.legs.length === 2 ? "split" : "split_merge";
+}
+
+function candidateMatchesArtifact(
+  candidate: FameRouteCandidate,
+  artifact: NonNullable<ReturnType<typeof routeArtifactById>>,
+): boolean {
+  if (candidate.kind !== requestedArtifactKind(artifact)) return false;
+  if (!samePoolPath(candidatePoolIds(candidate), artifact.poolIds))
+    return false;
+  if (candidate.legs.length !== artifact.route.legs.length) return false;
+
+  const routeAmountIn = BigInt(artifact.route.amountIn);
+  let firstAllocationBps: number | null = null;
+
+  return candidate.legs.every((leg, index) => {
+    const artifactLeg = artifact.route.legs[index];
+    if (!artifactLeg) return false;
+
+    if (leg.allocationBps === null) return true;
+    if (leg.amountMode !== artifactLeg.amountMode) return false;
+    if (artifactLeg.amountMode === "Exact") {
+      const allocation = allocationBpsForExactLeg(
+        routeAmountIn,
+        artifactLeg.amount,
+      );
+      firstAllocationBps = allocation;
+      return allocation !== null && leg.allocationBps === allocation;
+    }
+    if (artifactLeg.amountMode === "All" && firstAllocationBps !== null) {
+      return leg.allocationBps === 10_000 - firstAllocationBps;
+    }
+    return false;
+  });
+}
+
+function requestedRouteMismatch(
+  requestedRouteId: string,
+  detail: string,
+): FameRouteCandidateRejected {
+  return {
+    reason: "requested_route_unavailable",
+    detail: `Requested route ${requestedRouteId} is not available: ${detail}`,
+  };
+}
+
+function routeCandidateSetForRequest(
+  request: Pick<
+    FameAmountSolverRequest,
+    "tokenIn" | "tokenOut" | "requestedRouteId"
+  >,
+): FameRouteCandidateSet {
+  const candidateSet = routeCandidatesForPair(
+    request.tokenIn.address,
+    request.tokenOut.address,
+  );
+  const requestedRouteId = request.requestedRouteId?.trim();
+  if (!requestedRouteId) return candidateSet;
+
+  const artifact = routeArtifactById(requestedRouteId);
+  if (artifact) {
+    if (
+      !sameAddress(artifact.route.tokenIn, request.tokenIn.address) ||
+      !sameAddress(artifact.route.tokenOut, request.tokenOut.address)
+    ) {
+      return {
+        candidates: [],
+        rejected: [
+          requestedRouteMismatch(
+            requestedRouteId,
+            "the artifact token pair does not match this quote request.",
+          ),
+        ],
+      };
+    }
+
+    const candidates = candidateSet.candidates.filter((candidate) =>
+      candidateMatchesArtifact(candidate, artifact),
+    );
+    return candidates.length > 0
+      ? { candidates, rejected: candidateSet.rejected }
+      : {
+          candidates: [],
+          rejected: [
+            requestedRouteMismatch(
+              requestedRouteId,
+              "no generated candidate matches the artifact pool path.",
+            ),
+            ...candidateSet.rejected,
+          ],
+        };
+  }
+
+  const candidates = candidateSet.candidates.filter(
+    (candidate) => candidate.id === requestedRouteId,
+  );
+  return candidates.length > 0
+    ? { candidates, rejected: candidateSet.rejected }
+    : {
+        candidates: [],
+        rejected: [
+          requestedRouteMismatch(
+            requestedRouteId,
+            "no generated candidate has that id.",
+          ),
+          ...candidateSet.rejected,
+        ],
+      };
 }
 
 function routeDisplay(plan: FameQuotedRoutePlan): FameSwapRouteDisplayLeg[] {
@@ -115,10 +274,14 @@ function readyResult(
 ): Extract<FameAmountSolverResult, { status: "ready" }> {
   const route = buildRoute(request, plan);
   const routeHash = hashFameRoute(route);
+  const requestedArtifact = request.requestedRouteId
+    ? routeArtifactById(request.requestedRouteId)
+    : undefined;
 
   return {
     status: "ready",
-    routeArtifactId: plan.candidate.id,
+    routeArtifactId: requestedArtifact?.id ?? plan.candidate.id,
+    routeSource: requestedArtifact ? "artifact" : "generated",
     route,
     abiEncodedRoute: encodeFameRoute(route),
     routeHash,
@@ -136,10 +299,7 @@ function readyResult(
 export function solveFameSwapAmount(
   request: FameAmountSolverRequest,
 ): FameAmountSolverResult {
-  const candidateSet = routeCandidatesForPair(
-    request.tokenIn.address,
-    request.tokenOut.address,
-  );
+  const candidateSet = routeCandidateSetForRequest(request);
   if (candidateSet.candidates.length === 0) {
     return {
       status:
@@ -198,10 +358,7 @@ export function solveFameSwapAmount(
 export async function solveFameSwapAmountAsync(
   request: FameAsyncAmountSolverRequest,
 ): Promise<FameAmountSolverResult> {
-  const candidateSet = routeCandidatesForPair(
-    request.tokenIn.address,
-    request.tokenOut.address,
-  );
+  const candidateSet = routeCandidateSetForRequest(request);
   if (candidateSet.candidates.length === 0) {
     return {
       status:
@@ -250,7 +407,7 @@ export async function solveFameSwapAmountAsync(
   }
 
   const optimizerMode = request.optimizerMode ?? "select";
-  if (optimizerMode === "disabled") {
+  if (optimizerMode === "disabled" || request.requestedRouteId) {
     return legacyResult();
   }
 
@@ -282,8 +439,7 @@ export async function solveFameSwapAmountAsync(
     return {
       status: "quote_adapter_failure",
       rejectedCandidates: optimized.rejectedCandidates,
-      message:
-        "FAME optimizer timed out before completing a safe route quote.",
+      message: "FAME optimizer timed out before completing a safe route quote.",
     };
   }
 

--- a/src/features/fame-swap/solver/amountSolver.ts
+++ b/src/features/fame-swap/solver/amountSolver.ts
@@ -14,6 +14,7 @@ import type {
   FameCandidateRejection,
   FameQuoteAdapter,
 } from "./quotes/adapters";
+import type { FameRouteCandidate } from "./graph/routePlan";
 import { optimizeRouteAllocations } from "./optimizer/search";
 import { optimizerSummaryFromEvidence } from "./optimizer/summary";
 import type {
@@ -59,6 +60,7 @@ export interface FameAmountSolverRequest {
   feePpm: bigint;
   slippageBps: number;
   adapter?: FameQuoteAdapter;
+  candidateFilter?: (candidate: FameRouteCandidate) => boolean;
 }
 
 export interface FameAsyncAmountSolverRequest
@@ -77,6 +79,28 @@ function routeDisplay(plan: FameQuotedRoutePlan): FameSwapRouteDisplayLeg[] {
     poolId: leg.edge.poolId,
     allocationBps: leg.allocationBps,
   }));
+}
+
+function applyCandidateFilter(
+  candidates: readonly FameRouteCandidate[],
+  filter: FameAmountSolverRequest["candidateFilter"],
+): FameRouteCandidate[] {
+  if (!filter) return [...candidates];
+  return candidates.filter(filter);
+}
+
+function noFilteredCandidatesResult(): FameAmountSolverResult {
+  return {
+    status: "no_safe_route",
+    rejectedCandidates: [
+      {
+        candidateId: "candidate-filter",
+        reason: "unsafe_output",
+        message: "No route candidates matched the requested route-lab target.",
+      },
+    ],
+    message: "No route candidates matched the requested route-lab target.",
+  };
 }
 
 function buildRoute(
@@ -173,8 +197,14 @@ export function solveFameSwapAmount(
     };
   }
 
+  const candidates = applyCandidateFilter(
+    candidateSet.candidates,
+    request.candidateFilter,
+  );
+  if (candidates.length === 0) return noFilteredCandidatesResult();
+
   const ranked = rankRouteCandidates({
-    candidates: candidateSet.candidates,
+    candidates,
     amountIn: request.amountIn,
     feePpm: request.feePpm,
     slippageBps: request.slippageBps,
@@ -222,8 +252,14 @@ export async function solveFameSwapAmountAsync(
   async function legacyResult(
     optimizerEvidence?: FameOptimizerEvidence,
   ): Promise<FameAmountSolverResult> {
+    const candidates = applyCandidateFilter(
+      candidateSet.candidates,
+      request.candidateFilter,
+    );
+    if (candidates.length === 0) return noFilteredCandidatesResult();
+
     const ranked = await rankRouteCandidatesAsync({
-      candidates: candidateSet.candidates,
+      candidates,
       amountIn: request.amountIn,
       feePpm: request.feePpm,
       slippageBps: request.slippageBps,
@@ -249,7 +285,9 @@ export async function solveFameSwapAmountAsync(
     );
   }
 
-  const optimizerMode = request.optimizerMode ?? "select";
+  const optimizerMode = request.candidateFilter
+    ? "disabled"
+    : (request.optimizerMode ?? "select");
   if (optimizerMode === "disabled") {
     return legacyResult();
   }

--- a/src/features/fame-swap/solver/diagnostics.ts
+++ b/src/features/fame-swap/solver/diagnostics.ts
@@ -1,0 +1,28 @@
+const SENSITIVE_DIAGNOSTIC_LINE =
+  /\b(request body|response body|raw response|response headers|set-cookie|calldata|approval|swap request|private key|signer|authorization|api[-_ ]?key)\b|(?:^|[\s"'{}:,])(?:secret|token|access[_-]?token|refresh[_-]?token|authorization)(?:[-_ ]?(?:key|token))?["']?\s*[:=]/i;
+
+export function redactSensitiveDiagnosticText(value: string): string {
+  return value
+    .replace(/(?:https?|wss?):\/\/\S+/g, "[redacted-url]")
+    .replace(/\b(?:bearer|token)\s+[a-z0-9._~+/=-]+/gi, "[redacted-secret]")
+    .replace(/0x[a-fA-F0-9]{64,}/g, "[redacted-hex]");
+}
+
+export function displaySafeDiagnosticMessage(
+  value: unknown,
+  fallback = "FAME quote request failed.",
+): string {
+  const raw = value instanceof Error ? value.message : String(value);
+  return redactSensitiveDiagnosticText(
+    raw
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(
+        (line) => line.length > 0 && !SENSITIVE_DIAGNOSTIC_LINE.test(line),
+      ) ?? fallback,
+  );
+}
+
+export function displaySafeErrorMessage(error: unknown): string {
+  return displaySafeDiagnosticMessage(error);
+}

--- a/src/features/fame-swap/solver/graph/edgeMatrix.ts
+++ b/src/features/fame-swap/solver/graph/edgeMatrix.ts
@@ -9,6 +9,7 @@ import type {
   FameProtocolEvidence,
   FameProtocolEvidenceItem,
 } from "../quotes/adapters";
+import { redactSensitiveDiagnosticText as sanitizeDiagnosticText } from "../diagnostics";
 import type { FameRouteCandidate, FameRouteCandidateSet } from "./routePlan";
 
 export type FameRouteEdgeMatrixStatus =
@@ -165,24 +166,6 @@ function sameAddress(left: Address, right: Address): boolean {
 
 function tokenSymbol(address: Address): string {
   return tokenForAddress(address)?.symbol ?? address;
-}
-
-function sanitizeDiagnosticText(value: string): string {
-  const safeLine = value
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .find(
-      (line) =>
-        line.length > 0 &&
-        !/\b(request body|calldata|approval|swap request|private key|signer|authorization|api[-_ ]?key)\b|(?:^|\s)secret(?:[-_ ]?(?:key|token))?\s*[:=]/i.test(
-          line,
-        ),
-    );
-
-  return (safeLine ?? "Route diagnostic unavailable.")
-    .replace(/(?:https?|wss?):\/\/\S+/g, "[redacted-url]")
-    .replace(/\b(?:bearer|token)\s+[a-z0-9._~+/=-]+/gi, "[redacted-secret]")
-    .replace(/0x[a-fA-F0-9]{64,}/g, "[redacted-hex]");
 }
 
 function sanitizeCoverageField(

--- a/src/features/fame-swap/solver/poolActivation.test.ts
+++ b/src/features/fame-swap/solver/poolActivation.test.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  FAME_SELECTED_CL_ACTIVATION_CANDIDATE,
+  FAME_SELECTED_LIVE_ROUTE_DEPENDENCY,
+  assertReviewedPoolActivationCoverage,
+  famePoolActivationReport,
+} from "./poolActivation";
+
+describe("FAME pool activation report", () => {
+  it("accounts for every upstream pool exactly once", () => {
+    const report = famePoolActivationReport();
+    const poolIds = report.upstreamPools.map((pool) => pool.poolId);
+
+    assert.equal(report.upstreamPoolCount, 26);
+    assert.equal(report.upstreamPools.length, report.upstreamPoolCount);
+    assert.equal(new Set(poolIds).size, report.upstreamPoolCount);
+    assert.equal(
+      Object.values(report.statusCounts).reduce(
+        (total, count) => total + count,
+        0,
+      ),
+      report.upstreamPoolCount,
+    );
+  });
+
+  it("fails closed when upstream pools and reviewed activation rows diverge", () => {
+    assert.throws(
+      () =>
+        assertReviewedPoolActivationCoverage(["known", "new-pool"], ["known"]),
+      /Missing reviewed activation status for upstream pool new-pool/,
+    );
+    assert.throws(
+      () => assertReviewedPoolActivationCoverage(["known"], ["known", "stale"]),
+      /unknown upstream pool stale/,
+    );
+  });
+
+  it("keeps producer representation separate from quote activation", () => {
+    const report = famePoolActivationReport();
+    const unrepresented = [
+      "slipstream-spx-weth",
+      "slipstream-usdc-weth-migrating-50",
+      "slipstream-msusd-usdc-a",
+      "slipstream-weth-mseth",
+      "slipstream2-msusd-mseth",
+      "slipstream2-msusd-usdc-c",
+    ];
+
+    for (const poolId of unrepresented) {
+      const pool = report.upstreamPools.find(
+        (entry) => entry.poolId === poolId,
+      );
+      assert.ok(pool, poolId);
+      assert.equal(pool.producerRegistryPresence, "producer-unrepresented");
+      assert.equal(pool.producerRegistryEntry, null);
+    }
+  });
+
+  it("keeps the migrating Slipstream pool visible as blocked", () => {
+    const report = famePoolActivationReport();
+    const blocked = report.upstreamPools.find(
+      (entry) => entry.poolId === "slipstream-usdc-weth-migrating-50",
+    );
+
+    assert.equal(blocked?.activationStatus, "blocked");
+    assert.equal(blocked?.consumerQuoteCapability, "none");
+    assert.match(blocked?.reason ?? "", /migrating pool/i);
+  });
+
+  it("marks the selected pool compact quote active with its live V4 dependency", () => {
+    const report = famePoolActivationReport();
+    const candidate = report.upstreamPools.find(
+      (entry) => entry.poolId === FAME_SELECTED_CL_ACTIVATION_CANDIDATE,
+    );
+
+    assert.equal(candidate?.activationStatus, "cl-compact-quote-active");
+    assert.equal(candidate?.selectedCandidate, true);
+    assert.equal(candidate?.consumerQuoteCapability, "cl-compact-quote");
+    assert.deepEqual(candidate?.liveRouteDependencies, [
+      FAME_SELECTED_LIVE_ROUTE_DEPENDENCY,
+    ]);
+    assert.ok((candidate?.selectedRouteArtifactIds.length ?? 0) > 0);
+    assert.ok(
+      candidate?.routeReferences.every((reference) =>
+        reference.routePoolOrder.includes(FAME_SELECTED_LIVE_ROUTE_DEPENDENCY),
+      ),
+    );
+  });
+
+  it("derives consumer quote capability from reviewed activation status", () => {
+    const report = famePoolActivationReport();
+
+    for (const pool of report.upstreamPools) {
+      if (pool.activationStatus === "reserve-compact-quote-active") {
+        assert.equal(pool.consumerQuoteCapability, "reserve-compact-quote");
+      } else if (pool.activationStatus === "cl-compact-quote-active") {
+        assert.equal(pool.consumerQuoteCapability, "cl-compact-quote");
+      } else {
+        assert.equal(pool.consumerQuoteCapability, "none", pool.poolId);
+      }
+    }
+  });
+
+  it("keeps the basedflick/ZORA V4 dependency unsupported for compact quotes", () => {
+    const report = famePoolActivationReport();
+    const v4Dependency = report.upstreamPools.find(
+      (entry) => entry.poolId === FAME_SELECTED_LIVE_ROUTE_DEPENDENCY,
+    );
+
+    assert.equal(v4Dependency?.activationStatus, "unsupported");
+    assert.equal(v4Dependency?.consumerQuoteCapability, "none");
+    assert.equal(v4Dependency?.liveRouteDependency, true);
+    assert.match(v4Dependency?.reason ?? "", /V4 compact quote support/i);
+  });
+
+  it("reports producer-only entries without counting them as upstream pools", () => {
+    const report = famePoolActivationReport();
+
+    assert.ok(
+      report.producerOnlyPools.some(
+        (entry) => entry.poolId === "native-wrap-weth",
+      ),
+    );
+    assert.ok(
+      !report.upstreamPools.some(
+        (entry) => entry.poolId === "native-wrap-weth",
+      ),
+    );
+  });
+});

--- a/src/features/fame-swap/solver/poolActivation.test.ts
+++ b/src/features/fame-swap/solver/poolActivation.test.ts
@@ -102,16 +102,16 @@ describe("FAME pool activation report", () => {
     }
   });
 
-  it("keeps the basedflick/ZORA V4 dependency unsupported for compact quotes", () => {
+  it("keeps the basedflick/ZORA V4 dependency tracked-only for compact quotes", () => {
     const report = famePoolActivationReport();
     const v4Dependency = report.upstreamPools.find(
       (entry) => entry.poolId === FAME_SELECTED_LIVE_ROUTE_DEPENDENCY,
     );
 
-    assert.equal(v4Dependency?.activationStatus, "unsupported");
+    assert.equal(v4Dependency?.activationStatus, "tracked-only");
     assert.equal(v4Dependency?.consumerQuoteCapability, "none");
     assert.equal(v4Dependency?.liveRouteDependency, true);
-    assert.match(v4Dependency?.reason ?? "", /V4 compact quote support/i);
+    assert.match(v4Dependency?.reason ?? "", /Non-direct FAME pool/i);
   });
 
   it("reports producer-only entries without counting them as upstream pools", () => {

--- a/src/features/fame-swap/solver/poolActivation.ts
+++ b/src/features/fame-swap/solver/poolActivation.ts
@@ -1,0 +1,333 @@
+import { FAME_SWAP_ARTIFACT_MANIFEST } from "../artifacts/manifest";
+import type {
+  FamePoolConfig,
+  FamePoolVenue,
+  VenueFamilyName,
+} from "../router/types";
+import { poolUniverseFile, solverRoutesFile } from "./artifacts";
+import {
+  famePoolStateRegistry,
+  type FamePoolStateRegistryEntry,
+} from "./poolStateRegistry";
+import {
+  feeDescriptorForPool,
+  type FamePoolFeeDescriptor,
+} from "./poolUniverse";
+
+import {
+  FAME_POOL_ACTIVATION_LEDGER_HASH,
+  FAME_POOL_ACTIVATION_SCHEMA_VERSION,
+  FAME_SELECTED_CL_ACTIVATION_CANDIDATE,
+  FAME_SELECTED_LIVE_ROUTE_DEPENDENCY,
+  REVIEWED_POOL_ACTIVATIONS,
+  compactQuoteCapabilityForStatus,
+  type FameConsumerQuoteCapability,
+  type FamePoolActivationStatus,
+  type FameProducerRegistryPresence,
+} from "./poolActivationLedger";
+
+export {
+  FAME_POOL_ACTIVATION_SCHEMA_VERSION,
+  FAME_POOL_ACTIVATION_STATUS_VALUES,
+  FAME_SELECTED_CL_ACTIVATION_CANDIDATE,
+  FAME_SELECTED_LIVE_ROUTE_DEPENDENCY,
+  REVIEWED_POOL_ACTIVATIONS,
+  compactQuoteCapabilityForStatus,
+  poolIdsForActivationStatus,
+  reviewedPoolActivation,
+  reviewedPoolActivationEntries,
+} from "./poolActivationLedger";
+export type {
+  FameConsumerQuoteCapability,
+  FamePoolActivationStatus,
+  FameProducerRegistryPresence,
+  ReviewedFamePoolActivation,
+  ReviewedFamePoolActivationEntry,
+} from "./poolActivationLedger";
+
+export interface FamePoolActivationRouteReference {
+  id: string;
+  selected: boolean;
+  routePoolOrder: readonly string[];
+}
+
+export interface FamePoolActivationEntry {
+  poolId: string;
+  venue: FamePoolVenue;
+  venueFamily: VenueFamilyName;
+  activationStatus: FamePoolActivationStatus;
+  producerRegistryPresence: FameProducerRegistryPresence;
+  consumerQuoteCapability: FameConsumerQuoteCapability;
+  routeArtifactIds: readonly string[];
+  selectedRouteArtifactIds: readonly string[];
+  routeReferences: readonly FamePoolActivationRouteReference[];
+  liveRouteDependencies: readonly string[];
+  selectedCandidate: boolean;
+  liveRouteDependency: boolean;
+  producerRegistryEntry: FamePoolStateRegistryEntry | null;
+  fee: FamePoolFeeDescriptor;
+  reason: string;
+}
+
+export interface FameProducerOnlyActivationEntry {
+  poolId: string;
+  producerRegistryPresence: "producer-only";
+  activationStatus: "tracked-only";
+  consumerQuoteCapability: "none";
+  reason: string;
+}
+
+export interface FamePoolActivationReport {
+  schemaVersion: typeof FAME_POOL_ACTIVATION_SCHEMA_VERSION;
+  status: "generated-reviewed-activation";
+  source: {
+    repo: "www";
+    schemaVersion: number;
+    pinnedBaseBlock: number;
+    poolsJsonHash: string;
+    poolsContentHash: string;
+    solverRoutesJsonHash: string;
+    solverRoutesContentHash: string;
+    poolStateRegistrySchemaVersion: number;
+    activationLedgerHash: string;
+  };
+  selectedCandidatePoolId: typeof FAME_SELECTED_CL_ACTIVATION_CANDIDATE;
+  liveRouteDependencyPoolId: typeof FAME_SELECTED_LIVE_ROUTE_DEPENDENCY;
+  upstreamPoolCount: number;
+  producerRegistryPoolCount: number;
+  upstreamPools: readonly FamePoolActivationEntry[];
+  producerOnlyPools: readonly FameProducerOnlyActivationEntry[];
+  statusCounts: Record<FamePoolActivationStatus, number>;
+}
+
+const venueFamilies = {
+  solidly: "Solidly",
+  "uniswap-v2": "UniswapV2",
+  "aerodrome-v2": "AerodromeV2",
+  "aerodrome-slipstream": "Slipstream",
+  "aerodrome-slipstream2": "Slipstream2",
+  "uniswap-v3": "UniswapV3",
+  "uniswap-v4": "UniswapV4",
+  "native-wrap": "NativeWrap",
+} as const satisfies Record<FamePoolVenue, VenueFamilyName>;
+
+function selectedRouteIds(): Set<string> {
+  return new Set(FAME_SWAP_ARTIFACT_MANIFEST.routeArtifactIds);
+}
+
+function registryEntriesById(): Map<string, FamePoolStateRegistryEntry> {
+  return new Map(
+    famePoolStateRegistry().pools.map((entry) => [entry.id, entry]),
+  );
+}
+
+function routeReferencesForPool(
+  poolId: string,
+): FamePoolActivationRouteReference[] {
+  const selected = selectedRouteIds();
+  return solverRoutesFile.routes
+    .filter((route) => route.poolIds.includes(poolId))
+    .map((route) => ({
+      id: route.id,
+      selected: selected.has(route.id),
+      routePoolOrder: route.poolIds,
+    }))
+    .sort((left, right) => left.id.localeCompare(right.id));
+}
+
+function liveRouteDependencies(
+  poolId: string,
+  routeReferences: readonly FamePoolActivationRouteReference[],
+): string[] {
+  if (poolId !== FAME_SELECTED_CL_ACTIVATION_CANDIDATE) return [];
+  const dependsOnLiveV4 = routeReferences.some((reference) =>
+    reference.routePoolOrder.includes(FAME_SELECTED_LIVE_ROUTE_DEPENDENCY),
+  );
+  return dependsOnLiveV4 ? [FAME_SELECTED_LIVE_ROUTE_DEPENDENCY] : [];
+}
+
+export function assertReviewedPoolActivationCoverage(
+  upstreamPoolIds: readonly string[],
+  reviewedPoolIds: readonly string[] = Object.keys(REVIEWED_POOL_ACTIVATIONS),
+): void {
+  const upstream = new Set(upstreamPoolIds);
+  const reviewed = new Set(reviewedPoolIds);
+  for (const poolId of upstream) {
+    if (!reviewed.has(poolId)) {
+      throw new Error(
+        `Missing reviewed activation status for upstream pool ${poolId}.`,
+      );
+    }
+  }
+  for (const poolId of reviewed) {
+    if (!upstream.has(poolId)) {
+      throw new Error(
+        `Reviewed activation status references unknown upstream pool ${poolId}.`,
+      );
+    }
+  }
+}
+
+function activationEntryForPool(
+  pool: FamePoolConfig,
+  registryEntry: FamePoolStateRegistryEntry | null,
+): FamePoolActivationEntry {
+  const reviewed = REVIEWED_POOL_ACTIVATIONS[pool.id];
+  if (!reviewed) {
+    throw new Error(
+      `Missing reviewed activation status for upstream pool ${pool.id}.`,
+    );
+  }
+  const routeReferences = routeReferencesForPool(pool.id);
+  const selectedRouteArtifactIds = routeReferences
+    .filter((reference) => reference.selected)
+    .map((reference) => reference.id);
+  const activationStatus = reviewed.activationStatus;
+
+  return {
+    poolId: pool.id,
+    venue: pool.venue,
+    venueFamily: venueFamilies[pool.venue],
+    activationStatus,
+    producerRegistryPresence: reviewed.producerRegistryPresence,
+    consumerQuoteCapability: compactQuoteCapabilityForStatus(activationStatus),
+    routeArtifactIds: routeReferences.map((reference) => reference.id),
+    selectedRouteArtifactIds,
+    routeReferences,
+    liveRouteDependencies: liveRouteDependencies(pool.id, routeReferences),
+    selectedCandidate: pool.id === FAME_SELECTED_CL_ACTIVATION_CANDIDATE,
+    liveRouteDependency: pool.id === FAME_SELECTED_LIVE_ROUTE_DEPENDENCY,
+    producerRegistryEntry: registryEntry,
+    fee: feeDescriptorForPool(pool),
+    reason: reviewed.reason,
+  };
+}
+
+function statusCounts(
+  entries: readonly FamePoolActivationEntry[],
+): Record<FamePoolActivationStatus, number> {
+  const counts: Record<FamePoolActivationStatus, number> = {
+    "reserve-compact-quote-active": 0,
+    "cl-compact-quote-active": 0,
+    "cl-replay-candidate": 0,
+    "cl-head-only": 0,
+    "tracked-only": 0,
+    blocked: 0,
+    unsupported: 0,
+    "producer-unrepresented": 0,
+  };
+  for (const entry of entries) counts[entry.activationStatus] += 1;
+  return counts;
+}
+
+function producerOnlyEntries(
+  upstreamPoolIds: ReadonlySet<string>,
+): FameProducerOnlyActivationEntry[] {
+  return famePoolStateRegistry()
+    .pools.filter((entry) => !upstreamPoolIds.has(entry.id))
+    .map((entry) => ({
+      poolId: entry.id,
+      producerRegistryPresence: "producer-only" as const,
+      activationStatus: "tracked-only" as const,
+      consumerQuoteCapability: "none" as const,
+      reason:
+        "Producer-only helper entry; not part of the upstream www pool universe.",
+    }))
+    .sort((left, right) => left.poolId.localeCompare(right.poolId));
+}
+
+function assertActivationReport(report: FamePoolActivationReport): void {
+  const seen = new Set<string>();
+  for (const entry of report.upstreamPools) {
+    if (seen.has(entry.poolId)) {
+      throw new Error(
+        `Duplicate activation row for upstream pool ${entry.poolId}.`,
+      );
+    }
+    seen.add(entry.poolId);
+    if (
+      entry.activationStatus === "blocked" &&
+      entry.consumerQuoteCapability !== "none"
+    ) {
+      throw new Error(
+        `Blocked pool ${entry.poolId} cannot be compact quote capable.`,
+      );
+    }
+    if (
+      entry.consumerQuoteCapability !==
+      compactQuoteCapabilityForStatus(entry.activationStatus)
+    ) {
+      throw new Error(
+        `Pool ${entry.poolId} consumer quote capability must be derived from activation status ${entry.activationStatus}.`,
+      );
+    }
+    if (
+      entry.producerRegistryPresence === "present" &&
+      entry.producerRegistryEntry === null
+    ) {
+      throw new Error(
+        `Pool ${entry.poolId} is reviewed as producer-present but has no registry entry.`,
+      );
+    }
+    if (
+      entry.producerRegistryPresence === "producer-unrepresented" &&
+      entry.producerRegistryEntry !== null
+    ) {
+      throw new Error(
+        `Pool ${entry.poolId} is reviewed as producer-unrepresented but has a registry entry.`,
+      );
+    }
+    if (
+      entry.producerRegistryEntry !== null &&
+      entry.producerRegistryEntry.activationStatus !== entry.activationStatus
+    ) {
+      throw new Error(
+        `Pool ${entry.poolId} registry activation status ${entry.producerRegistryEntry.activationStatus} does not match reviewed status ${entry.activationStatus}.`,
+      );
+    }
+  }
+  if (seen.size !== report.upstreamPoolCount) {
+    throw new Error(
+      `Activation report covers ${seen.size.toString()} upstream pools, expected ${report.upstreamPoolCount.toString()}.`,
+    );
+  }
+}
+
+export function famePoolActivationReport(): FamePoolActivationReport {
+  assertReviewedPoolActivationCoverage(
+    poolUniverseFile.pools.map((pool) => pool.id),
+  );
+  const registryById = registryEntriesById();
+  const registry = famePoolStateRegistry();
+  const upstreamPools = poolUniverseFile.pools
+    .map((pool) =>
+      activationEntryForPool(pool, registryById.get(pool.id) ?? null),
+    )
+    .sort((left, right) => left.poolId.localeCompare(right.poolId));
+  const upstreamPoolIds = new Set(upstreamPools.map((entry) => entry.poolId));
+  const report: FamePoolActivationReport = {
+    schemaVersion: FAME_POOL_ACTIVATION_SCHEMA_VERSION,
+    status: "generated-reviewed-activation",
+    source: {
+      repo: "www",
+      schemaVersion: FAME_SWAP_ARTIFACT_MANIFEST.schemaVersion,
+      pinnedBaseBlock: FAME_SWAP_ARTIFACT_MANIFEST.pinnedBaseBlock,
+      poolsJsonHash: FAME_SWAP_ARTIFACT_MANIFEST.poolsJsonHash,
+      poolsContentHash: FAME_SWAP_ARTIFACT_MANIFEST.poolsContentHash,
+      solverRoutesJsonHash: FAME_SWAP_ARTIFACT_MANIFEST.solverRoutesJsonHash,
+      solverRoutesContentHash:
+        FAME_SWAP_ARTIFACT_MANIFEST.solverRoutesContentHash,
+      poolStateRegistrySchemaVersion: registry.schemaVersion,
+      activationLedgerHash: FAME_POOL_ACTIVATION_LEDGER_HASH,
+    },
+    selectedCandidatePoolId: FAME_SELECTED_CL_ACTIVATION_CANDIDATE,
+    liveRouteDependencyPoolId: FAME_SELECTED_LIVE_ROUTE_DEPENDENCY,
+    upstreamPoolCount: poolUniverseFile.pools.length,
+    producerRegistryPoolCount: registry.pools.length,
+    upstreamPools,
+    producerOnlyPools: producerOnlyEntries(upstreamPoolIds),
+    statusCounts: statusCounts(upstreamPools),
+  };
+  assertActivationReport(report);
+  return report;
+}

--- a/src/features/fame-swap/solver/poolActivationLedger.ts
+++ b/src/features/fame-swap/solver/poolActivationLedger.ts
@@ -1,0 +1,237 @@
+export const FAME_POOL_ACTIVATION_SCHEMA_VERSION = 1;
+export const FAME_POOL_ACTIVATION_LEDGER_HASH =
+  "0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b";
+
+export const FAME_SELECTED_CL_ACTIVATION_CANDIDATE =
+  "slipstream-basedflick-fame";
+export const FAME_SELECTED_LIVE_ROUTE_DEPENDENCY = "uniswap-v4-basedflick-zora";
+
+export const FAME_POOL_ACTIVATION_STATUS_VALUES = [
+  "reserve-compact-quote-active",
+  "cl-compact-quote-active",
+  "cl-replay-candidate",
+  "cl-head-only",
+  "tracked-only",
+  "blocked",
+  "unsupported",
+  "producer-unrepresented",
+] as const;
+
+export type FamePoolActivationStatus =
+  (typeof FAME_POOL_ACTIVATION_STATUS_VALUES)[number];
+
+export type FameProducerRegistryPresence =
+  | "present"
+  | "producer-only"
+  | "producer-unrepresented";
+
+export type FameConsumerQuoteCapability =
+  | "reserve-compact-quote"
+  | "cl-compact-quote"
+  | "none";
+
+export interface ReviewedFamePoolActivation {
+  activationStatus: FamePoolActivationStatus;
+  producerRegistryPresence: Exclude<
+    FameProducerRegistryPresence,
+    "producer-only"
+  >;
+  reason: string;
+}
+
+export interface ReviewedFamePoolActivationEntry
+  extends ReviewedFamePoolActivation {
+  poolId: string;
+}
+
+export const REVIEWED_POOL_ACTIVATIONS = {
+  "aerodrome-v2-usdc-weth": {
+    activationStatus: "reserve-compact-quote-active",
+    producerRegistryPresence: "present",
+    reason: "Reserve pool is active for compact quote rows.",
+  },
+  "scale-equalizer-frxusd-fame": {
+    activationStatus: "reserve-compact-quote-active",
+    producerRegistryPresence: "present",
+    reason: "Reserve pool is active for compact quote rows.",
+  },
+  "scale-equalizer-scale-fame": {
+    activationStatus: "reserve-compact-quote-active",
+    producerRegistryPresence: "present",
+    reason: "Reserve pool is active for compact quote rows.",
+  },
+  "scale-equalizer-usdc-frxusd": {
+    activationStatus: "tracked-only",
+    producerRegistryPresence: "present",
+    reason:
+      "Stable Solidly reserve math is not part of this activation lane; keep tracked for inventory only.",
+  },
+  "scale-equalizer-usdc-scale": {
+    activationStatus: "reserve-compact-quote-active",
+    producerRegistryPresence: "present",
+    reason: "Reserve pool is active for compact quote rows.",
+  },
+  "scale-equalizer-weth-fame": {
+    activationStatus: "reserve-compact-quote-active",
+    producerRegistryPresence: "present",
+    reason: "Reserve pool is active for compact quote rows.",
+  },
+  "slipstream-basedflick-fame": {
+    activationStatus: "cl-compact-quote-active",
+    producerRegistryPresence: "present",
+    reason:
+      "Selected v1 Slipstream CL leg is compact quote active for www routes; basedflick/ZORA remains a live V4 dependency.",
+  },
+  "slipstream-msusd-usdc-a": {
+    activationStatus: "producer-unrepresented",
+    producerRegistryPresence: "producer-unrepresented",
+    reason:
+      "Upstream Slipstream pool is not represented in the producer pool-state registry.",
+  },
+  "slipstream-spx-weth": {
+    activationStatus: "producer-unrepresented",
+    producerRegistryPresence: "producer-unrepresented",
+    reason:
+      "Upstream Slipstream pool is not represented in the producer pool-state registry.",
+  },
+  "slipstream-usdc-frxusd": {
+    activationStatus: "cl-head-only",
+    producerRegistryPresence: "present",
+    reason:
+      "Slipstream pool can support CL head-state diagnostics, but is not selected for compact quote activation in v1.",
+  },
+  "slipstream-usdc-weth-100": {
+    activationStatus: "cl-compact-quote-active",
+    producerRegistryPresence: "present",
+    reason:
+      "Reviewed Slipstream CL replay baseline is active for compact quote rows.",
+  },
+  "slipstream-usdc-weth-migrating-50": {
+    activationStatus: "blocked",
+    producerRegistryPresence: "producer-unrepresented",
+    reason:
+      "Aerodrome migrating pool belongs to the migration factory and must stay blocked until factory and tick-spacing assumptions are reviewed.",
+  },
+  "slipstream-weth-mseth": {
+    activationStatus: "producer-unrepresented",
+    producerRegistryPresence: "producer-unrepresented",
+    reason:
+      "Upstream Slipstream pool is not represented in the producer pool-state registry.",
+  },
+  "slipstream-zora-usdc": {
+    activationStatus: "cl-head-only",
+    producerRegistryPresence: "present",
+    reason:
+      "Slipstream pool can support CL head-state diagnostics, but is not selected for compact quote activation in v1.",
+  },
+  "slipstream-zora-weth": {
+    activationStatus: "cl-head-only",
+    producerRegistryPresence: "present",
+    reason:
+      "Slipstream pool can support CL head-state diagnostics, but is not selected for compact quote activation in v1.",
+  },
+  "slipstream2-msusd-mseth": {
+    activationStatus: "producer-unrepresented",
+    producerRegistryPresence: "producer-unrepresented",
+    reason:
+      "Slipstream2 pool is not represented in the producer registry and cannot inherit Slipstream replay support.",
+  },
+  "slipstream2-msusd-usdc-c": {
+    activationStatus: "producer-unrepresented",
+    producerRegistryPresence: "producer-unrepresented",
+    reason:
+      "Slipstream2 pool is not represented in the producer registry and cannot inherit Slipstream replay support.",
+  },
+  "uniswap-v2-fame-direct": {
+    activationStatus: "reserve-compact-quote-active",
+    producerRegistryPresence: "present",
+    reason: "Reserve pool is active for compact quote rows.",
+  },
+  "uniswap-v2-usdc-weth": {
+    activationStatus: "reserve-compact-quote-active",
+    producerRegistryPresence: "present",
+    reason: "Reserve pool is active for compact quote rows.",
+  },
+  "uniswap-v3-usdc-weth-30bps": {
+    activationStatus: "cl-head-only",
+    producerRegistryPresence: "present",
+    reason:
+      "Uniswap V3 pool can support CL head-state diagnostics, but is not compact quote active in this checkout.",
+  },
+  "uniswap-v3-usdc-weth-5bps": {
+    activationStatus: "cl-head-only",
+    producerRegistryPresence: "present",
+    reason:
+      "Uniswap V3 pool can support CL head-state diagnostics, but is not compact quote active in this checkout.",
+  },
+  "uniswap-v3-zora-usdc": {
+    activationStatus: "cl-head-only",
+    producerRegistryPresence: "present",
+    reason:
+      "Uniswap V3 pool can support CL head-state diagnostics, but is not compact quote active in this checkout.",
+  },
+  "uniswap-v3-zora-weth": {
+    activationStatus: "cl-head-only",
+    producerRegistryPresence: "present",
+    reason:
+      "Uniswap V3 pool can support CL head-state diagnostics, but is not compact quote active in this checkout.",
+  },
+  "uniswap-v4-basedflick-zora": {
+    activationStatus: "unsupported",
+    producerRegistryPresence: "present",
+    reason:
+      "Live V4 route dependency; Uniswap V4 compact quote support is unsupported until a V4 reducer model is reviewed.",
+  },
+  "uniswap-v4-usdc-eth": {
+    activationStatus: "unsupported",
+    producerRegistryPresence: "present",
+    reason:
+      "Uniswap V4 compact quote support is unsupported until PoolManager, PoolId, hook, fee, and StateView semantics have a reviewed reducer model.",
+  },
+  "uniswap-v4-zora-eth": {
+    activationStatus: "unsupported",
+    producerRegistryPresence: "present",
+    reason:
+      "Uniswap V4 compact quote support is unsupported until PoolManager, PoolId, hook, fee, and StateView semantics have a reviewed reducer model.",
+  },
+} as const satisfies Record<string, ReviewedFamePoolActivation>;
+
+export function reviewedPoolActivation(
+  poolId: string,
+): ReviewedFamePoolActivation | undefined {
+  return (
+    REVIEWED_POOL_ACTIVATIONS as Record<
+      string,
+      ReviewedFamePoolActivation | undefined
+    >
+  )[poolId];
+}
+
+export function reviewedPoolActivationEntries(): ReviewedFamePoolActivationEntry[] {
+  return Object.entries(REVIEWED_POOL_ACTIVATIONS).map(
+    ([poolId, activation]) => ({
+      poolId,
+      ...activation,
+    }),
+  );
+}
+
+export function poolIdsForActivationStatus(
+  status: FamePoolActivationStatus,
+): string[] {
+  return reviewedPoolActivationEntries()
+    .filter((entry) => entry.activationStatus === status)
+    .map((entry) => entry.poolId);
+}
+
+export function compactQuoteCapabilityForStatus(
+  status: FamePoolActivationStatus,
+): FameConsumerQuoteCapability {
+  if (status === "reserve-compact-quote-active") {
+    return "reserve-compact-quote";
+  }
+  if (status === "cl-compact-quote-active") {
+    return "cl-compact-quote";
+  }
+  return "none";
+}

--- a/src/features/fame-swap/solver/poolActivationLedger.ts
+++ b/src/features/fame-swap/solver/poolActivationLedger.ts
@@ -1,6 +1,6 @@
 export const FAME_POOL_ACTIVATION_SCHEMA_VERSION = 1;
 export const FAME_POOL_ACTIVATION_LEDGER_HASH =
-  "0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b";
+  "0xb533796d3cec89d202f49e0245c9769cba8aa7c92ad537fe33cfc44597927c0f";
 
 export const FAME_SELECTED_CL_ACTIVATION_CANDIDATE =
   "slipstream-basedflick-fame";
@@ -46,9 +46,10 @@ export interface ReviewedFamePoolActivationEntry
 
 export const REVIEWED_POOL_ACTIVATIONS = {
   "aerodrome-v2-usdc-weth": {
-    activationStatus: "reserve-compact-quote-active",
+    activationStatus: "tracked-only",
     producerRegistryPresence: "present",
-    reason: "Reserve pool is active for compact quote rows.",
+    reason:
+      "Non-direct FAME pool disabled to keep producer and quote traffic scoped to direct FAME pairs.",
   },
   "scale-equalizer-frxusd-fame": {
     activationStatus: "reserve-compact-quote-active",
@@ -64,12 +65,13 @@ export const REVIEWED_POOL_ACTIVATIONS = {
     activationStatus: "tracked-only",
     producerRegistryPresence: "present",
     reason:
-      "Stable Solidly reserve math is not part of this activation lane; keep tracked for inventory only.",
+      "Non-direct FAME pool disabled to keep producer and quote traffic scoped to direct FAME pairs.",
   },
   "scale-equalizer-usdc-scale": {
-    activationStatus: "reserve-compact-quote-active",
+    activationStatus: "tracked-only",
     producerRegistryPresence: "present",
-    reason: "Reserve pool is active for compact quote rows.",
+    reason:
+      "Non-direct FAME pool disabled to keep producer and quote traffic scoped to direct FAME pairs.",
   },
   "scale-equalizer-weth-fame": {
     activationStatus: "reserve-compact-quote-active",
@@ -95,16 +97,16 @@ export const REVIEWED_POOL_ACTIVATIONS = {
       "Upstream Slipstream pool is not represented in the producer pool-state registry.",
   },
   "slipstream-usdc-frxusd": {
-    activationStatus: "cl-head-only",
+    activationStatus: "tracked-only",
     producerRegistryPresence: "present",
     reason:
-      "Slipstream pool can support CL head-state diagnostics, but is not selected for compact quote activation in v1.",
+      "Non-direct FAME pool disabled to keep producer and quote traffic scoped to direct FAME pairs.",
   },
   "slipstream-usdc-weth-100": {
-    activationStatus: "cl-compact-quote-active",
+    activationStatus: "tracked-only",
     producerRegistryPresence: "present",
     reason:
-      "Reviewed Slipstream CL replay baseline is active for compact quote rows.",
+      "Non-direct FAME pool disabled to keep producer and quote traffic scoped to direct FAME pairs.",
   },
   "slipstream-usdc-weth-migrating-50": {
     activationStatus: "blocked",
@@ -119,16 +121,16 @@ export const REVIEWED_POOL_ACTIVATIONS = {
       "Upstream Slipstream pool is not represented in the producer pool-state registry.",
   },
   "slipstream-zora-usdc": {
-    activationStatus: "cl-head-only",
+    activationStatus: "tracked-only",
     producerRegistryPresence: "present",
     reason:
-      "Slipstream pool can support CL head-state diagnostics, but is not selected for compact quote activation in v1.",
+      "Non-direct FAME pool disabled to keep producer and quote traffic scoped to direct FAME pairs.",
   },
   "slipstream-zora-weth": {
-    activationStatus: "cl-head-only",
+    activationStatus: "tracked-only",
     producerRegistryPresence: "present",
     reason:
-      "Slipstream pool can support CL head-state diagnostics, but is not selected for compact quote activation in v1.",
+      "Non-direct FAME pool disabled to keep producer and quote traffic scoped to direct FAME pairs.",
   },
   "slipstream2-msusd-mseth": {
     activationStatus: "producer-unrepresented",
@@ -148,51 +150,52 @@ export const REVIEWED_POOL_ACTIVATIONS = {
     reason: "Reserve pool is active for compact quote rows.",
   },
   "uniswap-v2-usdc-weth": {
-    activationStatus: "reserve-compact-quote-active",
+    activationStatus: "tracked-only",
     producerRegistryPresence: "present",
-    reason: "Reserve pool is active for compact quote rows.",
+    reason:
+      "Non-direct FAME pool disabled to keep producer and quote traffic scoped to direct FAME pairs.",
   },
   "uniswap-v3-usdc-weth-30bps": {
-    activationStatus: "cl-head-only",
+    activationStatus: "tracked-only",
     producerRegistryPresence: "present",
     reason:
-      "Uniswap V3 pool can support CL head-state diagnostics, but is not compact quote active in this checkout.",
+      "Non-direct FAME pool disabled to keep producer and quote traffic scoped to direct FAME pairs.",
   },
   "uniswap-v3-usdc-weth-5bps": {
-    activationStatus: "cl-head-only",
+    activationStatus: "tracked-only",
     producerRegistryPresence: "present",
     reason:
-      "Uniswap V3 pool can support CL head-state diagnostics, but is not compact quote active in this checkout.",
+      "Non-direct FAME pool disabled to keep producer and quote traffic scoped to direct FAME pairs.",
   },
   "uniswap-v3-zora-usdc": {
-    activationStatus: "cl-head-only",
+    activationStatus: "tracked-only",
     producerRegistryPresence: "present",
     reason:
-      "Uniswap V3 pool can support CL head-state diagnostics, but is not compact quote active in this checkout.",
+      "Non-direct FAME pool disabled to keep producer and quote traffic scoped to direct FAME pairs.",
   },
   "uniswap-v3-zora-weth": {
-    activationStatus: "cl-head-only",
+    activationStatus: "tracked-only",
     producerRegistryPresence: "present",
     reason:
-      "Uniswap V3 pool can support CL head-state diagnostics, but is not compact quote active in this checkout.",
+      "Non-direct FAME pool disabled to keep producer and quote traffic scoped to direct FAME pairs.",
   },
   "uniswap-v4-basedflick-zora": {
-    activationStatus: "unsupported",
+    activationStatus: "tracked-only",
     producerRegistryPresence: "present",
     reason:
-      "Live V4 route dependency; Uniswap V4 compact quote support is unsupported until a V4 reducer model is reviewed.",
+      "Non-direct FAME pool disabled to keep producer and quote traffic scoped to direct FAME pairs.",
   },
   "uniswap-v4-usdc-eth": {
-    activationStatus: "unsupported",
+    activationStatus: "tracked-only",
     producerRegistryPresence: "present",
     reason:
-      "Uniswap V4 compact quote support is unsupported until PoolManager, PoolId, hook, fee, and StateView semantics have a reviewed reducer model.",
+      "Non-direct FAME pool disabled to keep producer and quote traffic scoped to direct FAME pairs.",
   },
   "uniswap-v4-zora-eth": {
-    activationStatus: "unsupported",
+    activationStatus: "tracked-only",
     producerRegistryPresence: "present",
     reason:
-      "Uniswap V4 compact quote support is unsupported until PoolManager, PoolId, hook, fee, and StateView semantics have a reviewed reducer model.",
+      "Non-direct FAME pool disabled to keep producer and quote traffic scoped to direct FAME pairs.",
   },
 } as const satisfies Record<string, ReviewedFamePoolActivation>;
 

--- a/src/features/fame-swap/solver/poolStateRegistry.test.ts
+++ b/src/features/fame-swap/solver/poolStateRegistry.test.ts
@@ -1,7 +1,17 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { describe, it } from "node:test";
 import { FAME_SWAP_ARTIFACT_MANIFEST } from "../artifacts/manifest";
 import {
+  FAME_POOL_ACTIVATION_LEDGER_HASH,
+  FAME_POOL_ACTIVATION_SCHEMA_VERSION,
+  FAME_SELECTED_CL_ACTIVATION_CANDIDATE,
+  FAME_SELECTED_LIVE_ROUTE_DEPENDENCY,
+  REVIEWED_POOL_ACTIVATIONS,
+  poolIdsForActivationStatus,
+} from "./poolActivationLedger";
+import {
+  activationStatusForRegistryPoolId,
   CL_REPLAY_CAPABLE_FAME_POOL_IDS,
   COMPACT_QUOTE_CAPABLE_FAME_POOL_IDS,
   famePoolSupportsCompactQuote,
@@ -10,6 +20,29 @@ import {
   QUOTE_MODEL_CAPABLE_FAME_POOL_IDS,
 } from "./poolStateRegistry";
 
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(",")}]`;
+  }
+  if (value !== null && typeof value === "object") {
+    return `{${Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, nested]) => `${JSON.stringify(key)}:${canonicalJson(nested)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function activationLedgerDigest(): string {
+  const material = {
+    schemaVersion: FAME_POOL_ACTIVATION_SCHEMA_VERSION,
+    selectedCandidatePoolId: FAME_SELECTED_CL_ACTIVATION_CANDIDATE,
+    liveRouteDependencyPoolId: FAME_SELECTED_LIVE_ROUTE_DEPENDENCY,
+    reviewedPoolActivations: REVIEWED_POOL_ACTIVATIONS,
+  };
+  return `0x${createHash("sha256").update(canonicalJson(material)).digest("hex")}`;
+}
+
 describe("FAME pool-state registry", () => {
   it("derives quote-model-capable pools from the reviewed route universe", () => {
     const registry = famePoolStateRegistry();
@@ -17,6 +50,10 @@ describe("FAME pool-state registry", () => {
       .filter((pool) => pool.capability === "quote-model")
       .map((pool) => pool.id);
 
+    assert.deepEqual(
+      QUOTE_MODEL_CAPABLE_FAME_POOL_IDS,
+      poolIdsForActivationStatus("reserve-compact-quote-active"),
+    );
     assert.deepEqual(capableIds, QUOTE_MODEL_CAPABLE_FAME_POOL_IDS);
     assert.deepEqual(capableIds, [
       "aerodrome-v2-usdc-weth",
@@ -33,6 +70,7 @@ describe("FAME pool-state registry", () => {
         .every(
           (pool) =>
             pool.stateSurface === "constant-product-reserves" &&
+            pool.activationStatus === "reserve-compact-quote-active" &&
             pool.replaySurface === null &&
             pool.quoteModel === "constant-product-reserves" &&
             pool.unsupportedReason === null,
@@ -44,6 +82,12 @@ describe("FAME pool-state registry", () => {
     const registry = famePoolStateRegistry();
     const trackedOnly = registry.pools.filter(
       (pool) => pool.capability === "tracked-only",
+    );
+    const candidate = registry.pools.find(
+      (pool) => pool.id === FAME_SELECTED_CL_ACTIVATION_CANDIDATE,
+    );
+    const v4Dependency = registry.pools.find(
+      (pool) => pool.id === FAME_SELECTED_LIVE_ROUTE_DEPENDENCY,
     );
     const marketState = registry.pools.filter(
       (pool) => pool.capability === "market-state",
@@ -88,10 +132,24 @@ describe("FAME pool-state registry", () => {
           pool.stateViewAddress !== null,
       ),
     );
+    assert.equal(candidate?.capability, "market-state");
+    assert.equal(candidate?.activationStatus, "cl-compact-quote-active");
+    assert.equal(
+      candidate?.factoryAddress,
+      "0x5e7bb104d84c7cb9b682aac2f3d509f5f406809a",
+    );
+    assert.equal(candidate?.stateSurface, "cl-head-snapshot");
+    assert.equal(candidate?.replaySurface, "cl-replay-v1");
+    assert.equal(v4Dependency?.capability, "market-state");
+    assert.equal(v4Dependency?.activationStatus, "unsupported");
+    assert.equal(v4Dependency?.replaySurface, null);
   });
 
-  it("marks only slipstream-usdc-weth-100 as CL replay-capable", () => {
+  it("marks activation-approved Slipstream v1 pools as CL replay-capable", () => {
     const registry = famePoolStateRegistry();
+    const candidate = registry.pools.find(
+      (pool) => pool.id === FAME_SELECTED_CL_ACTIVATION_CANDIDATE,
+    );
     const replayIds = registry.pools
       .filter((pool) => pool.replaySurface === "cl-replay-v1")
       .map((pool) => pool.id);
@@ -99,12 +157,35 @@ describe("FAME pool-state registry", () => {
       (pool) => pool.id === "slipstream-usdc-weth-100",
     );
 
+    assert.deepEqual(
+      CL_REPLAY_CAPABLE_FAME_POOL_IDS,
+      poolIdsForActivationStatus("cl-compact-quote-active"),
+    );
     assert.deepEqual(replayIds, CL_REPLAY_CAPABLE_FAME_POOL_IDS);
     assert.equal(replayPool?.capability, "market-state");
     assert.equal(replayPool?.stateSurface, "cl-head-snapshot");
     assert.equal(replayPool?.replaySurface, "cl-replay-v1");
+    assert.equal(replayPool?.activationStatus, "cl-compact-quote-active");
     assert.equal(replayPool?.venue, "aerodrome-slipstream");
     assert.equal(replayPool?.tickSpacing, 100);
+    assert.equal(candidate?.replaySurface, "cl-replay-v1");
+    assert.equal(candidate?.activationStatus, "cl-compact-quote-active");
+    assert.ok(CL_REPLAY_CAPABLE_FAME_POOL_IDS.includes(candidate?.id ?? ""));
+  });
+
+  it("fails closed when registry rows are not reviewed as producer-present", () => {
+    assert.equal(
+      activationStatusForRegistryPoolId("native-wrap-weth"),
+      "tracked-only",
+    );
+    assert.throws(
+      () => activationStatusForRegistryPoolId("slipstream-spx-weth"),
+      /reviewed producer presence is producer-unrepresented/,
+    );
+    assert.throws(
+      () => activationStatusForRegistryPoolId("not-reviewed"),
+      /missing reviewed activation/,
+    );
   });
 
   it("derives compact quote-capable pools from reserve quote models plus CL replay", () => {
@@ -118,6 +199,14 @@ describe("FAME pool-state registry", () => {
       true,
     );
     assert.equal(famePoolSupportsCompactQuote("native-wrap-weth"), false);
+    assert.equal(
+      famePoolSupportsCompactQuote(FAME_SELECTED_CL_ACTIVATION_CANDIDATE),
+      true,
+    );
+    assert.equal(
+      famePoolSupportsCompactQuote(FAME_SELECTED_LIVE_ROUTE_DEPENDENCY),
+      false,
+    );
   });
 
   it("omits direct SPX/FAME and cbBTC/FAME until authoritative metadata exists", () => {
@@ -152,12 +241,20 @@ describe("FAME pool-state registry", () => {
       registry.source.solverRoutesJsonHash,
       FAME_SWAP_ARTIFACT_MANIFEST.solverRoutesJsonHash,
     );
+    assert.equal(
+      registry.source.activationLedgerHash,
+      FAME_POOL_ACTIVATION_LEDGER_HASH,
+    );
+  });
+
+  it("pins the activation ledger hash to reviewed activation content", () => {
+    assert.equal(FAME_POOL_ACTIVATION_LEDGER_HASH, activationLedgerDigest());
   });
 
   it("derives the cross-repo source registry id from authoritative artifact hashes", () => {
     assert.equal(
       famePoolStateRegistrySourceId(),
-      `pool-state-registry-v3:${FAME_SWAP_ARTIFACT_MANIFEST.poolsJsonHash}:${FAME_SWAP_ARTIFACT_MANIFEST.solverRoutesJsonHash}`,
+      `pool-state-registry-v4:${FAME_SWAP_ARTIFACT_MANIFEST.poolsJsonHash}:${FAME_SWAP_ARTIFACT_MANIFEST.solverRoutesJsonHash}:${FAME_POOL_ACTIVATION_LEDGER_HASH}`,
     );
   });
 });

--- a/src/features/fame-swap/solver/poolStateRegistry.test.ts
+++ b/src/features/fame-swap/solver/poolStateRegistry.test.ts
@@ -14,8 +14,10 @@ import {
   activationStatusForRegistryPoolId,
   CL_REPLAY_CAPABLE_FAME_POOL_IDS,
   COMPACT_QUOTE_CAPABLE_FAME_POOL_IDS,
+  FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE,
   FAME_V4_ZORA_REVIEWED_POOL_SHAPE,
   UNISWAP_V4_DYNAMIC_FEE_FLAG,
+  V4_ZORA_ETH_QUOTE_LANE_CANDIDATE_FAME_POOL_ID,
   V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID,
   classifyFameV4ZoraPoolConfig,
   classifyFameV4ZoraQuoteLane,
@@ -246,6 +248,14 @@ describe("FAME pool-state registry", () => {
   });
 
   it("derives compact quote-capable pools from reserve, CL replay, and reviewed V4 Zora gates", () => {
+    const activeV4QuoteLane = {
+      status: "active",
+      sourceRegistryId: famePoolStateRegistrySourceId(),
+      parityStatus: "passed",
+      routeSimulationStatus: "passed",
+      evidenceId: "unit-v4-zora-activation",
+    } as const;
+
     assert.deepEqual(COMPACT_QUOTE_CAPABLE_FAME_POOL_IDS, [
       ...QUOTE_MODEL_CAPABLE_FAME_POOL_IDS,
       ...CL_REPLAY_CAPABLE_FAME_POOL_IDS,
@@ -261,14 +271,21 @@ describe("FAME pool-state registry", () => {
     );
     assert.equal(
       famePoolSupportsCompactQuote(V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID, {
-        v4ZoraQuoteLaneActivation: {
-          status: "active",
-          sourceRegistryId: famePoolStateRegistrySourceId(),
-          parityStatus: "passed",
-          routeSimulationStatus: "passed",
-          evidenceId: "unit-v4-zora-activation",
-        },
+        v4ZoraQuoteLaneActivation: activeV4QuoteLane,
       }),
+      true,
+    );
+    assert.equal(
+      famePoolSupportsCompactQuote(
+        V4_ZORA_ETH_QUOTE_LANE_CANDIDATE_FAME_POOL_ID,
+      ),
+      false,
+    );
+    assert.equal(
+      famePoolSupportsCompactQuote(
+        V4_ZORA_ETH_QUOTE_LANE_CANDIDATE_FAME_POOL_ID,
+        { v4ZoraQuoteLaneActivation: activeV4QuoteLane },
+      ),
       true,
     );
     assert.equal(famePoolSupportsCompactQuote("uniswap-v4-usdc-eth"), false);
@@ -283,7 +300,7 @@ describe("FAME pool-state registry", () => {
     );
   });
 
-  it("surfaces BASEDFLICK/ZORA as the only provenance-gated V4 Zora quote lane candidate", () => {
+  it("surfaces reviewed V4 Zora quote lane candidates with lane-specific provenance", () => {
     assert.deepEqual(
       classifyFameV4ZoraQuoteLane(V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID),
       {
@@ -319,6 +336,40 @@ describe("FAME pool-state registry", () => {
       ),
       true,
     );
+    const zoraEth = classifyFameV4ZoraQuoteLane(
+      V4_ZORA_ETH_QUOTE_LANE_CANDIDATE_FAME_POOL_ID,
+    );
+    assert.equal(zoraEth.status, "target-eligible");
+    if (zoraEth.status !== "target-eligible") {
+      throw new Error("Expected reviewed ZORA/ETH to be target eligible.");
+    }
+    assert.equal(
+      famePoolSupportsV4ZoraQuoteLane(
+        V4_ZORA_ETH_QUOTE_LANE_CANDIDATE_FAME_POOL_ID,
+      ),
+      true,
+    );
+    assert.equal(zoraEth.manifest.provenanceRequired, false);
+    assert.deepEqual(
+      zoraEth.reviewedPoolShape,
+      FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE,
+    );
+    assert.deepEqual(zoraEth.hookPermissions, {
+      beforeInitialize: false,
+      afterInitialize: false,
+      beforeAddLiquidity: false,
+      afterAddLiquidity: false,
+      beforeRemoveLiquidity: false,
+      afterRemoveLiquidity: false,
+      beforeSwap: false,
+      afterSwap: false,
+      beforeDonate: false,
+      afterDonate: false,
+      beforeSwapReturnDelta: false,
+      afterSwapReturnDelta: false,
+      afterAddLiquidityReturnDelta: false,
+      afterRemoveLiquidityReturnDelta: false,
+    });
     assert.deepEqual(
       classifyFameV4ZoraQuoteLane("uniswap-v4-usdc-eth", {
         provenanceVerified: true,
@@ -333,8 +384,13 @@ describe("FAME pool-state registry", () => {
 
   it("rejects V4 Zora candidate shape drift before route eligibility", () => {
     const pool = famePoolById(V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID);
+    const zoraEthPool = famePoolById(
+      V4_ZORA_ETH_QUOTE_LANE_CANDIDATE_FAME_POOL_ID,
+    );
     assert.equal(pool?.venue, "uniswap-v4");
+    assert.equal(zoraEthPool?.venue, "uniswap-v4");
     const target = pool as FameUniswapV4PoolConfig;
+    const zoraEthTarget = zoraEthPool as FameUniswapV4PoolConfig;
 
     assert.deepEqual(
       classifyFameV4ZoraPoolConfig(
@@ -396,6 +452,25 @@ describe("FAME pool-state registry", () => {
       },
     );
     assert.equal(FAME_V4_ZORA_REVIEWED_POOL_SHAPE.hookData, "0x");
+    assert.equal(
+      classifyFameV4ZoraPoolConfig({
+        ...zoraEthTarget,
+        hooks: "0x00000000000000000000000000000000000010c0",
+      }).status,
+      "target-blocked",
+    );
+    assert.deepEqual(
+      classifyFameV4ZoraPoolConfig({
+        ...zoraEthTarget,
+        hookData: "0x1234",
+      }),
+      {
+        status: "target-blocked",
+        poolId: V4_ZORA_ETH_QUOTE_LANE_CANDIDATE_FAME_POOL_ID,
+        reason: "hook-data-mismatch",
+      },
+    );
+    assert.equal(FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.hookData, "0x");
   });
 
   it("omits direct SPX/FAME and cbBTC/FAME until authoritative metadata exists", () => {

--- a/src/features/fame-swap/solver/poolStateRegistry.test.ts
+++ b/src/features/fame-swap/solver/poolStateRegistry.test.ts
@@ -66,13 +66,10 @@ describe("FAME pool-state registry", () => {
     );
     assert.deepEqual(capableIds, QUOTE_MODEL_CAPABLE_FAME_POOL_IDS);
     assert.deepEqual(capableIds, [
-      "aerodrome-v2-usdc-weth",
       "scale-equalizer-frxusd-fame",
       "scale-equalizer-scale-fame",
-      "scale-equalizer-usdc-scale",
       "scale-equalizer-weth-fame",
       "uniswap-v2-fame-direct",
-      "uniswap-v2-usdc-weth",
     ]);
     assert.ok(
       registry.pools
@@ -88,7 +85,7 @@ describe("FAME pool-state registry", () => {
     );
   });
 
-  it("keeps unsupported pools visible while making reviewed CL market-state eligible", () => {
+  it("keeps non-direct FAME pools visible without indexing them", () => {
     const registry = famePoolStateRegistry();
     const trackedOnly = registry.pools.filter(
       (pool) => pool.capability === "tracked-only",
@@ -107,7 +104,7 @@ describe("FAME pool-state registry", () => {
       trackedOnly.some(
         (pool) =>
           pool.id === "scale-equalizer-usdc-frxusd" &&
-          pool.unsupportedReason === "stable-pool",
+          pool.unsupportedReason === "non-direct-fame-pool",
       ),
     );
     assert.ok(
@@ -118,29 +115,7 @@ describe("FAME pool-state registry", () => {
       ),
     );
     assert.ok(
-      marketState.some(
-        (pool) =>
-          pool.venue === "aerodrome-slipstream" &&
-          pool.stateSurface === "cl-head-snapshot" &&
-          pool.tickSpacing !== null,
-      ),
-    );
-    assert.ok(
-      marketState.some(
-        (pool) =>
-          pool.venue === "uniswap-v3" &&
-          pool.stateSurface === "cl-head-snapshot" &&
-          pool.tickSpacing !== null,
-      ),
-    );
-    assert.ok(
-      marketState.some(
-        (pool) =>
-          pool.venue === "uniswap-v4" &&
-          pool.stateSurface === "cl-head-snapshot" &&
-          pool.poolKey !== null &&
-          pool.stateViewAddress !== null,
-      ),
+      marketState.every((pool) => pool.id === FAME_SELECTED_CL_ACTIVATION_CANDIDATE),
     );
     assert.equal(candidate?.capability, "market-state");
     assert.equal(candidate?.activationStatus, "cl-compact-quote-active");
@@ -150,9 +125,11 @@ describe("FAME pool-state registry", () => {
     );
     assert.equal(candidate?.stateSurface, "cl-head-snapshot");
     assert.equal(candidate?.replaySurface, "cl-replay-v1");
-    assert.equal(v4Dependency?.capability, "market-state");
-    assert.equal(v4Dependency?.activationStatus, "unsupported");
+    assert.equal(v4Dependency?.capability, "tracked-only");
+    assert.equal(v4Dependency?.activationStatus, "tracked-only");
+    assert.equal(v4Dependency?.stateSurface, null);
     assert.equal(v4Dependency?.replaySurface, null);
+    assert.equal(v4Dependency?.unsupportedReason, "non-direct-fame-pool");
   });
 
   it("emits schema-v4 row fields required by the pool-state producer parser", () => {
@@ -183,11 +160,11 @@ describe("FAME pool-state registry", () => {
     );
     assert.equal(
       pool("uniswap-v2-usdc-weth").activationStatus,
-      "reserve-compact-quote-active",
+      "tracked-only",
     );
     assert.equal(
       pool("slipstream-usdc-weth-100").activationStatus,
-      "cl-compact-quote-active",
+      "tracked-only",
     );
     assert.equal(
       pool(FAME_SELECTED_CL_ACTIVATION_CANDIDATE).activationStatus,
@@ -195,11 +172,11 @@ describe("FAME pool-state registry", () => {
     );
     assert.equal(
       pool("uniswap-v3-zora-usdc").activationStatus,
-      "cl-head-only",
+      "tracked-only",
     );
     assert.equal(
       pool(V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID).activationStatus,
-      "unsupported",
+      "tracked-only",
     );
     assert.equal(pool("native-wrap-weth").activationStatus, "tracked-only");
   });
@@ -212,21 +189,13 @@ describe("FAME pool-state registry", () => {
     const replayIds = registry.pools
       .filter((pool) => pool.replaySurface === "cl-replay-v1")
       .map((pool) => pool.id);
-    const replayPool = registry.pools.find(
-      (pool) => pool.id === "slipstream-usdc-weth-100",
-    );
 
     assert.deepEqual(
       CL_REPLAY_CAPABLE_FAME_POOL_IDS,
       poolIdsForActivationStatus("cl-compact-quote-active"),
     );
     assert.deepEqual(replayIds, CL_REPLAY_CAPABLE_FAME_POOL_IDS);
-    assert.equal(replayPool?.capability, "market-state");
-    assert.equal(replayPool?.stateSurface, "cl-head-snapshot");
-    assert.equal(replayPool?.replaySurface, "cl-replay-v1");
-    assert.equal(replayPool?.activationStatus, "cl-compact-quote-active");
-    assert.equal(replayPool?.venue, "aerodrome-slipstream");
-    assert.equal(replayPool?.tickSpacing, 100);
+    assert.deepEqual(replayIds, [FAME_SELECTED_CL_ACTIVATION_CANDIDATE]);
     assert.equal(candidate?.replaySurface, "cl-replay-v1");
     assert.equal(candidate?.activationStatus, "cl-compact-quote-active");
     assert.ok(CL_REPLAY_CAPABLE_FAME_POOL_IDS.includes(candidate?.id ?? ""));
@@ -260,10 +229,10 @@ describe("FAME pool-state registry", () => {
       ...QUOTE_MODEL_CAPABLE_FAME_POOL_IDS,
       ...CL_REPLAY_CAPABLE_FAME_POOL_IDS,
     ]);
-    assert.equal(famePoolSupportsCompactQuote("uniswap-v2-usdc-weth"), true);
+    assert.equal(famePoolSupportsCompactQuote("uniswap-v2-usdc-weth"), false);
     assert.equal(
       famePoolSupportsCompactQuote("slipstream-usdc-weth-100"),
-      true,
+      false,
     );
     assert.equal(
       famePoolSupportsCompactQuote(V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID),
@@ -273,7 +242,7 @@ describe("FAME pool-state registry", () => {
       famePoolSupportsCompactQuote(V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID, {
         v4ZoraQuoteLaneActivation: activeV4QuoteLane,
       }),
-      true,
+      false,
     );
     assert.equal(
       famePoolSupportsCompactQuote(
@@ -286,7 +255,7 @@ describe("FAME pool-state registry", () => {
         V4_ZORA_ETH_QUOTE_LANE_CANDIDATE_FAME_POOL_ID,
         { v4ZoraQuoteLaneActivation: activeV4QuoteLane },
       ),
-      true,
+      false,
     );
     assert.equal(famePoolSupportsCompactQuote("uniswap-v4-usdc-eth"), false);
     assert.equal(famePoolSupportsCompactQuote("native-wrap-weth"), false);

--- a/src/features/fame-swap/solver/poolStateRegistry.test.ts
+++ b/src/features/fame-swap/solver/poolStateRegistry.test.ts
@@ -4,11 +4,20 @@ import { FAME_SWAP_ARTIFACT_MANIFEST } from "../artifacts/manifest";
 import {
   CL_REPLAY_CAPABLE_FAME_POOL_IDS,
   COMPACT_QUOTE_CAPABLE_FAME_POOL_IDS,
+  FAME_POOL_STATE_ACTIVATION_LEDGER_HASH,
+  FAME_V4_ZORA_REVIEWED_POOL_SHAPE,
+  UNISWAP_V4_DYNAMIC_FEE_FLAG,
+  V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID,
+  classifyFameV4ZoraPoolConfig,
+  classifyFameV4ZoraQuoteLane,
   famePoolSupportsCompactQuote,
+  famePoolSupportsV4ZoraQuoteLane,
   famePoolStateRegistry,
   famePoolStateRegistrySourceId,
   QUOTE_MODEL_CAPABLE_FAME_POOL_IDS,
 } from "./poolStateRegistry";
+import { famePoolById } from "./poolUniverse";
+import type { FameUniswapV4PoolConfig } from "../router/types";
 
 describe("FAME pool-state registry", () => {
   it("derives quote-model-capable pools from the reviewed route universe", () => {
@@ -90,6 +99,54 @@ describe("FAME pool-state registry", () => {
     );
   });
 
+  it("emits schema-v4 row fields required by the pool-state producer parser", () => {
+    const registry = famePoolStateRegistry();
+    const pool = (poolId: string) => {
+      const entry = registry.pools.find((candidate) => candidate.id === poolId);
+      assert.ok(entry, `missing ${poolId}`);
+      return entry;
+    };
+
+    assert.ok(
+      registry.pools.every(
+        (entry) =>
+          "factoryAddress" in entry && "activationStatus" in entry,
+      ),
+    );
+    assert.equal(
+      pool("aerodrome-v2-usdc-weth").factoryAddress,
+      "0x420dd381b31aef6683db6b902084cb0ffece40da",
+    );
+    assert.equal(
+      pool("slipstream-usdc-weth-100").factoryAddress,
+      "0x5e7bb104d84c7cb9b682aac2f3d509f5f406809a",
+    );
+    assert.equal(
+      pool(V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID).factoryAddress,
+      null,
+    );
+    assert.equal(
+      pool("uniswap-v2-usdc-weth").activationStatus,
+      "reserve-compact-quote-active",
+    );
+    assert.equal(
+      pool("slipstream-usdc-weth-100").activationStatus,
+      "cl-compact-quote-active",
+    );
+    assert.equal(
+      pool("uniswap-v3-zora-usdc").activationStatus,
+      "cl-head-only",
+    );
+    assert.equal(
+      pool(V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID).activationStatus,
+      "unsupported",
+    );
+    assert.equal(
+      pool("native-wrap-weth").activationStatus,
+      "tracked-only",
+    );
+  });
+
   it("marks only slipstream-usdc-weth-100 as CL replay-capable", () => {
     const registry = famePoolStateRegistry();
     const replayIds = registry.pools
@@ -107,7 +164,7 @@ describe("FAME pool-state registry", () => {
     assert.equal(replayPool?.tickSpacing, 100);
   });
 
-  it("derives compact quote-capable pools from reserve quote models plus CL replay", () => {
+  it("derives compact quote-capable pools from reserve, CL replay, and reviewed V4 Zora gates", () => {
     assert.deepEqual(COMPACT_QUOTE_CAPABLE_FAME_POOL_IDS, [
       ...QUOTE_MODEL_CAPABLE_FAME_POOL_IDS,
       ...CL_REPLAY_CAPABLE_FAME_POOL_IDS,
@@ -117,7 +174,139 @@ describe("FAME pool-state registry", () => {
       famePoolSupportsCompactQuote("slipstream-usdc-weth-100"),
       true,
     );
+    assert.equal(
+      famePoolSupportsCompactQuote(V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID),
+      false,
+    );
+    assert.equal(
+      famePoolSupportsCompactQuote(V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID, {
+        v4ZoraQuoteLaneActivation: {
+          status: "active",
+          sourceRegistryId: famePoolStateRegistrySourceId(),
+          parityStatus: "passed",
+          routeSimulationStatus: "passed",
+          evidenceId: "unit-v4-zora-activation",
+        },
+      }),
+      true,
+    );
+    assert.equal(famePoolSupportsCompactQuote("uniswap-v4-usdc-eth"), false);
     assert.equal(famePoolSupportsCompactQuote("native-wrap-weth"), false);
+  });
+
+  it("surfaces BASEDFLICK/ZORA as the only provenance-gated V4 Zora quote lane candidate", () => {
+    assert.deepEqual(
+      classifyFameV4ZoraQuoteLane(V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID),
+      {
+        status: "target-blocked",
+        poolId: V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID,
+        reason: "missing-provenance",
+        hookPermissions: {
+          beforeInitialize: false,
+          afterInitialize: true,
+          beforeAddLiquidity: false,
+          afterAddLiquidity: false,
+          beforeRemoveLiquidity: false,
+          afterRemoveLiquidity: false,
+          beforeSwap: false,
+          afterSwap: true,
+          beforeDonate: false,
+          afterDonate: false,
+          beforeSwapReturnDelta: false,
+          afterSwapReturnDelta: false,
+          afterAddLiquidityReturnDelta: false,
+          afterRemoveLiquidityReturnDelta: false,
+        },
+      },
+    );
+    assert.equal(
+      famePoolSupportsV4ZoraQuoteLane(V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID),
+      false,
+    );
+    assert.equal(
+      famePoolSupportsV4ZoraQuoteLane(
+        V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID,
+        { provenanceVerified: true },
+      ),
+      true,
+    );
+    assert.deepEqual(
+      classifyFameV4ZoraQuoteLane("uniswap-v4-usdc-eth", {
+        provenanceVerified: true,
+      }),
+      {
+        status: "non-target-v4-unsupported",
+        poolId: "uniswap-v4-usdc-eth",
+        reason: "non-target-v4-pool",
+      },
+    );
+  });
+
+  it("rejects V4 Zora candidate shape drift before route eligibility", () => {
+    const pool = famePoolById(V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID);
+    assert.equal(pool?.venue, "uniswap-v4");
+    const target = pool as FameUniswapV4PoolConfig;
+
+    assert.deepEqual(
+      classifyFameV4ZoraPoolConfig(
+        {
+          ...target,
+          fee: UNISWAP_V4_DYNAMIC_FEE_FLAG,
+        },
+        { provenanceVerified: true },
+      ),
+      {
+        status: "target-blocked",
+        poolId: V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID,
+        reason: "dynamic-fee",
+      },
+    );
+    assert.deepEqual(
+      classifyFameV4ZoraPoolConfig(
+        {
+          ...target,
+          hookData: "0x1234",
+        },
+        { provenanceVerified: true },
+      ),
+      {
+        status: "target-blocked",
+        poolId: V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID,
+        reason: "hook-data-mismatch",
+      },
+    );
+    assert.deepEqual(
+      classifyFameV4ZoraPoolConfig(
+        {
+          ...target,
+          hooks: "0x00000000000000000000000000000000000010c0",
+        },
+        { provenanceVerified: true },
+      ),
+      {
+        status: "target-blocked",
+        poolId: V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID,
+        reason: "unsafe-hook-permissions",
+        hookPermissions: {
+          beforeInitialize: false,
+          afterInitialize: true,
+          beforeAddLiquidity: false,
+          afterAddLiquidity: false,
+          beforeRemoveLiquidity: false,
+          afterRemoveLiquidity: false,
+          beforeSwap: true,
+          afterSwap: true,
+          beforeDonate: false,
+          afterDonate: false,
+          beforeSwapReturnDelta: false,
+          afterSwapReturnDelta: false,
+          afterAddLiquidityReturnDelta: false,
+          afterRemoveLiquidityReturnDelta: false,
+        },
+        unsafeHookPermissions: ["beforeSwap"],
+      },
+    );
+    assert.equal(FAME_V4_ZORA_REVIEWED_POOL_SHAPE.hookData, "0x");
   });
 
   it("omits direct SPX/FAME and cbBTC/FAME until authoritative metadata exists", () => {
@@ -152,12 +341,16 @@ describe("FAME pool-state registry", () => {
       registry.source.solverRoutesJsonHash,
       FAME_SWAP_ARTIFACT_MANIFEST.solverRoutesJsonHash,
     );
+    assert.equal(
+      registry.source.activationLedgerHash,
+      FAME_POOL_STATE_ACTIVATION_LEDGER_HASH,
+    );
   });
 
   it("derives the cross-repo source registry id from authoritative artifact hashes", () => {
     assert.equal(
       famePoolStateRegistrySourceId(),
-      `pool-state-registry-v3:${FAME_SWAP_ARTIFACT_MANIFEST.poolsJsonHash}:${FAME_SWAP_ARTIFACT_MANIFEST.solverRoutesJsonHash}`,
+      `pool-state-registry-v4:${FAME_SWAP_ARTIFACT_MANIFEST.poolsJsonHash}:${FAME_SWAP_ARTIFACT_MANIFEST.solverRoutesJsonHash}:${FAME_POOL_STATE_ACTIVATION_LEDGER_HASH}`,
     );
   });
 });

--- a/src/features/fame-swap/solver/poolStateRegistry.ts
+++ b/src/features/fame-swap/solver/poolStateRegistry.ts
@@ -17,27 +17,34 @@ import {
   famePoolById,
   type FamePoolFeeDescriptor,
 } from "./poolUniverse";
+import {
+  FAME_POOL_ACTIVATION_LEDGER_HASH,
+  compactQuoteCapabilityForStatus,
+  poolIdsForActivationStatus,
+  reviewedPoolActivation,
+  type FamePoolActivationStatus,
+} from "./poolActivationLedger";
 
-export const FAME_POOL_STATE_REGISTRY_SCHEMA_VERSION = 3;
+export const FAME_POOL_STATE_REGISTRY_SCHEMA_VERSION = 4;
 
-export const QUOTE_MODEL_CAPABLE_FAME_POOL_IDS = [
-  "aerodrome-v2-usdc-weth",
-  "scale-equalizer-frxusd-fame",
-  "scale-equalizer-scale-fame",
-  "scale-equalizer-usdc-scale",
-  "scale-equalizer-weth-fame",
-  "uniswap-v2-fame-direct",
-  "uniswap-v2-usdc-weth",
-] as const;
+function activationPoolIds(
+  status: FamePoolActivationStatus,
+): readonly string[] {
+  return Object.freeze(poolIdsForActivationStatus(status));
+}
 
-export const CL_REPLAY_CAPABLE_FAME_POOL_IDS = [
-  "slipstream-usdc-weth-100",
-] as const;
+export const QUOTE_MODEL_CAPABLE_FAME_POOL_IDS = activationPoolIds(
+  "reserve-compact-quote-active",
+);
 
-export const COMPACT_QUOTE_CAPABLE_FAME_POOL_IDS = [
+export const CL_REPLAY_CAPABLE_FAME_POOL_IDS = activationPoolIds(
+  "cl-compact-quote-active",
+);
+
+export const COMPACT_QUOTE_CAPABLE_FAME_POOL_IDS: readonly string[] = [
   ...QUOTE_MODEL_CAPABLE_FAME_POOL_IDS,
   ...CL_REPLAY_CAPABLE_FAME_POOL_IDS,
-] as const;
+];
 
 export type FamePoolStateCapability =
   | "market-state"
@@ -63,6 +70,7 @@ export interface FamePoolStateRegistrySource {
   poolsContentHash: Hex;
   solverRoutesJsonHash: Hex;
   solverRoutesContentHash: Hex;
+  activationLedgerHash: Hex;
 }
 
 export interface FamePoolStateRegistryDirection {
@@ -76,6 +84,7 @@ export interface FamePoolStateRegistryEntry {
   venue: FamePoolVenue;
   venueFamily: VenueFamilyName;
   router: Address;
+  factoryAddress: Address | null;
   poolAddress: Address | null;
   poolKey: Hex | null;
   token0: Address;
@@ -85,6 +94,7 @@ export interface FamePoolStateRegistryEntry {
   tickSpacing: number | null;
   stateViewAddress: Address | null;
   capability: FamePoolStateCapability;
+  activationStatus: FamePoolActivationStatus;
   stateSurface: FamePoolStateSurface | null;
   replaySurface: FamePoolStateReplaySurface | null;
   quoteModel: FamePoolStateQuoteModel | null;
@@ -98,6 +108,8 @@ export interface FamePoolStateRegistryFile {
   candidateDirections: readonly FamePoolStateRegistryDirection[];
   pools: readonly FamePoolStateRegistryEntry[];
 }
+
+const FAME_PRODUCER_ONLY_POOL_IDS = new Set<string>(["native-wrap-weth"]);
 
 const FAME_POOL_STATE_REGISTRY_DIRECTIONS = [
   [FAME, USDC],
@@ -154,10 +166,28 @@ export function famePoolSupportsCompactQuote(poolId: string): boolean {
   return COMPACT_QUOTE_CAPABLE_FAME_POOL_IDS.some((id) => id === poolId);
 }
 
+export function activationStatusForRegistryPoolId(
+  poolId: string,
+): FamePoolActivationStatus {
+  const reviewed = reviewedPoolActivation(poolId);
+  if (reviewed) {
+    if (reviewed.producerRegistryPresence !== "present") {
+      throw new Error(
+        `FAME pool-state registry cannot include ${poolId}; reviewed producer presence is ${reviewed.producerRegistryPresence}.`,
+      );
+    }
+    return reviewed.activationStatus;
+  }
+  if (FAME_PRODUCER_ONLY_POOL_IDS.has(poolId)) return "tracked-only";
+  throw new Error(
+    `FAME pool-state registry is missing reviewed activation for ${poolId}; add an explicit activation row or producer-only exception.`,
+  );
+}
+
 export function famePoolStateRegistrySourceId(
   registry: FamePoolStateRegistryFile = famePoolStateRegistry(),
 ): string {
-  return `pool-state-registry-v${FAME_POOL_STATE_REGISTRY_SCHEMA_VERSION.toString()}:${registry.source.poolsJsonHash}:${registry.source.solverRoutesJsonHash}`;
+  return `pool-state-registry-v${FAME_POOL_STATE_REGISTRY_SCHEMA_VERSION.toString()}:${registry.source.poolsJsonHash}:${registry.source.solverRoutesJsonHash}:${registry.source.activationLedgerHash}`;
 }
 
 function unsupportedReasonForPool(
@@ -212,6 +242,10 @@ function stableFlag(pool: FamePoolConfig): boolean | null {
   return null;
 }
 
+function factoryAddress(pool: FamePoolConfig): Address | null {
+  return "factory" in pool ? pool.factory : null;
+}
+
 function poolAddress(pool: FamePoolConfig): Address | null {
   return "pool" in pool ? pool.pool : null;
 }
@@ -243,15 +277,24 @@ function token1(pool: FamePoolConfig): Address {
 function registryEntry(pool: FamePoolConfig): FamePoolStateRegistryEntry {
   const fee = feeDescriptorForPool(pool);
   const unsupportedReason = unsupportedReasonForPool(pool, fee);
-  const supportsQuoteModel = unsupportedReason === null;
+  const activationStatus = activationStatusForRegistryPoolId(pool.id);
+  const consumerQuoteCapability =
+    compactQuoteCapabilityForStatus(activationStatus);
+  const supportsQuoteModel =
+    consumerQuoteCapability === "reserve-compact-quote";
   const supportsMarketState = clHeadSnapshotEligible(pool, fee);
+  if (consumerQuoteCapability === "cl-compact-quote" && !supportsMarketState) {
+    throw new Error(
+      `FAME pool-state registry cannot make ${pool.id} CL compact-quote active without CL head-state metadata.`,
+    );
+  }
   const capability: FamePoolStateCapability = supportsQuoteModel
     ? "quote-model"
     : supportsMarketState
       ? "market-state"
       : "tracked-only";
   const replaySurface: FamePoolStateReplaySurface | null =
-    pool.id === "slipstream-usdc-weth-100" && supportsMarketState
+    consumerQuoteCapability === "cl-compact-quote" && supportsMarketState
       ? "cl-replay-v1"
       : null;
 
@@ -261,6 +304,7 @@ function registryEntry(pool: FamePoolConfig): FamePoolStateRegistryEntry {
     venue: pool.venue,
     venueFamily: venueFamilies[pool.venue],
     router: pool.router,
+    factoryAddress: factoryAddress(pool),
     poolAddress: poolAddress(pool),
     poolKey: poolKey(pool),
     token0: token0(pool),
@@ -270,6 +314,7 @@ function registryEntry(pool: FamePoolConfig): FamePoolStateRegistryEntry {
     tickSpacing: tickSpacing(pool),
     stateViewAddress: stateViewAddress(pool),
     capability,
+    activationStatus,
     stateSurface:
       capability === "quote-model"
         ? "constant-product-reserves"
@@ -306,6 +351,7 @@ export function famePoolStateRegistry(): FamePoolStateRegistryFile {
       solverRoutesJsonHash: FAME_SWAP_ARTIFACT_MANIFEST.solverRoutesJsonHash,
       solverRoutesContentHash:
         FAME_SWAP_ARTIFACT_MANIFEST.solverRoutesContentHash,
+      activationLedgerHash: FAME_POOL_ACTIVATION_LEDGER_HASH,
     },
     candidateDirections: FAME_POOL_STATE_REGISTRY_DIRECTIONS.map(
       ([tokenIn, tokenOut]) => ({

--- a/src/features/fame-swap/solver/poolStateRegistry.ts
+++ b/src/features/fame-swap/solver/poolStateRegistry.ts
@@ -49,6 +49,8 @@ export const COMPACT_QUOTE_CAPABLE_FAME_POOL_IDS: readonly string[] = [
 
 export const V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID =
   "uniswap-v4-basedflick-zora";
+export const V4_ZORA_ETH_QUOTE_LANE_CANDIDATE_FAME_POOL_ID =
+  "uniswap-v4-zora-eth";
 export const UNISWAP_V4_DYNAMIC_FEE_FLAG = 0x800000;
 export const UNISWAP_V4_MAX_LP_FEE = 1_000_000;
 
@@ -70,7 +72,7 @@ export interface FameV4HookPermissions {
 }
 
 export interface FameV4ZoraReviewedPoolShape {
-  poolId: typeof V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID;
+  poolId: string;
   chainId: typeof base.id;
   venue: "uniswap-v4";
   venueFamily: "UniswapV4";
@@ -81,9 +83,22 @@ export interface FameV4ZoraReviewedPoolShape {
   currency0: Address;
   currency1: Address;
   fee: number;
-  tickSpacing: 200;
+  tickSpacing: number;
   hooks: Address;
   hookData: Hex;
+}
+
+export interface FameV4ZoraReviewedPoolManifest {
+  poolId: string;
+  version: number;
+  provenanceRequired: boolean;
+  reviewedPoolShape: FameV4ZoraReviewedPoolShape;
+  requiredHookPermissions: readonly (keyof FameV4HookPermissions)[];
+  forbiddenSwapHookPermissions: readonly (
+    | "beforeSwap"
+    | "beforeSwapReturnDelta"
+    | "afterSwapReturnDelta"
+  )[];
 }
 
 export type FameV4ZoraQuoteLaneBlockReason =
@@ -108,7 +123,8 @@ export type FameV4ZoraQuoteLaneBlockReason =
 export type FameV4ZoraQuoteLaneClassification =
   | {
       status: "target-eligible";
-      poolId: typeof V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID;
+      poolId: string;
+      manifest: FameV4ZoraReviewedPoolManifest;
       reviewedPoolShape: FameV4ZoraReviewedPoolShape;
       hookPermissions: FameV4HookPermissions;
     }
@@ -261,6 +277,8 @@ const V4_HOOK_FLAGS = {
   afterRemoveLiquidityReturnDelta: 1n << 0n,
 } as const satisfies Record<keyof FameV4HookPermissions, bigint>;
 
+// TODO(fame-v4-zora): Replace this repo-local reviewed shape copy with a shared
+// or generated cross-repo manifest parity artifact before widening V4 activation.
 export const FAME_V4_ZORA_REVIEWED_POOL_SHAPE = {
   poolId: V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID,
   chainId: base.id,
@@ -278,6 +296,65 @@ export const FAME_V4_ZORA_REVIEWED_POOL_SHAPE = {
   hooks: "0xd61a675f8a0c67a73dc3b54fb7318b4d91409040",
   hookData: "0x",
 } as const satisfies FameV4ZoraReviewedPoolShape;
+
+export const FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE = {
+  poolId: V4_ZORA_ETH_QUOTE_LANE_CANDIDATE_FAME_POOL_ID,
+  chainId: base.id,
+  venue: "uniswap-v4",
+  venueFamily: "UniswapV4",
+  router: "0x6ff5693b99212da76ad316178a184ab56d299b43",
+  poolManager: "0x498581ff718922c3f8e6a244956af099b2652b2b",
+  stateViewAddress: "0xa3c0c9b65bad0b08107aa264b0f3db444b867a71",
+  poolKey:
+    "0xd694bd7285eeeee19d3d5da38f613859168c422d628def88a0c95dad12071f3a",
+  currency0: "0x0000000000000000000000000000000000000000",
+  currency1: "0x1111111111166b7fe7bd91427724b487980afc69",
+  fee: 3_000,
+  tickSpacing: 60,
+  hooks: "0x0000000000000000000000000000000000000000",
+  hookData: "0x",
+} as const satisfies FameV4ZoraReviewedPoolShape;
+
+export const FAME_V4_ZORA_REVIEWED_POOL_MANIFEST = {
+  poolId: V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID,
+  version: 1,
+  provenanceRequired: true,
+  reviewedPoolShape: FAME_V4_ZORA_REVIEWED_POOL_SHAPE,
+  requiredHookPermissions: ["afterInitialize", "afterSwap"],
+  forbiddenSwapHookPermissions: [
+    "beforeSwap",
+    "beforeSwapReturnDelta",
+    "afterSwapReturnDelta",
+  ],
+} as const satisfies FameV4ZoraReviewedPoolManifest;
+
+export const FAME_V4_ZORA_ETH_REVIEWED_POOL_MANIFEST = {
+  poolId: V4_ZORA_ETH_QUOTE_LANE_CANDIDATE_FAME_POOL_ID,
+  version: 1,
+  provenanceRequired: false,
+  reviewedPoolShape: FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE,
+  requiredHookPermissions: [],
+  forbiddenSwapHookPermissions: [
+    "beforeSwap",
+    "beforeSwapReturnDelta",
+    "afterSwapReturnDelta",
+  ],
+} as const satisfies FameV4ZoraReviewedPoolManifest;
+
+export const FAME_V4_ZORA_REVIEWED_POOL_MANIFESTS = [
+  FAME_V4_ZORA_REVIEWED_POOL_MANIFEST,
+  FAME_V4_ZORA_ETH_REVIEWED_POOL_MANIFEST,
+] as const satisfies readonly FameV4ZoraReviewedPoolManifest[];
+
+export function fameV4ZoraReviewedPoolManifestForPool(
+  poolId: string,
+): FameV4ZoraReviewedPoolManifest | null {
+  return (
+    FAME_V4_ZORA_REVIEWED_POOL_MANIFESTS.find(
+      (manifest) => manifest.poolId === poolId,
+    ) ?? null
+  );
+}
 
 function sameAddress(left: Address, right: Address): boolean {
   return left.toLowerCase() === right.toLowerCase();
@@ -332,13 +409,12 @@ export function decodeUniswapV4HookPermissions(
 }
 
 function unsafeSwapHookPermissions(
+  manifest: FameV4ZoraReviewedPoolManifest,
   permissions: FameV4HookPermissions,
 ): string[] {
-  return [
-    "beforeSwap",
-    "beforeSwapReturnDelta",
-    "afterSwapReturnDelta",
-  ].filter((name) => permissions[name as keyof FameV4HookPermissions]);
+  return manifest.forbiddenSwapHookPermissions.filter(
+    (name) => permissions[name],
+  );
 }
 
 function routePoolIdsForDirections(
@@ -407,7 +483,8 @@ export function classifyFameV4ZoraPoolConfig(
       reason: "not-uniswap-v4",
     };
   }
-  if (pool.id !== V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID) {
+  const manifest = fameV4ZoraReviewedPoolManifestForPool(pool.id);
+  if (manifest === null) {
     return {
       status: "non-target-v4-unsupported",
       poolId: pool.id,
@@ -415,7 +492,7 @@ export function classifyFameV4ZoraPoolConfig(
     };
   }
 
-  const reviewed = FAME_V4_ZORA_REVIEWED_POOL_SHAPE;
+  const reviewed = manifest.reviewedPoolShape;
   const v4Pool: FameUniswapV4PoolConfig = pool;
   if (!sameAddress(v4Pool.router, reviewed.router)) {
     return targetBlocked(pool.id, "router-mismatch");
@@ -452,15 +529,20 @@ export function classifyFameV4ZoraPoolConfig(
   }
 
   const hookPermissions = decodeUniswapV4HookPermissions(v4Pool.hooks);
-  const unsafePermissions = unsafeSwapHookPermissions(hookPermissions);
-  if (
-    !hookPermissions.afterInitialize ||
-    !hookPermissions.afterSwap ||
-    unsafePermissions.length > 0
-  ) {
+  const missingRequiredPermissions = manifest.requiredHookPermissions.filter(
+    (name) => !hookPermissions[name],
+  );
+  const unsafePermissions = unsafeSwapHookPermissions(
+    manifest,
+    hookPermissions,
+  );
+  if (missingRequiredPermissions.length > 0 || unsafePermissions.length > 0) {
     return targetBlocked(pool.id, "unsafe-hook-permissions", {
       hookPermissions,
-      unsafeHookPermissions: unsafePermissions,
+      unsafeHookPermissions: [
+        ...missingRequiredPermissions,
+        ...unsafePermissions,
+      ],
     });
   }
   if (!sameAddress(v4Pool.hooks, reviewed.hooks)) {
@@ -468,7 +550,7 @@ export function classifyFameV4ZoraPoolConfig(
       hookPermissions,
     });
   }
-  if (!options.provenanceVerified) {
+  if (manifest.provenanceRequired && !options.provenanceVerified) {
     return targetBlocked(pool.id, "missing-provenance", {
       hookPermissions,
     });
@@ -476,7 +558,8 @@ export function classifyFameV4ZoraPoolConfig(
 
   return {
     status: "target-eligible",
-    poolId: V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID,
+    poolId: manifest.poolId,
+    manifest,
     reviewedPoolShape: reviewed,
     hookPermissions,
   };

--- a/src/features/fame-swap/solver/poolStateRegistry.ts
+++ b/src/features/fame-swap/solver/poolStateRegistry.ts
@@ -4,6 +4,7 @@ import { FAME_SWAP_ARTIFACT_MANIFEST } from "../artifacts/manifest";
 import type {
   FamePoolConfig,
   FamePoolVenue,
+  FameUniswapV4PoolConfig,
   VenueFamilyName,
 } from "../router/types";
 import { FAME, NATIVE_ETH, USDC, WETH } from "../tokens";
@@ -18,7 +19,9 @@ import {
   type FamePoolFeeDescriptor,
 } from "./poolUniverse";
 
-export const FAME_POOL_STATE_REGISTRY_SCHEMA_VERSION = 3;
+export const FAME_POOL_STATE_REGISTRY_SCHEMA_VERSION = 4;
+export const FAME_POOL_STATE_ACTIVATION_LEDGER_HASH =
+  "0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b" as const satisfies Hex;
 
 export const QUOTE_MODEL_CAPABLE_FAME_POOL_IDS = [
   "aerodrome-v2-usdc-weth",
@@ -39,10 +42,131 @@ export const COMPACT_QUOTE_CAPABLE_FAME_POOL_IDS = [
   ...CL_REPLAY_CAPABLE_FAME_POOL_IDS,
 ] as const;
 
+export const V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID =
+  "uniswap-v4-basedflick-zora";
+export const UNISWAP_V4_DYNAMIC_FEE_FLAG = 0x800000;
+export const UNISWAP_V4_MAX_LP_FEE = 1_000_000;
+
+export interface FameV4HookPermissions {
+  beforeInitialize: boolean;
+  afterInitialize: boolean;
+  beforeAddLiquidity: boolean;
+  afterAddLiquidity: boolean;
+  beforeRemoveLiquidity: boolean;
+  afterRemoveLiquidity: boolean;
+  beforeSwap: boolean;
+  afterSwap: boolean;
+  beforeDonate: boolean;
+  afterDonate: boolean;
+  beforeSwapReturnDelta: boolean;
+  afterSwapReturnDelta: boolean;
+  afterAddLiquidityReturnDelta: boolean;
+  afterRemoveLiquidityReturnDelta: boolean;
+}
+
+export interface FameV4ZoraReviewedPoolShape {
+  poolId: typeof V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID;
+  chainId: typeof base.id;
+  venue: "uniswap-v4";
+  venueFamily: "UniswapV4";
+  router: Address;
+  poolManager: Address;
+  stateViewAddress: Address;
+  poolKey: Hex;
+  currency0: Address;
+  currency1: Address;
+  fee: number;
+  tickSpacing: 200;
+  hooks: Address;
+  hookData: Hex;
+}
+
+export type FameV4ZoraQuoteLaneBlockReason =
+  | "unknown-pool"
+  | "not-uniswap-v4"
+  | "non-target-v4-pool"
+  | "router-mismatch"
+  | "pool-manager-mismatch"
+  | "state-view-mismatch"
+  | "pool-key-mismatch"
+  | "currency0-mismatch"
+  | "currency1-mismatch"
+  | "invalid-fee"
+  | "dynamic-fee"
+  | "fee-mismatch"
+  | "tick-spacing-mismatch"
+  | "hook-data-mismatch"
+  | "unsafe-hook-permissions"
+  | "hook-address-mismatch"
+  | "missing-provenance";
+
+export type FameV4ZoraQuoteLaneClassification =
+  | {
+      status: "target-eligible";
+      poolId: typeof V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID;
+      reviewedPoolShape: FameV4ZoraReviewedPoolShape;
+      hookPermissions: FameV4HookPermissions;
+    }
+  | {
+      status: "target-blocked";
+      poolId: string;
+      reason: FameV4ZoraQuoteLaneBlockReason;
+      hookPermissions?: FameV4HookPermissions;
+      unsafeHookPermissions?: readonly string[];
+    }
+  | {
+      status: "non-target-v4-unsupported";
+      poolId: string;
+      reason: "non-target-v4-pool";
+    }
+  | {
+      status: "not-uniswap-v4";
+      poolId: string;
+      reason: "not-uniswap-v4" | "unknown-pool";
+    };
+
+export interface FameV4ZoraQuoteLaneOptions {
+  provenanceVerified?: boolean;
+}
+
+export type FameV4ZoraQuoteLaneActivation =
+  | {
+      status: "pending";
+      reason:
+        | "awaiting-parity-and-route-simulation"
+        | "blocked-by-parity"
+        | "blocked-by-route-simulation";
+    }
+  | {
+      status: "active";
+      sourceRegistryId: string;
+      parityStatus: "passed";
+      routeSimulationStatus: "passed";
+      evidenceId: string;
+    };
+
+export const FAME_V4_ZORA_QUOTE_LANE_ACTIVATION = {
+  status: "pending",
+  reason: "awaiting-parity-and-route-simulation",
+} as const satisfies FameV4ZoraQuoteLaneActivation;
+
+export interface FameCompactQuoteSupportOptions {
+  v4ZoraQuoteLaneActivation?: FameV4ZoraQuoteLaneActivation;
+}
+
 export type FamePoolStateCapability =
   | "market-state"
   | "quote-model"
   | "tracked-only";
+export type FamePoolActivationStatus =
+  | "reserve-compact-quote-active"
+  | "cl-compact-quote-active"
+  | "cl-replay-candidate"
+  | "cl-head-only"
+  | "tracked-only"
+  | "blocked"
+  | "unsupported"
+  | "producer-unrepresented";
 export type FamePoolStateQuoteModel = "constant-product-reserves";
 export type FamePoolStateReplaySurface = "cl-replay-v1";
 export type FamePoolStateSurface =
@@ -63,6 +187,7 @@ export interface FamePoolStateRegistrySource {
   poolsContentHash: Hex;
   solverRoutesJsonHash: Hex;
   solverRoutesContentHash: Hex;
+  activationLedgerHash: Hex;
 }
 
 export interface FamePoolStateRegistryDirection {
@@ -76,6 +201,7 @@ export interface FamePoolStateRegistryEntry {
   venue: FamePoolVenue;
   venueFamily: VenueFamilyName;
   router: Address;
+  factoryAddress: Address | null;
   poolAddress: Address | null;
   poolKey: Hex | null;
   token0: Address;
@@ -85,6 +211,7 @@ export interface FamePoolStateRegistryEntry {
   tickSpacing: number | null;
   stateViewAddress: Address | null;
   capability: FamePoolStateCapability;
+  activationStatus: FamePoolActivationStatus;
   stateSurface: FamePoolStateSurface | null;
   replaySurface: FamePoolStateReplaySurface | null;
   quoteModel: FamePoolStateQuoteModel | null;
@@ -119,6 +246,103 @@ const venueFamilies = {
   "native-wrap": "NativeWrap",
 } as const satisfies Record<FamePoolVenue, VenueFamilyName>;
 
+const V4_HOOK_FLAGS = {
+  beforeInitialize: 1n << 13n,
+  afterInitialize: 1n << 12n,
+  beforeAddLiquidity: 1n << 11n,
+  afterAddLiquidity: 1n << 10n,
+  beforeRemoveLiquidity: 1n << 9n,
+  afterRemoveLiquidity: 1n << 8n,
+  beforeSwap: 1n << 7n,
+  afterSwap: 1n << 6n,
+  beforeDonate: 1n << 5n,
+  afterDonate: 1n << 4n,
+  beforeSwapReturnDelta: 1n << 3n,
+  afterSwapReturnDelta: 1n << 2n,
+  afterAddLiquidityReturnDelta: 1n << 1n,
+  afterRemoveLiquidityReturnDelta: 1n << 0n,
+} as const satisfies Record<keyof FameV4HookPermissions, bigint>;
+
+export const FAME_V4_ZORA_REVIEWED_POOL_SHAPE = {
+  poolId: V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID,
+  chainId: base.id,
+  venue: "uniswap-v4",
+  venueFamily: "UniswapV4",
+  router: "0x6ff5693b99212da76ad316178a184ab56d299b43",
+  poolManager: "0x498581ff718922c3f8e6a244956af099b2652b2b",
+  stateViewAddress: "0xa3c0c9b65bad0b08107aa264b0f3db444b867a71",
+  poolKey:
+    "0x0fe6333346fcd0ffa4be3fda91f271bda52c6755f604b06483b709666d363628",
+  currency0: "0x1111111111166b7fe7bd91427724b487980afc69",
+  currency1: "0x15e012abf9d32cd67fc6cf480ea0e318e9ed5926",
+  fee: 30_000,
+  tickSpacing: 200,
+  hooks: "0xd61a675f8a0c67a73dc3b54fb7318b4d91409040",
+  hookData: "0x",
+} as const satisfies FameV4ZoraReviewedPoolShape;
+
+function sameAddress(left: Address, right: Address): boolean {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+function sameHex(left: Hex, right: Hex): boolean {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+function targetBlocked(
+  poolId: string,
+  reason: FameV4ZoraQuoteLaneBlockReason,
+  extra: Omit<
+    Extract<FameV4ZoraQuoteLaneClassification, { status: "target-blocked" }>,
+    "status" | "poolId" | "reason"
+  > = {},
+): FameV4ZoraQuoteLaneClassification {
+  return {
+    status: "target-blocked",
+    poolId,
+    reason,
+    ...extra,
+  };
+}
+
+export function decodeUniswapV4HookPermissions(
+  hooks: Address,
+): FameV4HookPermissions {
+  const hookBits = BigInt(hooks);
+  return {
+    beforeInitialize: (hookBits & V4_HOOK_FLAGS.beforeInitialize) !== 0n,
+    afterInitialize: (hookBits & V4_HOOK_FLAGS.afterInitialize) !== 0n,
+    beforeAddLiquidity: (hookBits & V4_HOOK_FLAGS.beforeAddLiquidity) !== 0n,
+    afterAddLiquidity: (hookBits & V4_HOOK_FLAGS.afterAddLiquidity) !== 0n,
+    beforeRemoveLiquidity:
+      (hookBits & V4_HOOK_FLAGS.beforeRemoveLiquidity) !== 0n,
+    afterRemoveLiquidity:
+      (hookBits & V4_HOOK_FLAGS.afterRemoveLiquidity) !== 0n,
+    beforeSwap: (hookBits & V4_HOOK_FLAGS.beforeSwap) !== 0n,
+    afterSwap: (hookBits & V4_HOOK_FLAGS.afterSwap) !== 0n,
+    beforeDonate: (hookBits & V4_HOOK_FLAGS.beforeDonate) !== 0n,
+    afterDonate: (hookBits & V4_HOOK_FLAGS.afterDonate) !== 0n,
+    beforeSwapReturnDelta:
+      (hookBits & V4_HOOK_FLAGS.beforeSwapReturnDelta) !== 0n,
+    afterSwapReturnDelta:
+      (hookBits & V4_HOOK_FLAGS.afterSwapReturnDelta) !== 0n,
+    afterAddLiquidityReturnDelta:
+      (hookBits & V4_HOOK_FLAGS.afterAddLiquidityReturnDelta) !== 0n,
+    afterRemoveLiquidityReturnDelta:
+      (hookBits & V4_HOOK_FLAGS.afterRemoveLiquidityReturnDelta) !== 0n,
+  };
+}
+
+function unsafeSwapHookPermissions(
+  permissions: FameV4HookPermissions,
+): string[] {
+  return [
+    "beforeSwap",
+    "beforeSwapReturnDelta",
+    "afterSwapReturnDelta",
+  ].filter((name) => permissions[name as keyof FameV4HookPermissions]);
+}
+
 function routePoolIdsForDirections(
   directions: readonly (readonly [Address, Address])[],
 ): string[] {
@@ -150,14 +374,144 @@ export function famePoolStateRegistryPoolIdsForPair(
   return routePoolIdsForDirections([[tokenIn, tokenOut]]);
 }
 
-export function famePoolSupportsCompactQuote(poolId: string): boolean {
-  return COMPACT_QUOTE_CAPABLE_FAME_POOL_IDS.some((id) => id === poolId);
+export function fameV4ZoraQuoteLaneActivationPassed(
+  activation: FameV4ZoraQuoteLaneActivation = FAME_V4_ZORA_QUOTE_LANE_ACTIVATION,
+): activation is Extract<FameV4ZoraQuoteLaneActivation, { status: "active" }> {
+  return (
+    activation.status === "active" &&
+    activation.parityStatus === "passed" &&
+    activation.routeSimulationStatus === "passed" &&
+    activation.sourceRegistryId.length > 0 &&
+    activation.evidenceId.length > 0
+  );
+}
+
+export function famePoolSupportsCompactQuote(
+  poolId: string,
+  options: FameCompactQuoteSupportOptions = {},
+): boolean {
+  return (
+    COMPACT_QUOTE_CAPABLE_FAME_POOL_IDS.some((id) => id === poolId) ||
+    (fameV4ZoraQuoteLaneActivationPassed(
+      options.v4ZoraQuoteLaneActivation,
+    ) && famePoolSupportsV4ZoraQuoteLane(poolId, { provenanceVerified: true }))
+  );
+}
+
+export function classifyFameV4ZoraPoolConfig(
+  pool: FamePoolConfig,
+  options: FameV4ZoraQuoteLaneOptions = {},
+): FameV4ZoraQuoteLaneClassification {
+  if (pool.venue !== "uniswap-v4") {
+    return {
+      status: "not-uniswap-v4",
+      poolId: pool.id,
+      reason: "not-uniswap-v4",
+    };
+  }
+  if (pool.id !== V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID) {
+    return {
+      status: "non-target-v4-unsupported",
+      poolId: pool.id,
+      reason: "non-target-v4-pool",
+    };
+  }
+
+  const reviewed = FAME_V4_ZORA_REVIEWED_POOL_SHAPE;
+  const v4Pool: FameUniswapV4PoolConfig = pool;
+  if (!sameAddress(v4Pool.router, reviewed.router)) {
+    return targetBlocked(pool.id, "router-mismatch");
+  }
+  if (!sameAddress(v4Pool.poolManager, reviewed.poolManager)) {
+    return targetBlocked(pool.id, "pool-manager-mismatch");
+  }
+  if (!sameAddress(v4Pool.stateView, reviewed.stateViewAddress)) {
+    return targetBlocked(pool.id, "state-view-mismatch");
+  }
+  if (!sameHex(v4Pool.poolId, reviewed.poolKey)) {
+    return targetBlocked(pool.id, "pool-key-mismatch");
+  }
+  if (!sameAddress(v4Pool.currency0, reviewed.currency0)) {
+    return targetBlocked(pool.id, "currency0-mismatch");
+  }
+  if (!sameAddress(v4Pool.currency1, reviewed.currency1)) {
+    return targetBlocked(pool.id, "currency1-mismatch");
+  }
+  if (v4Pool.fee === UNISWAP_V4_DYNAMIC_FEE_FLAG) {
+    return targetBlocked(pool.id, "dynamic-fee");
+  }
+  if (v4Pool.fee > UNISWAP_V4_MAX_LP_FEE) {
+    return targetBlocked(pool.id, "invalid-fee");
+  }
+  if (v4Pool.fee !== reviewed.fee) {
+    return targetBlocked(pool.id, "fee-mismatch");
+  }
+  if (v4Pool.tickSpacing !== reviewed.tickSpacing) {
+    return targetBlocked(pool.id, "tick-spacing-mismatch");
+  }
+  if ((v4Pool.hookData ?? "0x").toLowerCase() !== "0x") {
+    return targetBlocked(pool.id, "hook-data-mismatch");
+  }
+
+  const hookPermissions = decodeUniswapV4HookPermissions(v4Pool.hooks);
+  const unsafePermissions = unsafeSwapHookPermissions(hookPermissions);
+  if (
+    !hookPermissions.afterInitialize ||
+    !hookPermissions.afterSwap ||
+    unsafePermissions.length > 0
+  ) {
+    return targetBlocked(pool.id, "unsafe-hook-permissions", {
+      hookPermissions,
+      unsafeHookPermissions: unsafePermissions,
+    });
+  }
+  if (!sameAddress(v4Pool.hooks, reviewed.hooks)) {
+    return targetBlocked(pool.id, "hook-address-mismatch", {
+      hookPermissions,
+    });
+  }
+  if (!options.provenanceVerified) {
+    return targetBlocked(pool.id, "missing-provenance", {
+      hookPermissions,
+    });
+  }
+
+  return {
+    status: "target-eligible",
+    poolId: V4_ZORA_QUOTE_LANE_CANDIDATE_FAME_POOL_ID,
+    reviewedPoolShape: reviewed,
+    hookPermissions,
+  };
+}
+
+export function classifyFameV4ZoraQuoteLane(
+  poolId: string,
+  options: FameV4ZoraQuoteLaneOptions = {},
+): FameV4ZoraQuoteLaneClassification {
+  const pool = famePoolById(poolId);
+  if (!pool) {
+    return {
+      status: "not-uniswap-v4",
+      poolId,
+      reason: "unknown-pool",
+    };
+  }
+  return classifyFameV4ZoraPoolConfig(pool, options);
+}
+
+export function famePoolSupportsV4ZoraQuoteLane(
+  poolId: string,
+  options: FameV4ZoraQuoteLaneOptions = {},
+): boolean {
+  return (
+    classifyFameV4ZoraQuoteLane(poolId, options).status === "target-eligible"
+  );
 }
 
 export function famePoolStateRegistrySourceId(
   registry: FamePoolStateRegistryFile = famePoolStateRegistry(),
 ): string {
-  return `pool-state-registry-v${FAME_POOL_STATE_REGISTRY_SCHEMA_VERSION.toString()}:${registry.source.poolsJsonHash}:${registry.source.solverRoutesJsonHash}`;
+  return `pool-state-registry-v${FAME_POOL_STATE_REGISTRY_SCHEMA_VERSION.toString()}:${registry.source.poolsJsonHash}:${registry.source.solverRoutesJsonHash}:${registry.source.activationLedgerHash}`;
 }
 
 function unsupportedReasonForPool(
@@ -216,6 +570,10 @@ function poolAddress(pool: FamePoolConfig): Address | null {
   return "pool" in pool ? pool.pool : null;
 }
 
+function factoryAddress(pool: FamePoolConfig): Address | null {
+  return "factory" in pool ? pool.factory : null;
+}
+
 function poolKey(pool: FamePoolConfig): Hex | null {
   return "poolId" in pool ? pool.poolId : null;
 }
@@ -226,6 +584,18 @@ function tickSpacing(pool: FamePoolConfig): number | null {
 
 function stateViewAddress(pool: FamePoolConfig): Address | null {
   return pool.venue === "uniswap-v4" ? pool.stateView : null;
+}
+
+function activationStatusForPool(
+  pool: FamePoolConfig,
+  capability: FamePoolStateCapability,
+  replaySurface: FamePoolStateReplaySurface | null,
+): FamePoolActivationStatus {
+  if (capability === "quote-model") return "reserve-compact-quote-active";
+  if (capability === "tracked-only") return "tracked-only";
+  if (pool.venue === "uniswap-v4") return "unsupported";
+  if (replaySurface === "cl-replay-v1") return "cl-compact-quote-active";
+  return "cl-head-only";
 }
 
 function token0(pool: FamePoolConfig): Address {
@@ -261,6 +631,7 @@ function registryEntry(pool: FamePoolConfig): FamePoolStateRegistryEntry {
     venue: pool.venue,
     venueFamily: venueFamilies[pool.venue],
     router: pool.router,
+    factoryAddress: factoryAddress(pool),
     poolAddress: poolAddress(pool),
     poolKey: poolKey(pool),
     token0: token0(pool),
@@ -270,6 +641,11 @@ function registryEntry(pool: FamePoolConfig): FamePoolStateRegistryEntry {
     tickSpacing: tickSpacing(pool),
     stateViewAddress: stateViewAddress(pool),
     capability,
+    activationStatus: activationStatusForPool(
+      pool,
+      capability,
+      replaySurface,
+    ),
     stateSurface:
       capability === "quote-model"
         ? "constant-product-reserves"
@@ -306,6 +682,7 @@ export function famePoolStateRegistry(): FamePoolStateRegistryFile {
       solverRoutesJsonHash: FAME_SWAP_ARTIFACT_MANIFEST.solverRoutesJsonHash,
       solverRoutesContentHash:
         FAME_SWAP_ARTIFACT_MANIFEST.solverRoutesContentHash,
+      activationLedgerHash: FAME_POOL_STATE_ACTIVATION_LEDGER_HASH,
     },
     candidateDirections: FAME_POOL_STATE_REGISTRY_DIRECTIONS.map(
       ([tokenIn, tokenOut]) => ({

--- a/src/features/fame-swap/solver/poolStateRegistry.ts
+++ b/src/features/fame-swap/solver/poolStateRegistry.ts
@@ -188,6 +188,7 @@ export type FamePoolStateUnsupportedReason =
   | "concentrated-liquidity"
   | "missing-fee-metadata"
   | "native-wrap"
+  | "non-direct-fame-pool"
   | "stable-pool"
   | "unsupported-venue";
 
@@ -464,6 +465,9 @@ export function famePoolSupportsCompactQuote(
   poolId: string,
   options: FameCompactQuoteSupportOptions = {},
 ): boolean {
+  const pool = famePoolById(poolId);
+  if (!pool || !directFamePool(pool)) return false;
+
   return (
     COMPACT_QUOTE_CAPABLE_FAME_POOL_IDS.some((id) => id === poolId) ||
     (fameV4ZoraQuoteLaneActivationPassed(
@@ -616,7 +620,11 @@ export function famePoolStateRegistrySourceId(
 function unsupportedReasonForPool(
   pool: FamePoolConfig,
   fee: FamePoolFeeDescriptor,
+  activationStatus: FamePoolActivationStatus,
 ): FamePoolStateUnsupportedReason | null {
+  if (activationStatus === "tracked-only" && !directFamePool(pool)) {
+    return pool.venue === "native-wrap" ? "native-wrap" : "non-direct-fame-pool";
+  }
   if (pool.venue === "uniswap-v2") {
     return fee.status === "available" ? null : "missing-fee-metadata";
   }
@@ -685,6 +693,13 @@ function stateViewAddress(pool: FamePoolConfig): Address | null {
   return pool.venue === "uniswap-v4" ? pool.stateView : null;
 }
 
+function directFamePool(pool: FamePoolConfig): boolean {
+  return (
+    token0(pool).toLowerCase() === FAME ||
+    token1(pool).toLowerCase() === FAME
+  );
+}
+
 function activationStatusForPool(
   pool: FamePoolConfig,
   capability: FamePoolStateCapability,
@@ -711,13 +726,18 @@ function token1(pool: FamePoolConfig): Address {
 
 function registryEntry(pool: FamePoolConfig): FamePoolStateRegistryEntry {
   const fee = feeDescriptorForPool(pool);
-  const unsupportedReason = unsupportedReasonForPool(pool, fee);
   const activationStatus = activationStatusForRegistryPoolId(pool.id);
+  const unsupportedReason = unsupportedReasonForPool(
+    pool,
+    fee,
+    activationStatus,
+  );
   const consumerQuoteCapability =
     compactQuoteCapabilityForStatus(activationStatus);
   const supportsQuoteModel =
     consumerQuoteCapability === "reserve-compact-quote";
-  const supportsMarketState = clHeadSnapshotEligible(pool, fee);
+  const supportsMarketState =
+    activationStatus !== "tracked-only" && clHeadSnapshotEligible(pool, fee);
   if (consumerQuoteCapability === "cl-compact-quote" && !supportsMarketState) {
     throw new Error(
       `FAME pool-state registry cannot make ${pool.id} CL compact-quote active without CL head-state metadata.`,

--- a/src/features/fame-swap/solver/quote.ts
+++ b/src/features/fame-swap/solver/quote.ts
@@ -249,6 +249,7 @@ export function quoteFameSwap(
     feePpm: prepared.readiness.feePpm,
     slippageBps: prepared.slippageBps,
     adapter: request.adapter,
+    candidateFilter: request.candidateFilter,
   });
 
   return quoteFromSolverResult(request, prepared, solved);
@@ -272,6 +273,7 @@ export async function quoteFameSwapAsync(
     adapter: request.adapter,
     optimizerMode: request.optimizerMode ?? fameSwapOptimizerMode(),
     optimizerBudgets: request.optimizerBudgets,
+    candidateFilter: request.candidateFilter,
   });
 
   return quoteFromSolverResult(request, prepared, solved);

--- a/src/features/fame-swap/solver/quote.ts
+++ b/src/features/fame-swap/solver/quote.ts
@@ -206,7 +206,7 @@ function quoteFromSolverResult(
     requestedAmountIn: request.amountIn,
     routerAddress: prepared.readiness.routerAddress,
     routeArtifactId: solved.routeArtifactId,
-    routeSource: "generated",
+    routeSource: solved.routeSource,
     fixtureRouteHash: solved.routeHash,
     materializedRouteHash: solved.routeHash,
     poolIds: solved.poolIds,
@@ -249,6 +249,7 @@ export function quoteFameSwap(
     feePpm: prepared.readiness.feePpm,
     slippageBps: prepared.slippageBps,
     adapter: request.adapter,
+    requestedRouteId: request.requestedRouteId,
   });
 
   return quoteFromSolverResult(request, prepared, solved);
@@ -272,6 +273,7 @@ export async function quoteFameSwapAsync(
     adapter: request.adapter,
     optimizerMode: request.optimizerMode ?? fameSwapOptimizerMode(),
     optimizerBudgets: request.optimizerBudgets,
+    requestedRouteId: request.requestedRouteId,
   });
 
   return quoteFromSolverResult(request, prepared, solved);

--- a/src/features/fame-swap/solver/quoteWire.test.ts
+++ b/src/features/fame-swap/solver/quoteWire.test.ts
@@ -300,6 +300,77 @@ describe("FAME swap quote wire contract", () => {
     }
   });
 
+  it("keeps quote API diagnostics debug data compact and sanitized", () => {
+    const { quote } = readyWireResponse();
+    const wire = serializeFameSwapQuoteResponse(
+      {
+        ...quote,
+        diagnosticsVisibleByDefault: true,
+      },
+      {
+        includeDebug: true,
+        debug: {
+          quoteApi: {
+            configured: true,
+            attempted: true,
+            currentBlock: 125,
+            edgeCount: 2,
+            usedCount: 1,
+            fallbackCount: 1,
+            batchFailureCount: 0,
+            timing: {
+              batchRequestCount: 1,
+              totalBatchDurationMs: 4,
+              maxBatchDurationMs: 4,
+              lastBatchDurationMs: 4,
+            },
+            statusCounts: {
+              quoted: 1,
+              unavailable: 1,
+            },
+            fallbackReasonCounts: {
+              row_metadata_mismatch: 1,
+            },
+            details: [
+              {
+                poolId: "uniswap-v4-basedflick-zora",
+                tokenIn: "0x1111111111166b7fe7bd91427724b487980afc69",
+                tokenOut: "0x15e012abf9d32cd67fc6cf480ea0e318e9ed5926",
+                amountIn: "1000000",
+                currentBlock: 125,
+                outcome: "used",
+                quoteKind: "cl-quote-v1",
+                rowStatus: "quoted",
+                observedThroughBlock: 120,
+                evidenceId: "unit-v4-cl-quote",
+              },
+              {
+                poolId: "uniswap-v4-basedflick-zora",
+                tokenIn: "0x1111111111166b7fe7bd91427724b487980afc69",
+                tokenOut: "0x15e012abf9d32cd67fc6cf480ea0e318e9ed5926",
+                amountIn: "1000000",
+                currentBlock: 125,
+                outcome: "fallback",
+                fallbackReason: "row_metadata_mismatch",
+                evidenceId: "unit-v4-cl-quote",
+              },
+            ],
+            truncatedDetailCount: 0,
+          },
+        },
+      },
+    );
+
+    assert.ok(isRecord(wire.debug));
+    assert.ok(isRecord(wire.debug.quoteApi));
+    const debug = JSON.stringify(wire.debug);
+    assert.match(debug, /unit-v4-cl-quote|row_metadata_mismatch/);
+    assert.doesNotMatch(
+      debug,
+      /bitmapWords|initializedTicks|serviceToken|authorization|helperUrl|rpcUrl|secret/i,
+    );
+  });
+
   it("fails closed when a ready response route hash does not match the decoded route", () => {
     const { tokenIn, tokenOut, quote, wire } = readyWireResponse();
     const parsed = deserializeFameSwapQuoteResponse(

--- a/src/features/fame-swap/solver/quoteWire.ts
+++ b/src/features/fame-swap/solver/quoteWire.ts
@@ -17,6 +17,7 @@ import type {
   FameSwapRouteDisplayLeg,
 } from "./types";
 import type { FameCandidateRejection, FameLegQuote } from "./quotes/adapters";
+import { displaySafeDiagnosticMessage } from "./diagnostics";
 import type { FameQuoteContext } from "./quotes/quoteContext";
 import type { FameRouteFeeBreakdown } from "./quotes/rankRoutes";
 
@@ -204,9 +205,7 @@ function parseQuoteContext(value: unknown): FameQuoteContext | undefined {
       chainId: numberFrom(raw.chainId),
       currentBlock: numberFrom(raw.currentBlock),
       sourceRegistryId: String(raw.sourceRegistryId ?? ""),
-      effectiveMaxFreshnessBlocks: numberFrom(
-        raw.effectiveMaxFreshnessBlocks,
-      ),
+      effectiveMaxFreshnessBlocks: numberFrom(raw.effectiveMaxFreshnessBlocks),
       statusCounts: {
         fresh: numberFrom(statusCounts.fresh),
         stale: numberFrom(statusCounts.stale),
@@ -256,6 +255,27 @@ function parseRejections(value: unknown): FameCandidateRejection[] {
     : [];
 }
 
+function parseIndexedEvidence(value: unknown): FameLegQuote["indexedEvidence"] {
+  const raw = asRecord(value);
+  if (raw.source !== "indexed") return undefined;
+  if (raw.kind !== "compact-quote" && raw.kind !== "raw-replay")
+    return undefined;
+  if (
+    raw.quoteKind !== "constant-product-quote-v1" &&
+    raw.quoteKind !== "cl-quote-v1" &&
+    raw.quoteKind !== "cl-replay-v1"
+  ) {
+    return undefined;
+  }
+  return {
+    source: "indexed",
+    kind: raw.kind,
+    quoteKind: raw.quoteKind,
+    evidenceId: String(raw.evidenceId ?? ""),
+    poolId: String(raw.poolId ?? ""),
+  };
+}
+
 function parseLegQuote(value: unknown): FameLegQuote {
   const raw = asRecord(value);
   const priceImpact = asRecord(raw.priceImpact);
@@ -278,6 +298,7 @@ function parseLegQuote(value: unknown): FameLegQuote {
     feeIncludedInQuote: booleanFrom(raw.feeIncludedInQuote, true),
     evidence: String(raw.evidence ?? "quote evidence unavailable"),
     quoteContext: parseQuoteContext(raw.quoteContext),
+    indexedEvidence: parseIndexedEvidence(raw.indexedEvidence),
     priceImpact:
       priceImpact.preSwapPriceX18 || priceImpact.executionPriceX18
         ? {
@@ -355,22 +376,7 @@ function parseBlockedReadiness(
 }
 
 export function displaySafeErrorMessage(error: unknown): string {
-  const raw = error instanceof Error ? error.message : String(error);
-  return (
-    raw
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .find(
-        (line) =>
-          line.length > 0 &&
-          !/\b(request body|calldata|approval|swap request|private key|signer|authorization|api[-_ ]?key)\b|(?:^|\s)secret(?:[-_ ]?(?:key|token))?\s*[:=]/i.test(
-            line,
-          ),
-      ) ?? "FAME quote request failed."
-  )
-    .replace(/(?:https?|wss?):\/\/\S+/g, "[redacted-url]")
-    .replace(/\b(?:bearer|token)\s+[a-z0-9._~+/=-]+/gi, "[redacted-secret]")
-    .replace(/0x[a-fA-F0-9]{64,}/g, "[redacted-hex]");
+  return displaySafeDiagnosticMessage(error);
 }
 
 export function quoteAdapterFailure(
@@ -400,7 +406,11 @@ export function publicFeeBreakdown(
   return {
     ...feeBreakdown,
     legs: feeBreakdown.legs.map(
-      ({ protocolEvidence: _protocolEvidence, ...leg }) => leg,
+      ({
+        protocolEvidence: _protocolEvidence,
+        indexedEvidence: _indexedEvidence,
+        ...leg
+      }) => leg,
     ),
   };
 }

--- a/src/features/fame-swap/solver/quotes/adapters.ts
+++ b/src/features/fame-swap/solver/quotes/adapters.ts
@@ -9,6 +9,14 @@ export interface FameEdgeQuoteRequest {
   context?: FameQuoteContext;
 }
 
+export type FameIndexedQuoteEvidence = {
+  source: "indexed";
+  kind: "compact-quote" | "raw-replay";
+  quoteKind: "constant-product-quote-v1" | "cl-quote-v1" | "cl-replay-v1";
+  evidenceId: string;
+  poolId: string;
+};
+
 export type FameEdgeQuoteFailureReason =
   | "adapter_failure"
   | "amount_exceeds_capacity"
@@ -47,6 +55,7 @@ export type FameEdgeQuoteResult =
       context?: FameQuoteContext;
       priceImpact?: FamePriceImpactEstimate;
       protocolEvidence?: FameProtocolEvidence;
+      indexedEvidence?: FameIndexedQuoteEvidence;
     }
   | {
       status: "failed";
@@ -79,6 +88,7 @@ export interface FameLegQuote {
   quoteContext?: FameQuoteContext;
   priceImpact?: FamePriceImpactEstimate;
   protocolEvidence?: FameProtocolEvidence;
+  indexedEvidence?: FameIndexedQuoteEvidence;
 }
 
 export interface FameCandidateRejection {

--- a/src/features/fame-swap/solver/quotes/asyncRankRoutes.ts
+++ b/src/features/fame-swap/solver/quotes/asyncRankRoutes.ts
@@ -156,6 +156,7 @@ export async function quoteRouteCandidateAsync(
       quoteContext: quote.context ?? quoteContext,
       priceImpact: quote.priceImpact,
       protocolEvidence: quote.protocolEvidence,
+      indexedEvidence: quote.indexedEvidence,
     });
   }
 

--- a/src/features/fame-swap/solver/quotes/fixtures/pool-quotes-v1.json
+++ b/src/features/fame-swap/solver/quotes/fixtures/pool-quotes-v1.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "description": "Golden compact FAME pool quote response for reserve constant-product pools.",
   "response": {
-    "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+    "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
     "currentBlock": 125,
     "producerMaxFreshnessBlocks": 120,
     "effectiveMaxFreshnessBlocks": 120,
@@ -27,7 +27,7 @@
         "amountIn": "500",
         "amountOut": "831",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "2500000000000000000",
@@ -84,7 +84,7 @@
         "amountIn": "500",
         "amountOut": "166",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "400000000000000000",
@@ -141,7 +141,7 @@
         "amountIn": "500",
         "amountOut": "827",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "2500000000000000000",
@@ -198,7 +198,7 @@
         "amountIn": "500",
         "amountOut": "165",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "400000000000000000",
@@ -255,7 +255,7 @@
         "amountIn": "500",
         "amountOut": "827",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "2500000000000000000",
@@ -312,7 +312,7 @@
         "amountIn": "500",
         "amountOut": "165",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "400000000000000000",
@@ -369,7 +369,7 @@
         "amountIn": "500",
         "amountOut": "827",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "2500000000000000000",
@@ -426,7 +426,7 @@
         "amountIn": "500",
         "amountOut": "165",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "400000000000000000",
@@ -483,7 +483,7 @@
         "amountIn": "500",
         "amountOut": "827",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "2500000000000000000",
@@ -540,7 +540,7 @@
         "amountIn": "500",
         "amountOut": "165",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "400000000000000000",
@@ -597,7 +597,7 @@
         "amountIn": "500",
         "amountOut": "831",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "2500000000000000000",
@@ -654,7 +654,7 @@
         "amountIn": "500",
         "amountOut": "166",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "400000000000000000",
@@ -711,7 +711,7 @@
         "amountIn": "500",
         "amountOut": "831",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "2500000000000000000",
@@ -768,7 +768,7 @@
         "amountIn": "500",
         "amountOut": "166",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "400000000000000000",

--- a/src/features/fame-swap/solver/quotes/fixtures/pool-quotes-v1.json
+++ b/src/features/fame-swap/solver/quotes/fixtures/pool-quotes-v1.json
@@ -1,8 +1,46 @@
 {
   "schemaVersion": 1,
   "description": "Golden compact FAME pool quote response for reserve constant-product pools.",
+  "unavailableExamples": [
+    {
+      "status": "unavailable",
+      "requested": {
+        "poolId": "slipstream-usdc-weth-100",
+        "tokenIn": "0x4200000000000000000000000000000000000006",
+        "tokenOut": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        "amountIn": "1000000"
+      },
+      "reason": "producer-untrusted",
+      "poolId": "slipstream-usdc-weth-100",
+      "chainId": 8453,
+      "poolAddress": "0xb2cc224c1c9fee385f8ad6a55b4d94e92359dc59",
+      "observedThroughBlock": 120,
+      "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
+      "maxFreshnessBlocks": 120,
+      "producerStatus": "trusted",
+      "producerReason": null
+    },
+    {
+      "status": "unavailable",
+      "requested": {
+        "poolId": "slipstream-basedflick-fame",
+        "tokenIn": "0x15e012abf9d32cd67fc6cf480ea0e318e9ed5926",
+        "tokenOut": "0xf307e242bfe1ec1ff01a4cef2fdaa81b10a52418",
+        "amountIn": "1000000"
+      },
+      "reason": "producer-untrusted",
+      "poolId": "slipstream-basedflick-fame",
+      "chainId": 8453,
+      "poolAddress": "0xbd7e5bb5a6251f6dde2cf56afa50ed0c8b4c2cdb",
+      "observedThroughBlock": 120,
+      "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
+      "maxFreshnessBlocks": 120,
+      "producerStatus": "warming",
+      "producerReason": "shadow-not-promoted"
+    }
+  ],
   "response": {
-    "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+    "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
     "currentBlock": 125,
     "producerMaxFreshnessBlocks": 120,
     "effectiveMaxFreshnessBlocks": 120,
@@ -27,7 +65,7 @@
         "amountIn": "500",
         "amountOut": "831",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "2500000000000000000",
@@ -84,7 +122,7 @@
         "amountIn": "500",
         "amountOut": "166",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "400000000000000000",
@@ -141,7 +179,7 @@
         "amountIn": "500",
         "amountOut": "827",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "2500000000000000000",
@@ -198,7 +236,7 @@
         "amountIn": "500",
         "amountOut": "165",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "400000000000000000",
@@ -255,7 +293,7 @@
         "amountIn": "500",
         "amountOut": "827",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "2500000000000000000",
@@ -312,7 +350,7 @@
         "amountIn": "500",
         "amountOut": "165",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "400000000000000000",
@@ -369,7 +407,7 @@
         "amountIn": "500",
         "amountOut": "827",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "2500000000000000000",
@@ -426,7 +464,7 @@
         "amountIn": "500",
         "amountOut": "165",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "400000000000000000",
@@ -483,7 +521,7 @@
         "amountIn": "500",
         "amountOut": "827",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "2500000000000000000",
@@ -540,7 +578,7 @@
         "amountIn": "500",
         "amountOut": "165",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "400000000000000000",
@@ -597,7 +635,7 @@
         "amountIn": "500",
         "amountOut": "831",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "2500000000000000000",
@@ -654,7 +692,7 @@
         "amountIn": "500",
         "amountOut": "166",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "400000000000000000",
@@ -711,7 +749,7 @@
         "amountIn": "500",
         "amountOut": "831",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "2500000000000000000",
@@ -768,7 +806,7 @@
         "amountIn": "500",
         "amountOut": "166",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb5b11fb5b0e829d7cef286ed3eb9df977260d1de50aabd658994b3995efb958b",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "400000000000000000",

--- a/src/features/fame-swap/solver/quotes/indexedClReplayAdapter.ts
+++ b/src/features/fame-swap/solver/quotes/indexedClReplayAdapter.ts
@@ -124,29 +124,46 @@ function getSqrtRatioAtTick(tick: number): bigint {
     (absTick & 0x1) !== 0
       ? 0xfffcb933bd6fad37aa2d162d1a594001n
       : 0x100000000000000000000000000000000n;
-  if ((absTick & 0x2) !== 0) ratio = (ratio * 0xfff97272373d413259a46990580e213an) >> 128n;
-  if ((absTick & 0x4) !== 0) ratio = (ratio * 0xfff2e50f5f656932ef12357cf3c7fdccn) >> 128n;
-  if ((absTick & 0x8) !== 0) ratio = (ratio * 0xffe5caca7e10e4e61c3624eaa0941cd0n) >> 128n;
-  if ((absTick & 0x10) !== 0) ratio = (ratio * 0xffcb9843d60f6159c9db58835c926644n) >> 128n;
-  if ((absTick & 0x20) !== 0) ratio = (ratio * 0xff973b41fa98c081472e6896dfb254c0n) >> 128n;
-  if ((absTick & 0x40) !== 0) ratio = (ratio * 0xff2ea16466c96a3843ec78b326b52861n) >> 128n;
-  if ((absTick & 0x80) !== 0) ratio = (ratio * 0xfe5dee046a99a2a811c461f1969c3053n) >> 128n;
-  if ((absTick & 0x100) !== 0) ratio = (ratio * 0xfcbe86c7900a88aedcffc83b479aa3a4n) >> 128n;
-  if ((absTick & 0x200) !== 0) ratio = (ratio * 0xf987a7253ac413176f2b074cf7815e54n) >> 128n;
-  if ((absTick & 0x400) !== 0) ratio = (ratio * 0xf3392b0822b70005940c7a398e4b70f3n) >> 128n;
-  if ((absTick & 0x800) !== 0) ratio = (ratio * 0xe7159475a2c29b7443b29c7fa6e889d9n) >> 128n;
-  if ((absTick & 0x1000) !== 0) ratio = (ratio * 0xd097f3bdfd2022b8845ad8f792aa5825n) >> 128n;
-  if ((absTick & 0x2000) !== 0) ratio = (ratio * 0xa9f746462d870fdf8a65dc1f90e061e5n) >> 128n;
-  if ((absTick & 0x4000) !== 0) ratio = (ratio * 0x70d869a156d2a1b890bb3df62baf32f7n) >> 128n;
-  if ((absTick & 0x8000) !== 0) ratio = (ratio * 0x31be135f97d08fd981231505542fcfa6n) >> 128n;
-  if ((absTick & 0x10000) !== 0) ratio = (ratio * 0x9aa508b5b7a84e1c677de54f3e99bc9n) >> 128n;
-  if ((absTick & 0x20000) !== 0) ratio = (ratio * 0x5d6af8dedb81196699c329225ee604n) >> 128n;
-  if ((absTick & 0x40000) !== 0) ratio = (ratio * 0x2216e584f5fa1ea926041bedfe98n) >> 128n;
-  if ((absTick & 0x80000) !== 0) ratio = (ratio * 0x48a170391f7dc42444e8fa2n) >> 128n;
+  if ((absTick & 0x2) !== 0)
+    ratio = (ratio * 0xfff97272373d413259a46990580e213an) >> 128n;
+  if ((absTick & 0x4) !== 0)
+    ratio = (ratio * 0xfff2e50f5f656932ef12357cf3c7fdccn) >> 128n;
+  if ((absTick & 0x8) !== 0)
+    ratio = (ratio * 0xffe5caca7e10e4e61c3624eaa0941cd0n) >> 128n;
+  if ((absTick & 0x10) !== 0)
+    ratio = (ratio * 0xffcb9843d60f6159c9db58835c926644n) >> 128n;
+  if ((absTick & 0x20) !== 0)
+    ratio = (ratio * 0xff973b41fa98c081472e6896dfb254c0n) >> 128n;
+  if ((absTick & 0x40) !== 0)
+    ratio = (ratio * 0xff2ea16466c96a3843ec78b326b52861n) >> 128n;
+  if ((absTick & 0x80) !== 0)
+    ratio = (ratio * 0xfe5dee046a99a2a811c461f1969c3053n) >> 128n;
+  if ((absTick & 0x100) !== 0)
+    ratio = (ratio * 0xfcbe86c7900a88aedcffc83b479aa3a4n) >> 128n;
+  if ((absTick & 0x200) !== 0)
+    ratio = (ratio * 0xf987a7253ac413176f2b074cf7815e54n) >> 128n;
+  if ((absTick & 0x400) !== 0)
+    ratio = (ratio * 0xf3392b0822b70005940c7a398e4b70f3n) >> 128n;
+  if ((absTick & 0x800) !== 0)
+    ratio = (ratio * 0xe7159475a2c29b7443b29c7fa6e889d9n) >> 128n;
+  if ((absTick & 0x1000) !== 0)
+    ratio = (ratio * 0xd097f3bdfd2022b8845ad8f792aa5825n) >> 128n;
+  if ((absTick & 0x2000) !== 0)
+    ratio = (ratio * 0xa9f746462d870fdf8a65dc1f90e061e5n) >> 128n;
+  if ((absTick & 0x4000) !== 0)
+    ratio = (ratio * 0x70d869a156d2a1b890bb3df62baf32f7n) >> 128n;
+  if ((absTick & 0x8000) !== 0)
+    ratio = (ratio * 0x31be135f97d08fd981231505542fcfa6n) >> 128n;
+  if ((absTick & 0x10000) !== 0)
+    ratio = (ratio * 0x9aa508b5b7a84e1c677de54f3e99bc9n) >> 128n;
+  if ((absTick & 0x20000) !== 0)
+    ratio = (ratio * 0x5d6af8dedb81196699c329225ee604n) >> 128n;
+  if ((absTick & 0x40000) !== 0)
+    ratio = (ratio * 0x2216e584f5fa1ea926041bedfe98n) >> 128n;
+  if ((absTick & 0x80000) !== 0)
+    ratio = (ratio * 0x48a170391f7dc42444e8fa2n) >> 128n;
   if (tick > 0) ratio = MAX_UINT256 / ratio;
-  return ratio % (2n ** 32n) === 0n
-    ? ratio >> 32n
-    : (ratio >> 32n) + 1n;
+  return ratio % 2n ** 32n === 0n ? ratio >> 32n : (ratio >> 32n) + 1n;
 }
 
 function amount0Delta(
@@ -160,9 +177,12 @@ function amount0Delta(
   const numerator1 = liquidity << 96n;
   const numerator2 = upper - lower;
   if (roundUp) {
-    return divRoundingUp(mulDivRoundingUp(numerator1, numerator2, upper), lower);
+    return divRoundingUp(
+      mulDivRoundingUp(numerator1, numerator2, upper),
+      lower,
+    );
   }
-  return ((numerator1 * numerator2) / upper) / lower;
+  return (numerator1 * numerator2) / upper / lower;
 }
 
 function amount1Delta(
@@ -238,12 +258,21 @@ function computeSwapStep(options: {
     ? amountInAtTarget
     : options.zeroForOne
       ? amount0Delta(sqrtNextX96, options.sqrtPriceX96, options.liquidity, true)
-      : amount1Delta(options.sqrtPriceX96, sqrtNextX96, options.liquidity, true);
+      : amount1Delta(
+          options.sqrtPriceX96,
+          sqrtNextX96,
+          options.liquidity,
+          true,
+        );
   const amountOut = options.zeroForOne
     ? amount1Delta(sqrtNextX96, options.sqrtPriceX96, options.liquidity, false)
     : amount0Delta(options.sqrtPriceX96, sqrtNextX96, options.liquidity, false);
   const feeAmount = reachesTarget
-    ? mulDivRoundingUp(amountIn, options.feePips, FEE_DENOMINATOR - options.feePips)
+    ? mulDivRoundingUp(
+        amountIn,
+        options.feePips,
+        FEE_DENOMINATOR - options.feePips,
+      )
     : options.amountRemaining - amountIn;
   return { sqrtNextX96, amountIn, amountOut, feeAmount };
 }
@@ -263,9 +292,7 @@ function nextInitializedTick(
   return ticks.find((tick) => tick.tick > currentTick) ?? null;
 }
 
-function replayTicks(
-  state: FameIndexedClReplayPoolState,
-): ReplayTick[] | null {
+function replayTicks(state: FameIndexedClReplayPoolState): ReplayTick[] | null {
   const ticks = state.initializedTicks.map((tick) => {
     const liquidityGross = parseUnsignedDecimal(tick.liquidityGross);
     const liquidityNet = parseSignedDecimal(tick.liquidityNet);
@@ -313,7 +340,8 @@ export function replaySlipstreamExactInput(options: {
   while (amountRemaining > 0n) {
     if (liquidity <= 0n) return "outside-indexed-tick-range";
     const nextTick = nextInitializedTick(ticks, tick, options.zeroForOne);
-    const targetTick = nextTick?.tick ?? (options.zeroForOne ? MIN_TICK : MAX_TICK);
+    const targetTick =
+      nextTick?.tick ?? (options.zeroForOne ? MIN_TICK : MAX_TICK);
     const sqrtTarget = getSqrtRatioAtTick(targetTick);
     const step = computeSwapStep({
       sqrtPriceX96: sqrt,
@@ -345,7 +373,9 @@ export function replaySlipstreamExactInput(options: {
     tick = options.zeroForOne ? nextTick.tick - 1 : nextTick.tick;
   }
 
-  return amountOut > 0n ? { amountOut, sqrtPriceX96After: sqrt } : "replay-failed";
+  return amountOut > 0n
+    ? { amountOut, sqrtPriceX96After: sqrt }
+    : "replay-failed";
 }
 
 function replayStateForRequest(
@@ -353,7 +383,8 @@ function replayStateForRequest(
   request: FameEdgeQuoteRequest,
   expectedSourceRegistryId: string,
 ): FameIndexedClReplayPoolState | FameIndexedClReplayFallbackReason {
-  if (request.edge.pool.venue !== "aerodrome-slipstream") return "unsupported-pool";
+  if (request.edge.pool.venue !== "aerodrome-slipstream")
+    return "unsupported-pool";
   if (!state || state.status !== "fresh") return "fresh-replay-state-missing";
   if (!("stateKind" in state) || state.stateKind !== "cl-replay-v1") {
     return "fresh-replay-state-missing";
@@ -413,6 +444,13 @@ export function quoteFromIndexedSlipstreamReplay(options: {
     fee: options.request.edge.fee,
     evidence: source,
     context: options.context,
+    indexedEvidence: {
+      source: "indexed",
+      kind: "raw-replay",
+      quoteKind: "cl-replay-v1",
+      evidenceId: state.snapshotId,
+      poolId: state.poolId,
+    },
     priceImpact: concentratedLiquidityPriceImpact({
       amountIn: options.request.amountIn,
       amountOut: replay.amountOut,

--- a/src/features/fame-swap/solver/quotes/indexedPoolStateClient.test.ts
+++ b/src/features/fame-swap/solver/quotes/indexedPoolStateClient.test.ts
@@ -4,6 +4,30 @@ import {
   createIndexedPoolStateClient,
   parseIndexedPoolStateResponse,
 } from "./indexedPoolStateClient";
+import {
+  FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE,
+  FAME_V4_ZORA_REVIEWED_POOL_SHAPE,
+} from "../poolStateRegistry";
+
+function reviewedV4Evidence(
+  reviewed:
+    | typeof FAME_V4_ZORA_REVIEWED_POOL_SHAPE
+    | typeof FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE,
+  kind: "zora-protocol-pool" | "zero-hook-static-fee" = "zora-protocol-pool",
+) {
+  return {
+    status: "verified",
+    source: "reviewed-v4-manifest",
+    kind,
+    manifestVersion: 1,
+    poolId: reviewed.poolId,
+    poolKey: reviewed.poolKey,
+    staticFee: reviewed.fee.toString(),
+    hookAddress: reviewed.hooks,
+    hookData: reviewed.hookData,
+    protocolFeeStatus: "zero",
+  } as const;
+}
 
 describe("FAME indexed pool-state client", () => {
   it("posts bounded pool-state requests with service auth", async () => {
@@ -251,6 +275,9 @@ describe("FAME indexed pool-state client", () => {
           stateHash:
             "0x6666666666666666666666666666666666666666666666666666666666666666",
           source: "uniswap-v4-state-view",
+          reviewedPoolEvidence: reviewedV4Evidence(
+            FAME_V4_ZORA_REVIEWED_POOL_SHAPE,
+          ),
           zoraProvenance: {
             status: "verified",
             source: "zora-factory-event",
@@ -313,6 +340,9 @@ describe("FAME indexed pool-state client", () => {
           stateHash:
             "0x6666666666666666666666666666666666666666666666666666666666666666",
           source: "uniswap-v4-state-view",
+          reviewedPoolEvidence: reviewedV4Evidence(
+            FAME_V4_ZORA_REVIEWED_POOL_SHAPE,
+          ),
           zoraProvenance: {
             status: "verified",
             source: "zora-factory-event",
@@ -351,6 +381,77 @@ describe("FAME indexed pool-state client", () => {
     assert.equal(stale && "bitmapWords" in stale, false);
   });
 
+  it("parses no-hook ZORA/ETH V4 replay entries without provenance", () => {
+    const parsed = parseIndexedPoolStateResponse({
+      sourceRegistryId: "unit",
+      currentBlock: 125,
+      producerMaxFreshnessBlocks: 120,
+      effectiveMaxFreshnessBlocks: 120,
+      pools: [
+        {
+          status: "fresh",
+          stateKind: "v4-cl-replay-v1",
+          poolId: FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.poolId,
+          chainId: 8453,
+          poolKey: FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.poolKey,
+          stateViewAddress:
+            FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.stateViewAddress,
+          token0: FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.currency0,
+          token1: FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.currency1,
+          venueFamily: "UniswapV4",
+          tickSpacing: FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.tickSpacing,
+          sqrtPriceX96: "79228162514264337593543950336",
+          tick: 0,
+          liquidity: "8888",
+          lpFee: FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.fee.toString(),
+          protocolFee: "0",
+          feeSource: "v4-slot0",
+          observedThroughBlock: 120,
+          blockHash:
+            "0x4444444444444444444444444444444444444444444444444444444444444444",
+          parentHash:
+            "0x5555555555555555555555555555555555555555555555555555555555555555",
+          snapshotId: "unit-v4-zora-eth-replay",
+          stateHash:
+            "0x6666666666666666666666666666666666666666666666666666666666666666",
+          source: "uniswap-v4-state-view",
+          reviewedPoolEvidence: reviewedV4Evidence(
+            FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE,
+            "zero-hook-static-fee",
+          ),
+          sourceRegistryId: "unit",
+          maxFreshnessBlocks: 120,
+          bitmapWordCount: 1,
+          initializedTickCount: 0,
+          bitmapChunkCount: 1,
+          tickChunkCount: 0,
+          minWordPosition: 0,
+          maxWordPosition: 0,
+          minTick: null,
+          maxTick: null,
+          bitmapWords: [
+            {
+              wordPosition: 0,
+              bitmap:
+                "0x0000000000000000000000000000000000000000000000000000000000000000",
+            },
+          ],
+          initializedTicks: [],
+        },
+      ],
+    });
+    const pool = parsed.pools[0];
+
+    assert.equal(pool?.status, "fresh");
+    if (pool?.status !== "fresh" || !("stateKind" in pool)) {
+      throw new Error("Expected fresh ZORA/ETH V4 replay state.");
+    }
+    assert.equal(pool.stateKind, "v4-cl-replay-v1");
+    assert.equal(pool.poolId, FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.poolId);
+    assert.equal(pool.reviewedPoolEvidence.kind, "zero-hook-static-fee");
+    assert.equal(pool.zoraProvenance, undefined);
+  });
+
   it("rejects V4 replay entries whose provenance does not bind the row", () => {
     assert.throws(
       () =>
@@ -387,6 +488,9 @@ describe("FAME indexed pool-state client", () => {
               stateHash:
                 "0x6666666666666666666666666666666666666666666666666666666666666666",
               source: "uniswap-v4-state-view",
+              reviewedPoolEvidence: reviewedV4Evidence(
+                FAME_V4_ZORA_REVIEWED_POOL_SHAPE,
+              ),
               zoraProvenance: {
                 status: "verified",
                 source: "zora-factory-event",
@@ -456,6 +560,9 @@ describe("FAME indexed pool-state client", () => {
       stateHash:
         "0x6666666666666666666666666666666666666666666666666666666666666666",
       source: "uniswap-v4-state-view",
+      reviewedPoolEvidence: reviewedV4Evidence(
+        FAME_V4_ZORA_REVIEWED_POOL_SHAPE,
+      ),
       zoraProvenance: {
         status: "verified",
         source: "zora-factory-event",

--- a/src/features/fame-swap/solver/quotes/indexedPoolStateClient.test.ts
+++ b/src/features/fame-swap/solver/quotes/indexedPoolStateClient.test.ts
@@ -28,7 +28,7 @@ describe("FAME indexed pool-state client", () => {
     const response = await client.fetchPoolStates({
       currentBlock: 125,
       maxFreshnessBlocks: 10,
-      stateSurfaces: ["cl-replay-v1"],
+      stateSurfaces: ["cl-replay-v1", "v4-cl-replay-v1"],
       poolIds: ["uniswap-v2-fame-direct"],
     });
 
@@ -37,7 +37,7 @@ describe("FAME indexed pool-state client", () => {
     assert.deepEqual(await requests[0]?.json(), {
       currentBlock: 125,
       maxFreshnessBlocks: 10,
-      stateSurfaces: ["cl-replay-v1"],
+      stateSurfaces: ["cl-replay-v1", "v4-cl-replay-v1"],
       pools: [{ poolId: "uniswap-v2-fame-direct" }],
     });
   });
@@ -215,6 +215,311 @@ describe("FAME indexed pool-state client", () => {
     assert.equal(pool?.status, "stale");
     assert.equal(pool && "stateKind" in pool && pool.stateKind, "cl-replay-v1");
     assert.equal(pool && "bitmapWords" in pool, false);
+  });
+
+  it("parses V4 replay entries with PoolKey identity", () => {
+    const parsed = parseIndexedPoolStateResponse({
+      sourceRegistryId: "unit",
+      currentBlock: 125,
+      producerMaxFreshnessBlocks: 120,
+      effectiveMaxFreshnessBlocks: 120,
+      pools: [
+        {
+          status: "fresh",
+          stateKind: "v4-cl-replay-v1",
+          poolId: "uniswap-v4-basedflick-zora",
+          chainId: 8453,
+          poolKey:
+            "0x0fe6333346fcd0ffa4be3fda91f271bda52c6755f604b06483b709666d363628",
+          stateViewAddress: "0xa3c0c9b65bad0b08107aa264b0f3db444b867a71",
+          token0: "0x1111111111166b7fe7bd91427724b487980afc69",
+          token1: "0x15e012abf9d32cd67fc6cf480ea0e318e9ed5926",
+          venueFamily: "UniswapV4",
+          tickSpacing: 200,
+          sqrtPriceX96: "79228162514264337593543950336",
+          tick: -17400,
+          liquidity: "8888",
+          lpFee: "30000",
+          protocolFee: "0",
+          feeSource: "v4-slot0",
+          observedThroughBlock: 120,
+          blockHash:
+            "0x4444444444444444444444444444444444444444444444444444444444444444",
+          parentHash:
+            "0x5555555555555555555555555555555555555555555555555555555555555555",
+          snapshotId: "unit-v4-cl-replay",
+          stateHash:
+            "0x6666666666666666666666666666666666666666666666666666666666666666",
+          source: "uniswap-v4-state-view",
+          zoraProvenance: {
+            status: "verified",
+            source: "zora-factory-event",
+            chainId: 8453,
+            factoryAddress: "0x0000000000000000000000000000000000000003",
+            coinAddress: "0x15e012abf9d32cd67fc6cf480ea0e318e9ed5926",
+            poolKey:
+              "0x0fe6333346fcd0ffa4be3fda91f271bda52c6755f604b06483b709666d363628",
+            poolId:
+              "0x0fe6333346fcd0ffa4be3fda91f271bda52c6755f604b06483b709666d363628",
+            transactionHash:
+              "0x7777777777777777777777777777777777777777777777777777777777777777",
+            eventName: "CoinCreatedV4",
+          },
+          sourceRegistryId: "unit",
+          maxFreshnessBlocks: 120,
+          bitmapWordCount: 1,
+          initializedTickCount: 1,
+          bitmapChunkCount: 1,
+          tickChunkCount: 1,
+          minWordPosition: -1,
+          maxWordPosition: -1,
+          minTick: -17400,
+          maxTick: -17400,
+          bitmapWords: [
+            {
+              wordPosition: -1,
+              bitmap:
+                "0x0000000000000000000002000000000000000000000000000000000000000000",
+            },
+          ],
+          initializedTicks: [
+            { tick: -17400, liquidityGross: "30", liquidityNet: "10" },
+          ],
+        },
+        {
+          status: "stale",
+          stateKind: "v4-cl-replay-v1",
+          poolId: "uniswap-v4-basedflick-zora",
+          chainId: 8453,
+          poolKey:
+            "0x0fe6333346fcd0ffa4be3fda91f271bda52c6755f604b06483b709666d363628",
+          stateViewAddress: "0xa3c0c9b65bad0b08107aa264b0f3db444b867a71",
+          token0: "0x1111111111166b7fe7bd91427724b487980afc69",
+          token1: "0x15e012abf9d32cd67fc6cf480ea0e318e9ed5926",
+          venueFamily: "UniswapV4",
+          tickSpacing: 200,
+          sqrtPriceX96: "79228162514264337593543950336",
+          tick: -17400,
+          liquidity: "8888",
+          lpFee: "30000",
+          protocolFee: "0",
+          feeSource: "v4-slot0",
+          observedThroughBlock: 1,
+          blockHash:
+            "0x4444444444444444444444444444444444444444444444444444444444444444",
+          parentHash:
+            "0x5555555555555555555555555555555555555555555555555555555555555555",
+          snapshotId: "unit-v4-cl-replay",
+          stateHash:
+            "0x6666666666666666666666666666666666666666666666666666666666666666",
+          source: "uniswap-v4-state-view",
+          zoraProvenance: {
+            status: "verified",
+            source: "zora-factory-event",
+            chainId: 8453,
+            factoryAddress: "0x0000000000000000000000000000000000000003",
+            coinAddress: "0x15e012abf9d32cd67fc6cf480ea0e318e9ed5926",
+            poolKey:
+              "0x0fe6333346fcd0ffa4be3fda91f271bda52c6755f604b06483b709666d363628",
+            poolId:
+              "0x0fe6333346fcd0ffa4be3fda91f271bda52c6755f604b06483b709666d363628",
+            transactionHash:
+              "0x7777777777777777777777777777777777777777777777777777777777777777",
+            eventName: "CoinCreatedV4",
+          },
+          sourceRegistryId: "unit",
+          maxFreshnessBlocks: 120,
+          bitmapWordCount: 1,
+          initializedTickCount: 1,
+          bitmapChunkCount: 1,
+          tickChunkCount: 1,
+          minWordPosition: -1,
+          maxWordPosition: -1,
+          minTick: -17400,
+          maxTick: -17400,
+        },
+      ],
+    });
+
+    const [fresh, stale] = parsed.pools;
+    assert.equal(fresh?.status, "fresh");
+    assert.equal(fresh && "stateKind" in fresh && fresh.stateKind, "v4-cl-replay-v1");
+    assert.equal(fresh && "poolAddress" in fresh, false);
+    assert.equal(fresh && "poolKey" in fresh && fresh.poolKey.startsWith("0x"), true);
+    assert.equal(stale?.status, "stale");
+    assert.equal(stale && "stateKind" in stale && stale.stateKind, "v4-cl-replay-v1");
+    assert.equal(stale && "bitmapWords" in stale, false);
+  });
+
+  it("rejects V4 replay entries whose provenance does not bind the row", () => {
+    assert.throws(
+      () =>
+        parseIndexedPoolStateResponse({
+          sourceRegistryId: "unit",
+          currentBlock: 125,
+          producerMaxFreshnessBlocks: 120,
+          effectiveMaxFreshnessBlocks: 120,
+          pools: [
+            {
+              status: "fresh",
+              stateKind: "v4-cl-replay-v1",
+              poolId: "uniswap-v4-basedflick-zora",
+              chainId: 8453,
+              poolKey:
+                "0x0fe6333346fcd0ffa4be3fda91f271bda52c6755f604b06483b709666d363628",
+              stateViewAddress: "0xa3c0c9b65bad0b08107aa264b0f3db444b867a71",
+              token0: "0x1111111111166b7fe7bd91427724b487980afc69",
+              token1: "0x15e012abf9d32cd67fc6cf480ea0e318e9ed5926",
+              venueFamily: "UniswapV4",
+              tickSpacing: 200,
+              sqrtPriceX96: "79228162514264337593543950336",
+              tick: -17400,
+              liquidity: "8888",
+              lpFee: "30000",
+              protocolFee: "0",
+              feeSource: "v4-slot0",
+              observedThroughBlock: 120,
+              blockHash:
+                "0x4444444444444444444444444444444444444444444444444444444444444444",
+              parentHash:
+                "0x5555555555555555555555555555555555555555555555555555555555555555",
+              snapshotId: "unit-v4-cl-replay",
+              stateHash:
+                "0x6666666666666666666666666666666666666666666666666666666666666666",
+              source: "uniswap-v4-state-view",
+              zoraProvenance: {
+                status: "verified",
+                source: "zora-factory-event",
+                chainId: 8453,
+                factoryAddress: "0x0000000000000000000000000000000000000003",
+                coinAddress: "0x1111111111166b7fe7bd91427724b487980afc69",
+                poolKey:
+                  "0x0fe6333346fcd0ffa4be3fda91f271bda52c6755f604b06483b709666d363628",
+                poolId:
+                  "0x0fe6333346fcd0ffa4be3fda91f271bda52c6755f604b06483b709666d363628",
+                transactionHash:
+                  "0x7777777777777777777777777777777777777777777777777777777777777777",
+                eventName: "CoinCreatedV4",
+              },
+              sourceRegistryId: "unit",
+              maxFreshnessBlocks: 120,
+              bitmapWordCount: 1,
+              initializedTickCount: 1,
+              bitmapChunkCount: 1,
+              tickChunkCount: 1,
+              minWordPosition: -1,
+              maxWordPosition: -1,
+              minTick: -17400,
+              maxTick: -17400,
+              bitmapWords: [
+                {
+                  wordPosition: -1,
+                  bitmap:
+                    "0x0000000000000000000002000000000000000000000000000000000000000000",
+                },
+              ],
+              initializedTicks: [
+                { tick: -17400, liquidityGross: "30", liquidityNet: "10" },
+              ],
+            },
+          ],
+        }),
+      /zoraProvenance/,
+    );
+  });
+
+  it("requires V4 empty tick snapshots to carry bitmap coverage", () => {
+    const emptyV4Entry = {
+      status: "fresh",
+      stateKind: "v4-cl-replay-v1",
+      poolId: "uniswap-v4-basedflick-zora",
+      chainId: 8453,
+      poolKey:
+        "0x0fe6333346fcd0ffa4be3fda91f271bda52c6755f604b06483b709666d363628",
+      stateViewAddress: "0xa3c0c9b65bad0b08107aa264b0f3db444b867a71",
+      token0: "0x1111111111166b7fe7bd91427724b487980afc69",
+      token1: "0x15e012abf9d32cd67fc6cf480ea0e318e9ed5926",
+      venueFamily: "UniswapV4",
+      tickSpacing: 200,
+      sqrtPriceX96: "79228162514264337593543950336",
+      tick: -17400,
+      liquidity: "0",
+      lpFee: "30000",
+      protocolFee: "0",
+      feeSource: "v4-slot0",
+      observedThroughBlock: 120,
+      blockHash:
+        "0x4444444444444444444444444444444444444444444444444444444444444444",
+      parentHash:
+        "0x5555555555555555555555555555555555555555555555555555555555555555",
+      snapshotId: "unit-v4-cl-replay-empty",
+      stateHash:
+        "0x6666666666666666666666666666666666666666666666666666666666666666",
+      source: "uniswap-v4-state-view",
+      zoraProvenance: {
+        status: "verified",
+        source: "zora-factory-event",
+        chainId: 8453,
+        factoryAddress: "0x0000000000000000000000000000000000000003",
+        coinAddress: "0x15e012abf9d32cd67fc6cf480ea0e318e9ed5926",
+        poolKey:
+          "0x0fe6333346fcd0ffa4be3fda91f271bda52c6755f604b06483b709666d363628",
+        poolId:
+          "0x0fe6333346fcd0ffa4be3fda91f271bda52c6755f604b06483b709666d363628",
+        transactionHash:
+          "0x7777777777777777777777777777777777777777777777777777777777777777",
+        eventName: "CoinCreatedV4",
+      },
+      sourceRegistryId: "unit",
+      maxFreshnessBlocks: 120,
+      bitmapWordCount: 1,
+      initializedTickCount: 0,
+      bitmapChunkCount: 1,
+      tickChunkCount: 0,
+      minWordPosition: -18,
+      maxWordPosition: -18,
+      minTick: null,
+      maxTick: null,
+      bitmapWords: [
+        {
+          wordPosition: -18,
+          bitmap:
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+        },
+      ],
+      initializedTicks: [],
+    };
+
+    assert.equal(
+      parseIndexedPoolStateResponse({
+        sourceRegistryId: "unit",
+        currentBlock: 125,
+        producerMaxFreshnessBlocks: 120,
+        effectiveMaxFreshnessBlocks: 120,
+        pools: [emptyV4Entry],
+      }).pools[0]?.status,
+      "fresh",
+    );
+    assert.throws(
+      () =>
+        parseIndexedPoolStateResponse({
+          sourceRegistryId: "unit",
+          currentBlock: 125,
+          producerMaxFreshnessBlocks: 120,
+          effectiveMaxFreshnessBlocks: 120,
+          pools: [
+            {
+              ...emptyV4Entry,
+              bitmapWordCount: 0,
+              bitmapChunkCount: 0,
+              minWordPosition: null,
+              maxWordPosition: null,
+              bitmapWords: [],
+            },
+          ],
+        }),
+      /bitmapWords/,
+    );
   });
 
   it("rejects incomplete fresh CL replay tick snapshots", () => {

--- a/src/features/fame-swap/solver/quotes/indexedPoolStateClient.ts
+++ b/src/features/fame-swap/solver/quotes/indexedPoolStateClient.ts
@@ -78,6 +78,31 @@ export interface FameIndexedClReplayStaleEntry
   status: "stale";
 }
 
+export interface FameV4ZoraVerifiedProvenance {
+  status: "verified";
+  source: "zora-factory-event" | "zora-factory-transaction-trace";
+  chainId: 8453;
+  factoryAddress: Address;
+  coinAddress: Address;
+  poolKey: Hex;
+  poolId: Hex;
+  transactionHash: Hex;
+  eventName: string | null;
+}
+
+export interface FameV4ReviewedPoolEvidence {
+  status: "verified";
+  source: "reviewed-v4-manifest";
+  kind: "zero-hook-static-fee" | "zora-protocol-pool";
+  manifestVersion: number;
+  poolId: string;
+  poolKey: Hex;
+  staticFee: string;
+  hookAddress: Address;
+  hookData: Hex;
+  protocolFeeStatus: "zero";
+}
+
 interface FameIndexedV4ClReplayBaseEntry
   extends FameIndexedPoolStateObservedFields {
   status: "fresh" | "stale";
@@ -101,17 +126,8 @@ interface FameIndexedV4ClReplayBaseEntry
   snapshotId: string;
   stateHash: Hex;
   source: "uniswap-v4-state-view";
-  zoraProvenance: {
-    status: "verified";
-    source: "zora-factory-event" | "zora-factory-transaction-trace";
-    chainId: 8453;
-    factoryAddress: Address;
-    coinAddress: Address;
-    poolKey: Hex;
-    poolId: Hex;
-    transactionHash: Hex;
-    eventName: string | null;
-  };
+  reviewedPoolEvidence: FameV4ReviewedPoolEvidence;
+  zoraProvenance?: FameV4ZoraVerifiedProvenance;
   sourceRegistryId: string;
   bitmapWordCount: number;
   initializedTickCount: number;
@@ -422,15 +438,32 @@ function parseV4ClReplayBaseEntry(
   const stateViewAddress = addressField(record, "stateViewAddress");
   const token0 = addressField(record, "token0");
   const token1 = addressField(record, "token1");
-  const zoraProvenance = parseV4ZoraProvenance(
+  const lpFee = decimalStringField(record, "lpFee");
+  const protocolFee = decimalStringField(record, "protocolFee");
+  const reviewedPoolEvidence = parseV4ReviewedPoolEvidence(
+    record.reviewedPoolEvidence,
+    "reviewedPoolEvidence",
+  );
+  const zoraProvenance = parseOptionalV4ZoraProvenance(
     record.zoraProvenance,
     "zoraProvenance",
   );
   if (
-    zoraProvenance.chainId !== chainId ||
-    zoraProvenance.poolKey.toLowerCase() !== poolKey.toLowerCase() ||
-    zoraProvenance.poolId.toLowerCase() !== poolKey.toLowerCase() ||
-    zoraProvenance.coinAddress.toLowerCase() !== token1.toLowerCase()
+    reviewedPoolEvidence.poolId !== poolId ||
+    reviewedPoolEvidence.poolKey.toLowerCase() !== poolKey.toLowerCase() ||
+    reviewedPoolEvidence.staticFee !== lpFee ||
+    protocolFee !== "0"
+  ) {
+    throw new Error(
+      "FAME indexed pool-state response invalid at reviewedPoolEvidence.",
+    );
+  }
+  if (
+    zoraProvenance !== undefined &&
+    (zoraProvenance.chainId !== chainId ||
+      zoraProvenance.poolKey.toLowerCase() !== poolKey.toLowerCase() ||
+      zoraProvenance.poolId.toLowerCase() !== poolKey.toLowerCase() ||
+      zoraProvenance.coinAddress.toLowerCase() !== token1.toLowerCase())
   ) {
     throw new Error(
       "FAME indexed pool-state response invalid at zoraProvenance.",
@@ -451,8 +484,8 @@ function parseV4ClReplayBaseEntry(
     sqrtPriceX96: decimalStringField(record, "sqrtPriceX96"),
     tick: safeIntegerField(record, "tick"),
     liquidity: decimalStringField(record, "liquidity"),
-    lpFee: decimalStringField(record, "lpFee"),
-    protocolFee: decimalStringField(record, "protocolFee"),
+    lpFee,
+    protocolFee,
     feeSource,
     observedThroughBlock: safeIntegerField(record, "observedThroughBlock"),
     blockHash: hexField(record, "blockHash"),
@@ -460,6 +493,7 @@ function parseV4ClReplayBaseEntry(
     snapshotId: stringField(record, "snapshotId"),
     stateHash: hexField(record, "stateHash"),
     source,
+    reviewedPoolEvidence,
     zoraProvenance,
     sourceRegistryId: stringField(record, "sourceRegistryId"),
     maxFreshnessBlocks: safeIntegerField(record, "maxFreshnessBlocks"),
@@ -477,7 +511,7 @@ function parseV4ClReplayBaseEntry(
 function parseV4ZoraProvenance(
   value: unknown,
   path: string,
-): FameIndexedV4ClReplayBaseEntry["zoraProvenance"] {
+): FameV4ZoraVerifiedProvenance {
   const record = asRecord(value, path);
   const status = stringField(record, "status");
   if (status !== "verified") {
@@ -508,6 +542,49 @@ function parseV4ZoraProvenance(
     poolId: bytes32HexField(record, "poolId"),
     transactionHash: bytes32HexField(record, "transactionHash"),
     eventName,
+  };
+}
+
+function parseOptionalV4ZoraProvenance(
+  value: unknown,
+  path: string,
+): FameV4ZoraVerifiedProvenance | undefined {
+  if (value === undefined) return undefined;
+  return parseV4ZoraProvenance(value, path);
+}
+
+function parseV4ReviewedPoolEvidence(
+  value: unknown,
+  path: string,
+): FameV4ReviewedPoolEvidence {
+  const record = asRecord(value, path);
+  const status = stringField(record, "status");
+  if (status !== "verified") {
+    throw new Error(`FAME indexed pool-state response invalid at ${path}.`);
+  }
+  const source = stringField(record, "source");
+  if (source !== "reviewed-v4-manifest") {
+    throw new Error(`FAME indexed pool-state response invalid at ${path}.`);
+  }
+  const kind = stringField(record, "kind");
+  if (kind !== "zero-hook-static-fee" && kind !== "zora-protocol-pool") {
+    throw new Error(`FAME indexed pool-state response invalid at ${path}.`);
+  }
+  const protocolFeeStatus = stringField(record, "protocolFeeStatus");
+  if (protocolFeeStatus !== "zero") {
+    throw new Error(`FAME indexed pool-state response invalid at ${path}.`);
+  }
+  return {
+    status,
+    source,
+    kind,
+    manifestVersion: safeIntegerField(record, "manifestVersion"),
+    poolId: stringField(record, "poolId"),
+    poolKey: bytes32HexField(record, "poolKey"),
+    staticFee: decimalStringField(record, "staticFee"),
+    hookAddress: addressField(record, "hookAddress"),
+    hookData: hexField(record, "hookData"),
+    protocolFeeStatus,
   };
 }
 

--- a/src/features/fame-swap/solver/quotes/indexedPoolStateClient.ts
+++ b/src/features/fame-swap/solver/quotes/indexedPoolStateClient.ts
@@ -78,10 +78,76 @@ export interface FameIndexedClReplayStaleEntry
   status: "stale";
 }
 
+interface FameIndexedV4ClReplayBaseEntry
+  extends FameIndexedPoolStateObservedFields {
+  status: "fresh" | "stale";
+  stateKind: "v4-cl-replay-v1";
+  poolId: string;
+  chainId: number;
+  poolKey: Hex;
+  stateViewAddress: Address;
+  token0: Address;
+  token1: Address;
+  venueFamily: "UniswapV4";
+  tickSpacing: number;
+  sqrtPriceX96: string;
+  tick: number;
+  liquidity: string;
+  lpFee: string;
+  protocolFee: string;
+  feeSource: "v4-slot0";
+  blockHash: Hex;
+  parentHash: Hex;
+  snapshotId: string;
+  stateHash: Hex;
+  source: "uniswap-v4-state-view";
+  zoraProvenance: {
+    status: "verified";
+    source: "zora-factory-event" | "zora-factory-transaction-trace";
+    chainId: 8453;
+    factoryAddress: Address;
+    coinAddress: Address;
+    poolKey: Hex;
+    poolId: Hex;
+    transactionHash: Hex;
+    eventName: string | null;
+  };
+  sourceRegistryId: string;
+  bitmapWordCount: number;
+  initializedTickCount: number;
+  bitmapChunkCount: number;
+  tickChunkCount: number;
+  minWordPosition: number | null;
+  maxWordPosition: number | null;
+  minTick: number | null;
+  maxTick: number | null;
+}
+
+export interface FameIndexedV4ClReplayFreshEntry
+  extends FameIndexedV4ClReplayBaseEntry {
+  status: "fresh";
+  bitmapWords: {
+    wordPosition: number;
+    bitmap: Hex;
+  }[];
+  initializedTicks: {
+    tick: number;
+    liquidityGross: string;
+    liquidityNet: string;
+  }[];
+}
+
+export interface FameIndexedV4ClReplayStaleEntry
+  extends FameIndexedV4ClReplayBaseEntry {
+  status: "stale";
+}
+
 export type FameIndexedPoolStateEntry =
   | FameIndexedReservePoolStateEntry
   | FameIndexedClReplayFreshEntry
   | FameIndexedClReplayStaleEntry
+  | FameIndexedV4ClReplayFreshEntry
+  | FameIndexedV4ClReplayStaleEntry
   | {
       status: "unsupported";
       poolId: string;
@@ -112,7 +178,11 @@ export interface FameIndexedPoolStateClient {
     currentBlock: number;
     poolIds: readonly string[];
     maxFreshnessBlocks?: number;
-    stateSurfaces?: readonly ("cl-head-snapshot" | "cl-replay-v1")[];
+    stateSurfaces?: readonly (
+      | "cl-head-snapshot"
+      | "cl-replay-v1"
+      | "v4-cl-replay-v1"
+    )[];
   }): Promise<FameIndexedPoolStateBatchResponse>;
 }
 
@@ -187,6 +257,14 @@ function signedDecimalStringField(
 function hexField(record: Record<string, unknown>, key: string): Hex {
   const value = stringField(record, key);
   if (!isHex(value, { strict: true })) {
+    throw new Error(`FAME indexed pool-state response invalid at ${key}.`);
+  }
+  return value;
+}
+
+function bytes32HexField(record: Record<string, unknown>, key: string): Hex {
+  const value = hexField(record, key);
+  if (!/^0x[0-9a-fA-F]{64}$/.test(value)) {
     throw new Error(`FAME indexed pool-state response invalid at ${key}.`);
   }
   return value;
@@ -317,6 +395,122 @@ function parseClReplayBaseEntry(
   };
 }
 
+function parseV4ClReplayBaseEntry(
+  record: Record<string, unknown>,
+  status: "fresh" | "stale",
+): FameIndexedV4ClReplayBaseEntry {
+  const feeSource = stringField(record, "feeSource");
+  if (feeSource !== "v4-slot0") {
+    throw new Error("FAME indexed pool-state response invalid at feeSource.");
+  }
+  const source = stringField(record, "source");
+  if (source !== "uniswap-v4-state-view") {
+    throw new Error("FAME indexed pool-state response invalid at source.");
+  }
+  const venueFamily = stringField(record, "venueFamily");
+  if (venueFamily !== "UniswapV4") {
+    throw new Error("FAME indexed pool-state response invalid at venueFamily.");
+  }
+  const tickSpacing = safeIntegerField(record, "tickSpacing");
+  if (tickSpacing <= 0) {
+    throw new Error("FAME indexed pool-state response invalid at tickSpacing.");
+  }
+
+  const poolId = stringField(record, "poolId");
+  const chainId = safeIntegerField(record, "chainId");
+  const poolKey = bytes32HexField(record, "poolKey");
+  const stateViewAddress = addressField(record, "stateViewAddress");
+  const token0 = addressField(record, "token0");
+  const token1 = addressField(record, "token1");
+  const zoraProvenance = parseV4ZoraProvenance(
+    record.zoraProvenance,
+    "zoraProvenance",
+  );
+  if (
+    zoraProvenance.chainId !== chainId ||
+    zoraProvenance.poolKey.toLowerCase() !== poolKey.toLowerCase() ||
+    zoraProvenance.poolId.toLowerCase() !== poolKey.toLowerCase() ||
+    zoraProvenance.coinAddress.toLowerCase() !== token1.toLowerCase()
+  ) {
+    throw new Error(
+      "FAME indexed pool-state response invalid at zoraProvenance.",
+    );
+  }
+
+  return {
+    status,
+    stateKind: "v4-cl-replay-v1",
+    poolId,
+    chainId,
+    poolKey,
+    stateViewAddress,
+    token0,
+    token1,
+    venueFamily,
+    tickSpacing,
+    sqrtPriceX96: decimalStringField(record, "sqrtPriceX96"),
+    tick: safeIntegerField(record, "tick"),
+    liquidity: decimalStringField(record, "liquidity"),
+    lpFee: decimalStringField(record, "lpFee"),
+    protocolFee: decimalStringField(record, "protocolFee"),
+    feeSource,
+    observedThroughBlock: safeIntegerField(record, "observedThroughBlock"),
+    blockHash: hexField(record, "blockHash"),
+    parentHash: hexField(record, "parentHash"),
+    snapshotId: stringField(record, "snapshotId"),
+    stateHash: hexField(record, "stateHash"),
+    source,
+    zoraProvenance,
+    sourceRegistryId: stringField(record, "sourceRegistryId"),
+    maxFreshnessBlocks: safeIntegerField(record, "maxFreshnessBlocks"),
+    bitmapWordCount: safeIntegerField(record, "bitmapWordCount"),
+    initializedTickCount: safeIntegerField(record, "initializedTickCount"),
+    bitmapChunkCount: safeIntegerField(record, "bitmapChunkCount"),
+    tickChunkCount: safeIntegerField(record, "tickChunkCount"),
+    minWordPosition: nullableNumberField(record, "minWordPosition"),
+    maxWordPosition: nullableNumberField(record, "maxWordPosition"),
+    minTick: nullableNumberField(record, "minTick"),
+    maxTick: nullableNumberField(record, "maxTick"),
+  };
+}
+
+function parseV4ZoraProvenance(
+  value: unknown,
+  path: string,
+): FameIndexedV4ClReplayBaseEntry["zoraProvenance"] {
+  const record = asRecord(value, path);
+  const status = stringField(record, "status");
+  if (status !== "verified") {
+    throw new Error(`FAME indexed pool-state response invalid at ${path}.`);
+  }
+  const source = stringField(record, "source");
+  if (
+    source !== "zora-factory-event" &&
+    source !== "zora-factory-transaction-trace"
+  ) {
+    throw new Error(`FAME indexed pool-state response invalid at ${path}.`);
+  }
+  const chainId = safeIntegerField(record, "chainId");
+  if (chainId !== 8453) {
+    throw new Error(`FAME indexed pool-state response invalid at ${path}.`);
+  }
+  const eventName = record.eventName;
+  if (eventName !== null && typeof eventName !== "string") {
+    throw new Error(`FAME indexed pool-state response invalid at ${path}.`);
+  }
+  return {
+    status,
+    source,
+    chainId,
+    factoryAddress: addressField(record, "factoryAddress"),
+    coinAddress: addressField(record, "coinAddress"),
+    poolKey: bytes32HexField(record, "poolKey"),
+    poolId: bytes32HexField(record, "poolId"),
+    transactionHash: bytes32HexField(record, "transactionHash"),
+    eventName,
+  };
+}
+
 function bitmapWordPosition(tick: number, tickSpacing: number): number {
   return Math.floor(tick / tickSpacing / 256);
 }
@@ -327,7 +521,7 @@ function bitmapBitPosition(tick: number, tickSpacing: number): number {
 }
 
 function validateClReplayFreshEntry(
-  entry: FameIndexedClReplayFreshEntry,
+  entry: FameIndexedClReplayFreshEntry | FameIndexedV4ClReplayFreshEntry,
 ): void {
   if (entry.bitmapWords.length !== entry.bitmapWordCount) {
     throw new Error("FAME indexed pool-state response invalid at bitmapWords.");
@@ -339,20 +533,50 @@ function validateClReplayFreshEntry(
   }
 
   const ticks = entry.initializedTicks.map((tick) => tick.tick);
+  const bitmapPositions = entry.bitmapWords.map((word) => word.wordPosition);
   if (new Set(ticks).size !== ticks.length) {
     throw new Error(
       "FAME indexed pool-state response invalid at initializedTicks.",
     );
   }
+  if (new Set(bitmapPositions).size !== bitmapPositions.length) {
+    throw new Error("FAME indexed pool-state response invalid at bitmapWords.");
+  }
+  if (bitmapPositions.length === 0) {
+    if (entry.minWordPosition !== null || entry.maxWordPosition !== null) {
+      throw new Error(
+        "FAME indexed pool-state response invalid at bitmap word bounds.",
+      );
+    }
+  } else if (
+    entry.minWordPosition !== Math.min(...bitmapPositions) ||
+    entry.maxWordPosition !== Math.max(...bitmapPositions)
+  ) {
+    throw new Error(
+      "FAME indexed pool-state response invalid at bitmap word bounds.",
+    );
+  }
+
+  const bitmapByWord = new Map(
+    entry.bitmapWords.map((word) => [word.wordPosition, BigInt(word.bitmap)]),
+  );
   if (ticks.length === 0) {
     if (
       entry.minTick !== null ||
-      entry.maxTick !== null ||
-      entry.minWordPosition !== null ||
-      entry.maxWordPosition !== null
+      entry.maxTick !== null
     ) {
       throw new Error(
         "FAME indexed pool-state response invalid at initialized tick bounds.",
+      );
+    }
+    if (entry.stateKind === "v4-cl-replay-v1" && bitmapByWord.size === 0) {
+      throw new Error(
+        "FAME indexed pool-state response invalid at bitmapWords.",
+      );
+    }
+    if ([...bitmapByWord.values()].some((bitmap) => bitmap !== 0n)) {
+      throw new Error(
+        "FAME indexed pool-state response invalid at initialized tick bitmap.",
       );
     }
     return;
@@ -363,21 +587,6 @@ function validateClReplayFreshEntry(
   if (entry.minTick !== minTick || entry.maxTick !== maxTick) {
     throw new Error(
       "FAME indexed pool-state response invalid at initialized tick bounds.",
-    );
-  }
-
-  const bitmapByWord = new Map(
-    entry.bitmapWords.map((word) => [word.wordPosition, BigInt(word.bitmap)]),
-  );
-  const wordPositions = ticks.map((tick) =>
-    bitmapWordPosition(tick, entry.tickSpacing),
-  );
-  if (
-    entry.minWordPosition !== Math.min(...wordPositions) ||
-    entry.maxWordPosition !== Math.max(...wordPositions)
-  ) {
-    throw new Error(
-      "FAME indexed pool-state response invalid at bitmap word bounds.",
     );
   }
 
@@ -426,6 +635,32 @@ function parseEntry(value: unknown, path: string): FameIndexedPoolStateEntry {
           parseInitializedTick,
         ),
       } satisfies FameIndexedClReplayFreshEntry;
+      validateClReplayFreshEntry(entry);
+      return entry;
+    }
+    if (stateKind === "v4-cl-replay-v1") {
+      const baseEntry = parseV4ClReplayBaseEntry(record, status);
+      if (status === "stale") {
+        return {
+          ...baseEntry,
+          status,
+        } satisfies FameIndexedV4ClReplayStaleEntry;
+      }
+
+      const entry = {
+        ...baseEntry,
+        status,
+        bitmapWords: parseArray(
+          record.bitmapWords,
+          `${path}.bitmapWords`,
+          parseBitmapWord,
+        ),
+        initializedTicks: parseArray(
+          record.initializedTicks,
+          `${path}.initializedTicks`,
+          parseInitializedTick,
+        ),
+      } satisfies FameIndexedV4ClReplayFreshEntry;
       validateClReplayFreshEntry(entry);
       return entry;
     }

--- a/src/features/fame-swap/solver/quotes/indexedQuoteApiAdapter.test.ts
+++ b/src/features/fame-swap/solver/quotes/indexedQuoteApiAdapter.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import type { Address } from "viem";
-import { FAME, USDC, WETH } from "../../tokens";
+import { FAME, WETH } from "../../tokens";
 import {
   FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE,
   FAME_V4_ZORA_REVIEWED_POOL_SHAPE,
@@ -41,12 +41,14 @@ const UNIT_V4_ZORA_ACTIVATION = {
 
 function edgeFor(
   poolId: string,
-  tokenIn: Address = WETH,
-  tokenOut: Address = USDC,
+  tokenIn?: Address,
+  tokenOut?: Address,
 ) {
-  const edge = famePoolEdgesForPair(tokenIn, tokenOut).find(
-    (candidate) => candidate.poolId === poolId,
-  );
+  const edges =
+    tokenIn && tokenOut
+      ? famePoolEdgesForPair(tokenIn, tokenOut)
+      : famePoolEdges();
+  const edge = edges.find((candidate) => candidate.poolId === poolId);
   assert.ok(edge);
   return edge;
 }
@@ -64,15 +66,15 @@ function clRow(
   return {
     status: "quoted",
     quoteKind: "cl-quote-v1",
-    poolId: "slipstream-usdc-weth-100",
+    poolId: "slipstream-basedflick-fame",
     chainId: 8453,
-    poolAddress: "0xb2cc224c1c9fee385f8ad6a55b4d94e92359dc59",
-    token0: WETH,
-    token1: USDC,
+    poolAddress: "0xbd7e5bb5a6251f6dde2cf56afa50ed0c8b4c2cdb",
+    token0: BASEDFLICK,
+    token1: FAME,
     tokenIn: quoteRequest.tokenIn,
     tokenOut: quoteRequest.tokenOut,
     venueFamily: "Slipstream",
-    tickSpacing: 100,
+    tickSpacing: 2000,
     amountIn: quoteRequest.amountIn,
     amountOut: "999900",
     sqrtPriceX96: Q96.toString(),
@@ -103,11 +105,11 @@ function reserveRow(
   return {
     status: "quoted",
     quoteKind: "constant-product-quote-v1",
-    poolId: "uniswap-v2-usdc-weth",
+    poolId: "uniswap-v2-fame-direct",
     chainId: 8453,
-    poolAddress: "0x88a43bbdf9d098eec7bceda4e2494615dfd9bb9c",
+    poolAddress: "0x3e2cab55bebf41719148b4e6b63f6644b18ae49c",
     token0: WETH,
-    token1: USDC,
+    token1: FAME,
     tokenIn: quoteRequest.tokenIn,
     tokenOut: quoteRequest.tokenOut,
     venueFamily: "UniswapV2",
@@ -252,7 +254,7 @@ function quotedResponse(
     producerMaxFreshnessBlocks: 120,
     effectiveMaxFreshnessBlocks: 120,
     quotes: request.quotes.map((quoteRequest) =>
-      quoteRequest.poolId === "slipstream-usdc-weth-100"
+      quoteRequest.poolId === "slipstream-basedflick-fame"
         ? clRow(quoteRequest)
         : reserveRow(quoteRequest),
     ),
@@ -291,7 +293,7 @@ function fallbackAdapter(counter: { calls: number }): FameQuoteAdapter {
 
 describe("FAME indexed quote API adapter", () => {
   it("quotes Slipstream edges from compact CL rows", async () => {
-    const edge = edgeFor("slipstream-usdc-weth-100");
+    const edge = edgeFor("slipstream-basedflick-fame");
     const fallback = { calls: 0 };
     const clientRequests: FamePoolQuoteBatchRequest[] = [];
     const adapter = createIndexedQuoteApiAdapter({
@@ -314,9 +316,9 @@ describe("FAME indexed quote API adapter", () => {
       maxFreshnessBlocks: 10,
       quotes: [
         {
-          poolId: "slipstream-usdc-weth-100",
-          tokenIn: WETH,
-          tokenOut: USDC,
+          poolId: "slipstream-basedflick-fame",
+          tokenIn: edge.tokenIn,
+          tokenOut: edge.tokenOut,
           amountIn: "1000000",
         },
       ],
@@ -388,7 +390,7 @@ describe("FAME indexed quote API adapter", () => {
     assert.equal(quote.status, "quoted");
   });
 
-  it("quotes the reviewed V4 Zora edge from activated compact CL rows", async () => {
+  it("keeps the reviewed basedflick/ZORA V4 edge on live fallback after activation", async () => {
     const edge = edgeForPool(FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId);
     const fallback = { calls: 0 };
     const clientRequests: FamePoolQuoteBatchRequest[] = [];
@@ -414,37 +416,13 @@ describe("FAME indexed quote API adapter", () => {
 
     const quote = await adapter.quoteEdge({ edge, amountIn: 1_000_000n });
 
-    assert.equal(fallback.calls, 0);
-    assert.deepEqual(clientRequests[0], {
-      currentBlock: 125,
-      maxFreshnessBlocks: 10,
-      quotes: [
-        {
-          poolId: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId,
-          tokenIn: edge.tokenIn,
-          tokenOut: edge.tokenOut,
-          amountIn: "1000000",
-        },
-      ],
-    });
+    assert.equal(clientRequests.length, 0);
+    assert.equal(fallback.calls, 1);
     assert.equal(quote.status, "quoted");
-    if (quote.status === "quoted") {
-      assert.equal(quote.amountOut, 969_999n);
-      assert.match(quote.evidence, /indexed Uniswap V4 CL quote/);
-      assert.equal(quote.context?.source, "indexed");
-      assert.deepEqual(quote.indexedEvidence, {
-        source: "indexed",
-        kind: "compact-quote",
-        quoteKind: "cl-quote-v1",
-        evidenceId: "unit-v4-cl-quote",
-        poolId: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId,
-      });
-      assert.equal(quote.priceImpact?.method, "quoter-price-after");
-    }
-    assert.equal(diagnostics.snapshot().usedCount, 1);
+    assert.equal(diagnostics.snapshot().attempted, false);
   });
 
-  it("quotes the reviewed V4 ZORA/ETH edge without Zora provenance", async () => {
+  it("keeps the reviewed ZORA/ETH V4 edge on live fallback after activation", async () => {
     const edge = edgeForPool(FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.poolId);
     const fallback = { calls: 0 };
     const clientRequests: FamePoolQuoteBatchRequest[] = [];
@@ -470,36 +448,14 @@ describe("FAME indexed quote API adapter", () => {
 
     const quote = await adapter.quoteEdge({ edge, amountIn: 1_000_000n });
 
-    assert.equal(fallback.calls, 0);
-    assert.deepEqual(clientRequests[0], {
-      currentBlock: 125,
-      maxFreshnessBlocks: 10,
-      quotes: [
-        {
-          poolId: FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.poolId,
-          tokenIn: edge.tokenIn,
-          tokenOut: edge.tokenOut,
-          amountIn: "1000000",
-        },
-      ],
-    });
+    assert.equal(clientRequests.length, 0);
+    assert.equal(fallback.calls, 1);
     assert.equal(quote.status, "quoted");
-    if (quote.status === "quoted") {
-      assert.equal(quote.amountOut, 969_999n);
-      assert.match(quote.evidence, /indexed Uniswap V4 CL quote/);
-      assert.deepEqual(quote.indexedEvidence, {
-        source: "indexed",
-        kind: "compact-quote",
-        quoteKind: "cl-quote-v1",
-        evidenceId: "unit-v4-cl-quote",
-        poolId: FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.poolId,
-      });
-    }
-    assert.equal(diagnostics.snapshot().usedCount, 1);
+    assert.equal(diagnostics.snapshot().attempted, false);
   });
 
   it("quotes reserve edges from constant-product compact rows", async () => {
-    const edge = edgeFor("uniswap-v2-usdc-weth");
+    const edge = edgeFor("uniswap-v2-fame-direct");
     const fallback = { calls: 0 };
     const diagnostics = createQuoteApiDiagnosticsRecorder(true);
     const adapter = createIndexedQuoteApiAdapter({
@@ -610,8 +566,8 @@ describe("FAME indexed quote API adapter", () => {
   });
 
   it("uses compact output and live fallback in the same batch", async () => {
-    const clEdge = edgeFor("slipstream-usdc-weth-100");
-    const reserveEdge = edgeFor("uniswap-v2-usdc-weth");
+    const clEdge = edgeFor("slipstream-basedflick-fame");
+    const reserveEdge = edgeFor("uniswap-v2-fame-direct");
     const fallback = { calls: 0 };
     const clientRequests: FamePoolQuoteBatchRequest[] = [];
     const diagnostics = createQuoteApiDiagnosticsRecorder(true);
@@ -624,7 +580,7 @@ describe("FAME indexed quote API adapter", () => {
           producerMaxFreshnessBlocks: 120,
           effectiveMaxFreshnessBlocks: 120,
           quotes: request.quotes.map((quoteRequest) =>
-            quoteRequest.poolId === "slipstream-usdc-weth-100"
+            quoteRequest.poolId === "slipstream-basedflick-fame"
               ? clRow(quoteRequest)
               : {
                   status: "unavailable" as const,
@@ -632,7 +588,7 @@ describe("FAME indexed quote API adapter", () => {
                   reason: "stale-indexed-state" as const,
                   poolId: quoteRequest.poolId,
                   chainId: 8453,
-                  poolAddress: "0x88a43bbdf9d098eec7bceda4e2494615dfd9bb9c",
+                  poolAddress: "0x3e2cab55bebf41719148b4e6b63f6644b18ae49c",
                   observedThroughBlock: 1,
                   sourceRegistryId: "unit-registry",
                   maxFreshnessBlocks: 120,
@@ -666,8 +622,8 @@ describe("FAME indexed quote API adapter", () => {
   });
 
   it("falls back only the producer-untrusted CL row and records producer diagnostics", async () => {
-    const clEdge = edgeFor("slipstream-usdc-weth-100");
-    const reserveEdge = edgeFor("uniswap-v2-usdc-weth");
+    const clEdge = edgeFor("slipstream-basedflick-fame");
+    const reserveEdge = edgeFor("uniswap-v2-fame-direct");
     const fallback = { calls: 0 };
     const diagnostics = createQuoteApiDiagnosticsRecorder(true);
     const adapter = createIndexedQuoteApiAdapter({
@@ -679,14 +635,14 @@ describe("FAME indexed quote API adapter", () => {
           producerMaxFreshnessBlocks: 120,
           effectiveMaxFreshnessBlocks: 120,
           quotes: request.quotes.map((quoteRequest) =>
-            quoteRequest.poolId === "slipstream-usdc-weth-100"
+            quoteRequest.poolId === "slipstream-basedflick-fame"
               ? {
                   status: "unavailable" as const,
                   requested: quoteRequest,
                   reason: "producer-untrusted" as const,
                   poolId: quoteRequest.poolId,
                   chainId: 8453,
-                  poolAddress: "0xb2cc224c1c9fee385f8ad6a55b4d94e92359dc59",
+                  poolAddress: "0xbd7e5bb5a6251f6dde2cf56afa50ed0c8b4c2cdb",
                   observedThroughBlock: 120,
                   sourceRegistryId: "unit-registry",
                   maxFreshnessBlocks: 120,
@@ -732,7 +688,7 @@ describe("FAME indexed quote API adapter", () => {
   });
 
   it("falls back when compact quote metadata does not match the local pool", async () => {
-    const edge = edgeFor("uniswap-v2-usdc-weth");
+    const edge = edgeFor("uniswap-v2-fame-direct");
     const fallback = { calls: 0 };
     const diagnostics = createQuoteApiDiagnosticsRecorder(true);
     const adapter = createIndexedQuoteApiAdapter({
@@ -765,7 +721,7 @@ describe("FAME indexed quote API adapter", () => {
     );
   });
 
-  it("falls back when a reviewed V4 row is stale for the requested block", async () => {
+  it("keeps reviewed V4 rows off the helper even when stale row fixtures exist", async () => {
     const edge = edgeForPool(FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId);
     const fallback = { calls: 0 };
     const diagnostics = createQuoteApiDiagnosticsRecorder(true);
@@ -796,19 +752,10 @@ describe("FAME indexed quote API adapter", () => {
 
     assert.equal(fallback.calls, 1);
     assert.equal(quote.status, "quoted");
-    assert.equal(
-      diagnostics.snapshot().fallbackReasonCounts.row_metadata_mismatch,
-      1,
-    );
-    assert.equal(
-      diagnostics.snapshot().details.find(
-        (detail) => detail.outcome === "fallback",
-      )?.evidenceId,
-      "unit-v4-cl-quote",
-    );
+    assert.equal(diagnostics.snapshot().attempted, false);
   });
 
-  it("falls back when a reviewed V4 response has duplicate matching rows", async () => {
+  it("keeps reviewed V4 rows off the helper even when duplicate row fixtures exist", async () => {
     const edge = edgeForPool(FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId);
     const fallback = { calls: 0 };
     const diagnostics = createQuoteApiDiagnosticsRecorder(true);
@@ -837,10 +784,10 @@ describe("FAME indexed quote API adapter", () => {
 
     assert.equal(fallback.calls, 1);
     assert.equal(quote.status, "quoted");
-    assert.equal(diagnostics.snapshot().fallbackReasonCounts.row_ambiguous, 1);
+    assert.equal(diagnostics.snapshot().attempted, false);
   });
 
-  it("falls back when reviewed V4 row metadata does not match the local pool", async () => {
+  it("keeps reviewed V4 rows off the helper even when metadata mismatch fixtures exist", async () => {
     const edge = edgeForPool(FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId);
     const fallback = { calls: 0 };
     const diagnostics = createQuoteApiDiagnosticsRecorder(true);
@@ -871,10 +818,7 @@ describe("FAME indexed quote API adapter", () => {
 
     assert.equal(fallback.calls, 1);
     assert.equal(quote.status, "quoted");
-    assert.equal(
-      diagnostics.snapshot().fallbackReasonCounts.row_metadata_mismatch,
-      1,
-    );
+    assert.equal(diagnostics.snapshot().attempted, false);
   });
 
   it("does not request compact rows for unreviewed V4 pools", async () => {
@@ -899,7 +843,7 @@ describe("FAME indexed quote API adapter", () => {
     assert.equal(quote.status, "quoted");
   });
 
-  it("falls back when a V4 edge receives a Slipstream-sourced CL row", async () => {
+  it("keeps V4 edges off the helper even when Slipstream row fixtures exist", async () => {
     const edge = edgeForPool(FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId);
     const fallback = { calls: 0 };
     const diagnostics = createQuoteApiDiagnosticsRecorder(true);
@@ -931,16 +875,13 @@ describe("FAME indexed quote API adapter", () => {
 
     assert.equal(fallback.calls, 1);
     assert.equal(quote.status, "quoted");
-    assert.equal(
-      diagnostics.snapshot().fallbackReasonCounts.row_kind_mismatch,
-      1,
-    );
+    assert.equal(diagnostics.snapshot().attempted, false);
   });
 
   for (const testCase of [
     {
       name: "response source registry mismatch",
-      poolId: "uniswap-v2-usdc-weth",
+      poolId: "uniswap-v2-fame-direct",
       expectedReason: "source_registry_mismatch",
       response: (request: FamePoolQuoteBatchRequest) => ({
         ...quotedResponse(request),
@@ -949,7 +890,7 @@ describe("FAME indexed quote API adapter", () => {
     },
     {
       name: "missing response row",
-      poolId: "uniswap-v2-usdc-weth",
+      poolId: "uniswap-v2-fame-direct",
       expectedReason: "row_not_found",
       response: (request: FamePoolQuoteBatchRequest) => ({
         ...quotedResponse(request),
@@ -958,7 +899,7 @@ describe("FAME indexed quote API adapter", () => {
     },
     {
       name: "row source registry mismatch",
-      poolId: "uniswap-v2-usdc-weth",
+      poolId: "uniswap-v2-fame-direct",
       expectedReason: "row_source_registry_mismatch",
       response: (request: FamePoolQuoteBatchRequest) => ({
         ...quotedResponse(request),
@@ -969,14 +910,14 @@ describe("FAME indexed quote API adapter", () => {
     },
     {
       name: "row kind mismatch",
-      poolId: "uniswap-v2-usdc-weth",
+      poolId: "uniswap-v2-fame-direct",
       expectedReason: "row_kind_mismatch",
       response: (request: FamePoolQuoteBatchRequest) => ({
         ...quotedResponse(request),
         quotes: request.quotes.map((quoteRequest) =>
           clRow(quoteRequest, {
-            poolId: "uniswap-v2-usdc-weth",
-            poolAddress: "0x88a43bbdf9d098eec7bceda4e2494615dfd9bb9c",
+            poolId: "uniswap-v2-fame-direct",
+            poolAddress: "0x3e2cab55bebf41719148b4e6b63f6644b18ae49c",
             venueFamily: "UniswapV2",
           }),
         ),
@@ -984,7 +925,7 @@ describe("FAME indexed quote API adapter", () => {
     },
     {
       name: "unusable CL amount",
-      poolId: "slipstream-usdc-weth-100",
+      poolId: "slipstream-basedflick-fame",
       expectedReason: "row_amount_invalid",
       response: (request: FamePoolQuoteBatchRequest) => ({
         ...quotedResponse(request),
@@ -995,7 +936,7 @@ describe("FAME indexed quote API adapter", () => {
     },
     {
       name: "unusable reserve price impact",
-      poolId: "uniswap-v2-usdc-weth",
+      poolId: "uniswap-v2-fame-direct",
       expectedReason: "row_price_impact_invalid",
       response: (request: FamePoolQuoteBatchRequest) => ({
         ...quotedResponse(request),
@@ -1043,7 +984,7 @@ describe("FAME indexed quote API adapter", () => {
   }
 
   it("falls back every affected edge on batch failure with sanitized diagnostics", async () => {
-    const edge = edgeFor("slipstream-usdc-weth-100");
+    const edge = edgeFor("slipstream-basedflick-fame");
     const fallback = { calls: 0 };
     const diagnostics = createQuoteApiDiagnosticsRecorder(true);
     const adapter = createIndexedQuoteApiAdapter({
@@ -1072,8 +1013,8 @@ describe("FAME indexed quote API adapter", () => {
   });
 
   it("reports one batch failure callback for a shared failed batch", async () => {
-    const clEdge = edgeFor("slipstream-usdc-weth-100");
-    const reserveEdge = edgeFor("uniswap-v2-usdc-weth");
+    const clEdge = edgeFor("slipstream-basedflick-fame");
+    const reserveEdge = edgeFor("uniswap-v2-fame-direct");
     const fallback = { calls: 0 };
     let batchFailures = 0;
     const adapter = createIndexedQuoteApiAdapter({
@@ -1102,7 +1043,7 @@ describe("FAME indexed quote API adapter", () => {
   });
 
   it("coalesces duplicate evaluated edges into one quote API request", async () => {
-    const edge = edgeFor("slipstream-usdc-weth-100");
+    const edge = edgeFor("slipstream-basedflick-fame");
     const fallback = { calls: 0 };
     const clientRequests: FamePoolQuoteBatchRequest[] = [];
     const adapter = createIndexedQuoteApiAdapter({

--- a/src/features/fame-swap/solver/quotes/indexedQuoteApiAdapter.test.ts
+++ b/src/features/fame-swap/solver/quotes/indexedQuoteApiAdapter.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { USDC, WETH } from "../../tokens";
-import { famePoolEdgesForPair } from "../poolUniverse";
+import {
+  FAME_V4_ZORA_REVIEWED_POOL_SHAPE,
+  type FameV4ZoraQuoteLaneActivation,
+} from "../poolStateRegistry";
+import { famePoolEdges, famePoolEdgesForPair } from "../poolUniverse";
 import type {
   FameEdgeQuoteRequest,
   FameEdgeQuoteResult,
@@ -18,14 +22,28 @@ import type {
   FamePoolQuoteBatchRequest,
   FamePoolQuoteBatchResponse,
   FamePoolQuoteClient,
+  FameV4ClPoolQuoteQuotedEntry,
 } from "./indexedQuoteApiClient";
 
 const Q96 = 79_228_162_514_264_337_593_543_950_336n;
+const UNIT_V4_ZORA_ACTIVATION = {
+  status: "active",
+  sourceRegistryId: "unit-registry",
+  parityStatus: "passed",
+  routeSimulationStatus: "passed",
+  evidenceId: "unit-v4-zora-activation",
+} as const satisfies FameV4ZoraQuoteLaneActivation;
 
 function edgeFor(poolId: string) {
   const edge = famePoolEdgesForPair(WETH, USDC).find(
     (candidate) => candidate.poolId === poolId,
   );
+  assert.ok(edge);
+  return edge;
+}
+
+function edgeForPool(poolId: string) {
+  const edge = famePoolEdges().find((candidate) => candidate.poolId === poolId);
   assert.ok(edge);
   return edge;
 }
@@ -133,6 +151,68 @@ function reserveRow(
   };
 }
 
+function v4Row(
+  quoteRequest: FamePoolQuoteBatchRequest["quotes"][number],
+  overrides: Partial<FameV4ClPoolQuoteQuotedEntry> = {},
+): FameV4ClPoolQuoteQuotedEntry {
+  const reviewed = FAME_V4_ZORA_REVIEWED_POOL_SHAPE;
+  return {
+    status: "quoted",
+    quoteKind: "cl-quote-v1",
+    poolId: reviewed.poolId,
+    chainId: 8453,
+    poolAddress: null,
+    poolKey: reviewed.poolKey,
+    poolManager: reviewed.poolManager,
+    stateViewAddress: reviewed.stateViewAddress,
+    token0: reviewed.currency0,
+    token1: reviewed.currency1,
+    tokenIn: quoteRequest.tokenIn,
+    tokenOut: quoteRequest.tokenOut,
+    venueFamily: "UniswapV4",
+    tickSpacing: reviewed.tickSpacing,
+    amountIn: quoteRequest.amountIn,
+    amountOut: "969999",
+    sqrtPriceX96: Q96.toString(),
+    sqrtPriceX96After: (Q96 - 1n).toString(),
+    tick: 0,
+    liquidity: "1000000000000000000",
+    fee: reviewed.fee.toString(),
+    lpFee: reviewed.fee.toString(),
+    protocolFee: "0",
+    protocolFeeStatus: "zero",
+    staticFee: reviewed.fee.toString(),
+    feeSource: "v4-slot0",
+    observedThroughBlock: 120,
+    blockHash:
+      "0x4444444444444444444444444444444444444444444444444444444444444444",
+    parentHash:
+      "0x5555555555555555555555555555555555555555555555555555555555555555",
+    snapshotId: "unit-v4-cl-quote",
+    stateHash:
+      "0x6666666666666666666666666666666666666666666666666666666666666666",
+    source: "uniswap-v4-state-view",
+    sourceRegistryId: "unit-registry",
+    maxFreshnessBlocks: 120,
+    hookAddress: reviewed.hooks,
+    hookData: reviewed.hookData,
+    hookDataStatus: "empty",
+    zoraProvenance: {
+      status: "verified",
+      source: "zora-factory-event",
+      chainId: 8453,
+      factoryAddress: "0x0000000000000000000000000000000000000003",
+      coinAddress: reviewed.currency1,
+      poolKey: reviewed.poolKey,
+      poolId: reviewed.poolKey,
+      transactionHash:
+        "0x7777777777777777777777777777777777777777777777777777777777777777",
+      eventName: "CoinCreatedV4",
+    },
+    ...overrides,
+  };
+}
+
 function quotedResponse(
   request: FamePoolQuoteBatchRequest,
 ): FamePoolQuoteBatchResponse {
@@ -220,6 +300,113 @@ describe("FAME indexed quote API adapter", () => {
     }
   });
 
+  it("falls back for the reviewed V4 Zora edge until parity and route-simulation activation passes", async () => {
+    const edge = edgeForPool(FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId);
+    const fallback = { calls: 0 };
+    const clientRequests: FamePoolQuoteBatchRequest[] = [];
+    const adapter = createIndexedQuoteApiAdapter({
+      quoteClient: quoteClient({
+        requests: clientRequests,
+        response: async (request) => ({
+          sourceRegistryId: "unit-registry",
+          currentBlock: request.currentBlock,
+          producerMaxFreshnessBlocks: 120,
+          effectiveMaxFreshnessBlocks: 120,
+          quotes: request.quotes.map((quoteRequest) => v4Row(quoteRequest)),
+        }),
+      }),
+      fallback: fallbackAdapter(fallback),
+      currentBlock: 125,
+      expectedSourceRegistryId: "unit-registry",
+    });
+
+    const quote = await adapter.quoteEdge({ edge, amountIn: 1_000_000n });
+
+    assert.equal(clientRequests.length, 0);
+    assert.equal(fallback.calls, 1);
+    assert.equal(quote.status, "quoted");
+  });
+
+  it("falls back before requesting V4 rows when activation source registry mismatches", async () => {
+    const edge = edgeForPool(FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId);
+    const fallback = { calls: 0 };
+    const clientRequests: FamePoolQuoteBatchRequest[] = [];
+    const adapter = createIndexedQuoteApiAdapter({
+      quoteClient: quoteClient({
+        requests: clientRequests,
+        response: async (request) => ({
+          sourceRegistryId: "unit-registry",
+          currentBlock: request.currentBlock,
+          producerMaxFreshnessBlocks: 120,
+          effectiveMaxFreshnessBlocks: 120,
+          quotes: request.quotes.map((quoteRequest) => v4Row(quoteRequest)),
+        }),
+      }),
+      fallback: fallbackAdapter(fallback),
+      currentBlock: 125,
+      expectedSourceRegistryId: "unit-registry",
+      v4ZoraQuoteLaneActivation: {
+        ...UNIT_V4_ZORA_ACTIVATION,
+        sourceRegistryId: "other-registry",
+      },
+    });
+
+    const quote = await adapter.quoteEdge({ edge, amountIn: 1_000_000n });
+
+    assert.equal(clientRequests.length, 0);
+    assert.equal(fallback.calls, 1);
+    assert.equal(quote.status, "quoted");
+  });
+
+  it("quotes the reviewed V4 Zora edge from activated compact CL rows", async () => {
+    const edge = edgeForPool(FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId);
+    const fallback = { calls: 0 };
+    const clientRequests: FamePoolQuoteBatchRequest[] = [];
+    const diagnostics = createQuoteApiDiagnosticsRecorder(true);
+    const adapter = createIndexedQuoteApiAdapter({
+      quoteClient: quoteClient({
+        requests: clientRequests,
+        response: async (request) => ({
+          sourceRegistryId: "unit-registry",
+          currentBlock: request.currentBlock,
+          producerMaxFreshnessBlocks: 120,
+          effectiveMaxFreshnessBlocks: 120,
+          quotes: request.quotes.map((quoteRequest) => v4Row(quoteRequest)),
+        }),
+      }),
+      fallback: fallbackAdapter(fallback),
+      currentBlock: 125,
+      maxFreshnessBlocks: 10,
+      expectedSourceRegistryId: "unit-registry",
+      v4ZoraQuoteLaneActivation: UNIT_V4_ZORA_ACTIVATION,
+      diagnostics,
+    });
+
+    const quote = await adapter.quoteEdge({ edge, amountIn: 1_000_000n });
+
+    assert.equal(fallback.calls, 0);
+    assert.deepEqual(clientRequests[0], {
+      currentBlock: 125,
+      maxFreshnessBlocks: 10,
+      quotes: [
+        {
+          poolId: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId,
+          tokenIn: edge.tokenIn,
+          tokenOut: edge.tokenOut,
+          amountIn: "1000000",
+        },
+      ],
+    });
+    assert.equal(quote.status, "quoted");
+    if (quote.status === "quoted") {
+      assert.equal(quote.amountOut, 969_999n);
+      assert.match(quote.evidence, /indexed Uniswap V4 CL quote/);
+      assert.equal(quote.context?.source, "indexed");
+      assert.equal(quote.priceImpact?.method, "quoter-price-after");
+    }
+    assert.equal(diagnostics.snapshot().usedCount, 1);
+  });
+
   it("quotes reserve edges from constant-product compact rows", async () => {
     const edge = edgeFor("uniswap-v2-usdc-weth");
     const fallback = { calls: 0 };
@@ -232,6 +419,7 @@ describe("FAME indexed quote API adapter", () => {
       fallback: fallbackAdapter(fallback),
       currentBlock: 125,
       expectedSourceRegistryId: "unit-registry",
+      v4ZoraQuoteLaneActivation: UNIT_V4_ZORA_ACTIVATION,
       diagnostics,
     });
 
@@ -303,6 +491,7 @@ describe("FAME indexed quote API adapter", () => {
       fallback: fallbackAdapter(fallback),
       currentBlock: 125,
       expectedSourceRegistryId: "unit-registry",
+      v4ZoraQuoteLaneActivation: UNIT_V4_ZORA_ACTIVATION,
       diagnostics,
     });
 
@@ -344,6 +533,7 @@ describe("FAME indexed quote API adapter", () => {
       fallback: fallbackAdapter(fallback),
       currentBlock: 125,
       expectedSourceRegistryId: "unit-registry",
+      v4ZoraQuoteLaneActivation: UNIT_V4_ZORA_ACTIVATION,
       diagnostics,
     });
 
@@ -353,6 +543,177 @@ describe("FAME indexed quote API adapter", () => {
     assert.equal(quote.status, "quoted");
     assert.equal(
       diagnostics.snapshot().fallbackReasonCounts.row_metadata_mismatch,
+      1,
+    );
+  });
+
+  it("falls back when a reviewed V4 row is stale for the requested block", async () => {
+    const edge = edgeForPool(FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId);
+    const fallback = { calls: 0 };
+    const diagnostics = createQuoteApiDiagnosticsRecorder(true);
+    const adapter = createIndexedQuoteApiAdapter({
+      quoteClient: quoteClient({
+        requests: [],
+        response: async (request) => ({
+          sourceRegistryId: "unit-registry",
+          currentBlock: request.currentBlock,
+          producerMaxFreshnessBlocks: 120,
+          effectiveMaxFreshnessBlocks: 10,
+          quotes: request.quotes.map((quoteRequest) =>
+            v4Row(quoteRequest, {
+              observedThroughBlock: 100,
+              maxFreshnessBlocks: 10,
+            }),
+          ),
+        }),
+      }),
+      fallback: fallbackAdapter(fallback),
+      currentBlock: 125,
+      expectedSourceRegistryId: "unit-registry",
+      v4ZoraQuoteLaneActivation: UNIT_V4_ZORA_ACTIVATION,
+      diagnostics,
+    });
+
+    const quote = await adapter.quoteEdge({ edge, amountIn: 1_000_000n });
+
+    assert.equal(fallback.calls, 1);
+    assert.equal(quote.status, "quoted");
+    assert.equal(
+      diagnostics.snapshot().fallbackReasonCounts.row_metadata_mismatch,
+      1,
+    );
+    assert.equal(
+      diagnostics.snapshot().details.find(
+        (detail) => detail.outcome === "fallback",
+      )?.evidenceId,
+      "unit-v4-cl-quote",
+    );
+  });
+
+  it("falls back when a reviewed V4 response has duplicate matching rows", async () => {
+    const edge = edgeForPool(FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId);
+    const fallback = { calls: 0 };
+    const diagnostics = createQuoteApiDiagnosticsRecorder(true);
+    const adapter = createIndexedQuoteApiAdapter({
+      quoteClient: quoteClient({
+        requests: [],
+        response: async (request) => ({
+          sourceRegistryId: "unit-registry",
+          currentBlock: request.currentBlock,
+          producerMaxFreshnessBlocks: 120,
+          effectiveMaxFreshnessBlocks: 120,
+          quotes: request.quotes.flatMap((quoteRequest) => [
+            v4Row(quoteRequest),
+            v4Row(quoteRequest, { snapshotId: "unit-v4-cl-quote-duplicate" }),
+          ]),
+        }),
+      }),
+      fallback: fallbackAdapter(fallback),
+      currentBlock: 125,
+      expectedSourceRegistryId: "unit-registry",
+      v4ZoraQuoteLaneActivation: UNIT_V4_ZORA_ACTIVATION,
+      diagnostics,
+    });
+
+    const quote = await adapter.quoteEdge({ edge, amountIn: 1_000_000n });
+
+    assert.equal(fallback.calls, 1);
+    assert.equal(quote.status, "quoted");
+    assert.equal(diagnostics.snapshot().fallbackReasonCounts.row_ambiguous, 1);
+  });
+
+  it("falls back when reviewed V4 row metadata does not match the local pool", async () => {
+    const edge = edgeForPool(FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId);
+    const fallback = { calls: 0 };
+    const diagnostics = createQuoteApiDiagnosticsRecorder(true);
+    const adapter = createIndexedQuoteApiAdapter({
+      quoteClient: quoteClient({
+        requests: [],
+        response: async (request) => ({
+          sourceRegistryId: "unit-registry",
+          currentBlock: request.currentBlock,
+          producerMaxFreshnessBlocks: 120,
+          effectiveMaxFreshnessBlocks: 120,
+          quotes: request.quotes.map((quoteRequest) =>
+            v4Row(quoteRequest, {
+              poolKey:
+                "0x8888888888888888888888888888888888888888888888888888888888888888",
+            }),
+          ),
+        }),
+      }),
+      fallback: fallbackAdapter(fallback),
+      currentBlock: 125,
+      expectedSourceRegistryId: "unit-registry",
+      v4ZoraQuoteLaneActivation: UNIT_V4_ZORA_ACTIVATION,
+      diagnostics,
+    });
+
+    const quote = await adapter.quoteEdge({ edge, amountIn: 1_000_000n });
+
+    assert.equal(fallback.calls, 1);
+    assert.equal(quote.status, "quoted");
+    assert.equal(
+      diagnostics.snapshot().fallbackReasonCounts.row_metadata_mismatch,
+      1,
+    );
+  });
+
+  it("does not request compact rows for non-target V4 pools", async () => {
+    const edge = edgeForPool("uniswap-v4-zora-eth");
+    const fallback = { calls: 0 };
+    const clientRequests: FamePoolQuoteBatchRequest[] = [];
+    const adapter = createIndexedQuoteApiAdapter({
+      quoteClient: quoteClient({
+        requests: clientRequests,
+        response: async (request) => quotedResponse(request),
+      }),
+      fallback: fallbackAdapter(fallback),
+      currentBlock: 125,
+      expectedSourceRegistryId: "unit-registry",
+    });
+
+    const quote = await adapter.quoteEdge({ edge, amountIn: 1_000_000n });
+
+    assert.equal(clientRequests.length, 0);
+    assert.equal(fallback.calls, 1);
+    assert.equal(quote.status, "quoted");
+  });
+
+  it("falls back when a V4 edge receives a Slipstream-sourced CL row", async () => {
+    const edge = edgeForPool(FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId);
+    const fallback = { calls: 0 };
+    const diagnostics = createQuoteApiDiagnosticsRecorder(true);
+    const adapter = createIndexedQuoteApiAdapter({
+      quoteClient: quoteClient({
+        requests: [],
+        response: async (request) => ({
+          sourceRegistryId: "unit-registry",
+          currentBlock: request.currentBlock,
+          producerMaxFreshnessBlocks: 120,
+          effectiveMaxFreshnessBlocks: 120,
+          quotes: request.quotes.map((quoteRequest) =>
+            clRow(quoteRequest, {
+              poolId: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId,
+              poolAddress: "0x0000000000000000000000000000000000000001",
+              venueFamily: "UniswapV4",
+            }),
+          ),
+        }),
+      }),
+      fallback: fallbackAdapter(fallback),
+      currentBlock: 125,
+      expectedSourceRegistryId: "unit-registry",
+      v4ZoraQuoteLaneActivation: UNIT_V4_ZORA_ACTIVATION,
+      diagnostics,
+    });
+
+    const quote = await adapter.quoteEdge({ edge, amountIn: 1_000_000n });
+
+    assert.equal(fallback.calls, 1);
+    assert.equal(quote.status, "quoted");
+    assert.equal(
+      diagnostics.snapshot().fallbackReasonCounts.row_kind_mismatch,
       1,
     );
   });

--- a/src/features/fame-swap/solver/quotes/indexedQuoteApiAdapter.test.ts
+++ b/src/features/fame-swap/solver/quotes/indexedQuoteApiAdapter.test.ts
@@ -3,7 +3,9 @@ import { describe, it } from "node:test";
 import type { Address } from "viem";
 import { FAME, USDC, WETH } from "../../tokens";
 import {
+  FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE,
   FAME_V4_ZORA_REVIEWED_POOL_SHAPE,
+  fameV4ZoraReviewedPoolManifestForPool,
   type FameV4ZoraQuoteLaneActivation,
 } from "../poolStateRegistry";
 import { famePoolEdges, famePoolEdgesForPair } from "../poolUniverse";
@@ -162,7 +164,9 @@ function v4Row(
   quoteRequest: FamePoolQuoteBatchRequest["quotes"][number],
   overrides: Partial<FameV4ClPoolQuoteQuotedEntry> = {},
 ): FameV4ClPoolQuoteQuotedEntry {
-  const reviewed = FAME_V4_ZORA_REVIEWED_POOL_SHAPE;
+  const manifest = fameV4ZoraReviewedPoolManifestForPool(quoteRequest.poolId);
+  assert.ok(manifest);
+  const reviewed = manifest.reviewedPoolShape;
   return {
     status: "quoted",
     quoteKind: "cl-quote-v1",
@@ -204,18 +208,37 @@ function v4Row(
     hookAddress: reviewed.hooks,
     hookData: reviewed.hookData,
     hookDataStatus: "empty",
-    zoraProvenance: {
+    reviewedPoolEvidence: {
       status: "verified",
-      source: "zora-factory-event",
-      chainId: 8453,
-      factoryAddress: "0x0000000000000000000000000000000000000003",
-      coinAddress: reviewed.currency1,
+      source: "reviewed-v4-manifest",
+      kind: manifest.provenanceRequired
+        ? "zora-protocol-pool"
+        : "zero-hook-static-fee",
+      manifestVersion: manifest.version,
+      poolId: reviewed.poolId,
       poolKey: reviewed.poolKey,
-      poolId: reviewed.poolKey,
-      transactionHash:
-        "0x7777777777777777777777777777777777777777777777777777777777777777",
-      eventName: "CoinCreatedV4",
+      staticFee: reviewed.fee.toString(),
+      hookAddress: reviewed.hooks,
+      hookData: reviewed.hookData,
+      protocolFeeStatus: "zero",
     },
+    ...(manifest.provenanceRequired
+      ? {
+          zoraProvenance: {
+            status: "verified" as const,
+            source: "zora-factory-event" as const,
+            chainId: 8453 as const,
+            factoryAddress:
+              "0x0000000000000000000000000000000000000003" as const,
+            coinAddress: reviewed.currency1,
+            poolKey: reviewed.poolKey,
+            poolId: reviewed.poolKey,
+            transactionHash:
+              "0x7777777777777777777777777777777777777777777777777777777777777777" as const,
+            eventName: "CoinCreatedV4",
+          },
+        }
+      : {}),
     ...overrides,
   };
 }
@@ -409,7 +432,68 @@ describe("FAME indexed quote API adapter", () => {
       assert.equal(quote.amountOut, 969_999n);
       assert.match(quote.evidence, /indexed Uniswap V4 CL quote/);
       assert.equal(quote.context?.source, "indexed");
+      assert.deepEqual(quote.indexedEvidence, {
+        source: "indexed",
+        kind: "compact-quote",
+        quoteKind: "cl-quote-v1",
+        evidenceId: "unit-v4-cl-quote",
+        poolId: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId,
+      });
       assert.equal(quote.priceImpact?.method, "quoter-price-after");
+    }
+    assert.equal(diagnostics.snapshot().usedCount, 1);
+  });
+
+  it("quotes the reviewed V4 ZORA/ETH edge without Zora provenance", async () => {
+    const edge = edgeForPool(FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.poolId);
+    const fallback = { calls: 0 };
+    const clientRequests: FamePoolQuoteBatchRequest[] = [];
+    const diagnostics = createQuoteApiDiagnosticsRecorder(true);
+    const adapter = createIndexedQuoteApiAdapter({
+      quoteClient: quoteClient({
+        requests: clientRequests,
+        response: async (request) => ({
+          sourceRegistryId: "unit-registry",
+          currentBlock: request.currentBlock,
+          producerMaxFreshnessBlocks: 120,
+          effectiveMaxFreshnessBlocks: 120,
+          quotes: request.quotes.map((quoteRequest) => v4Row(quoteRequest)),
+        }),
+      }),
+      fallback: fallbackAdapter(fallback),
+      currentBlock: 125,
+      maxFreshnessBlocks: 10,
+      expectedSourceRegistryId: "unit-registry",
+      v4ZoraQuoteLaneActivation: UNIT_V4_ZORA_ACTIVATION,
+      diagnostics,
+    });
+
+    const quote = await adapter.quoteEdge({ edge, amountIn: 1_000_000n });
+
+    assert.equal(fallback.calls, 0);
+    assert.deepEqual(clientRequests[0], {
+      currentBlock: 125,
+      maxFreshnessBlocks: 10,
+      quotes: [
+        {
+          poolId: FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.poolId,
+          tokenIn: edge.tokenIn,
+          tokenOut: edge.tokenOut,
+          amountIn: "1000000",
+        },
+      ],
+    });
+    assert.equal(quote.status, "quoted");
+    if (quote.status === "quoted") {
+      assert.equal(quote.amountOut, 969_999n);
+      assert.match(quote.evidence, /indexed Uniswap V4 CL quote/);
+      assert.deepEqual(quote.indexedEvidence, {
+        source: "indexed",
+        kind: "compact-quote",
+        quoteKind: "cl-quote-v1",
+        evidenceId: "unit-v4-cl-quote",
+        poolId: FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.poolId,
+      });
     }
     assert.equal(diagnostics.snapshot().usedCount, 1);
   });
@@ -793,8 +877,8 @@ describe("FAME indexed quote API adapter", () => {
     );
   });
 
-  it("does not request compact rows for non-target V4 pools", async () => {
-    const edge = edgeForPool("uniswap-v4-zora-eth");
+  it("does not request compact rows for unreviewed V4 pools", async () => {
+    const edge = edgeForPool("uniswap-v4-usdc-eth");
     const fallback = { calls: 0 };
     const clientRequests: FamePoolQuoteBatchRequest[] = [];
     const adapter = createIndexedQuoteApiAdapter({
@@ -805,6 +889,7 @@ describe("FAME indexed quote API adapter", () => {
       fallback: fallbackAdapter(fallback),
       currentBlock: 125,
       expectedSourceRegistryId: "unit-registry",
+      v4ZoraQuoteLaneActivation: UNIT_V4_ZORA_ACTIVATION,
     });
 
     const quote = await adapter.quoteEdge({ edge, amountIn: 1_000_000n });

--- a/src/features/fame-swap/solver/quotes/indexedQuoteApiAdapter.test.ts
+++ b/src/features/fame-swap/solver/quotes/indexedQuoteApiAdapter.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { USDC, WETH } from "../../tokens";
+import type { Address } from "viem";
+import { FAME, USDC, WETH } from "../../tokens";
 import { famePoolEdgesForPair } from "../poolUniverse";
 import type {
   FameEdgeQuoteRequest,
@@ -21,9 +22,15 @@ import type {
 } from "./indexedQuoteApiClient";
 
 const Q96 = 79_228_162_514_264_337_593_543_950_336n;
+const BASEDFLICK = "0x15e012abf9d32cd67fc6cf480ea0e318e9ed5926" as const;
+const ZORA = "0x1111111111166b7fe7bd91427724b487980afc69" as const;
 
-function edgeFor(poolId: string) {
-  const edge = famePoolEdgesForPair(WETH, USDC).find(
+function edgeFor(
+  poolId: string,
+  tokenIn: Address = WETH,
+  tokenOut: Address = USDC,
+) {
+  const edge = famePoolEdgesForPair(tokenIn, tokenOut).find(
     (candidate) => candidate.poolId === poolId,
   );
   assert.ok(edge);
@@ -269,6 +276,67 @@ describe("FAME indexed quote API adapter", () => {
     );
   });
 
+  it("requests the promoted selected Slipstream row but not its live V4 dependency", async () => {
+    const selectedEdge = edgeFor(
+      "slipstream-basedflick-fame",
+      FAME,
+      BASEDFLICK,
+    );
+    const v4Edge = edgeFor("uniswap-v4-basedflick-zora", BASEDFLICK, ZORA);
+    const fallback = { calls: 0 };
+    const clientRequests: FamePoolQuoteBatchRequest[] = [];
+    const adapter = createIndexedQuoteApiAdapter({
+      quoteClient: quoteClient({
+        requests: clientRequests,
+        response: async (request) => ({
+          sourceRegistryId: "unit-registry",
+          currentBlock: request.currentBlock,
+          producerMaxFreshnessBlocks: 120,
+          effectiveMaxFreshnessBlocks: 120,
+          quotes: request.quotes.map((quoteRequest) =>
+            clRow(quoteRequest, {
+              poolId: "slipstream-basedflick-fame",
+              poolAddress: "0xbd7e5bb5a6251f6dde2cf56afa50ed0c8b4c2cdb",
+              token0: BASEDFLICK,
+              token1: FAME,
+              tickSpacing: 2000,
+              amountOut: "980100000232613992",
+              snapshotId: "unit-selected-candidate",
+            }),
+          ),
+        }),
+      }),
+      fallback: fallbackAdapter(fallback),
+      currentBlock: 125,
+      expectedSourceRegistryId: "unit-registry",
+    });
+
+    const [selectedQuote, v4Quote] = await Promise.all([
+      adapter.quoteEdge({
+        edge: selectedEdge,
+        amountIn: 31_597_600_141_347_829n,
+      }),
+      adapter.quoteEdge({ edge: v4Edge, amountIn: 980_100_000_232_613_992n }),
+    ]);
+
+    assert.equal(clientRequests.length, 1);
+    assert.deepEqual(
+      clientRequests[0]?.quotes.map((quote) => quote.poolId),
+      ["slipstream-basedflick-fame"],
+    );
+    assert.equal(fallback.calls, 1);
+    assert.equal(selectedQuote.status, "quoted");
+    if (selectedQuote.status === "quoted") {
+      assert.equal(selectedQuote.amountOut, 980_100_000_232_613_992n);
+      assert.match(selectedQuote.evidence, /indexed Slipstream CL quote/);
+      assert.equal(selectedQuote.context?.source, "indexed");
+    }
+    assert.equal(v4Quote.status, "quoted");
+    if (v4Quote.status === "quoted") {
+      assert.equal(v4Quote.evidence, "fallback live quote");
+    }
+  });
+
   it("uses compact output and live fallback in the same batch", async () => {
     const clEdge = edgeFor("slipstream-usdc-weth-100");
     const reserveEdge = edgeFor("uniswap-v2-usdc-weth");
@@ -322,6 +390,72 @@ describe("FAME indexed quote API adapter", () => {
       diagnostics.snapshot().fallbackReasonCounts.unavailable_row,
       1,
     );
+  });
+
+  it("falls back only the producer-untrusted CL row and records producer diagnostics", async () => {
+    const clEdge = edgeFor("slipstream-usdc-weth-100");
+    const reserveEdge = edgeFor("uniswap-v2-usdc-weth");
+    const fallback = { calls: 0 };
+    const diagnostics = createQuoteApiDiagnosticsRecorder(true);
+    const adapter = createIndexedQuoteApiAdapter({
+      quoteClient: quoteClient({
+        requests: [],
+        response: async (request) => ({
+          sourceRegistryId: "unit-registry",
+          currentBlock: request.currentBlock,
+          producerMaxFreshnessBlocks: 120,
+          effectiveMaxFreshnessBlocks: 120,
+          quotes: request.quotes.map((quoteRequest) =>
+            quoteRequest.poolId === "slipstream-usdc-weth-100"
+              ? {
+                  status: "unavailable" as const,
+                  requested: quoteRequest,
+                  reason: "producer-untrusted" as const,
+                  poolId: quoteRequest.poolId,
+                  chainId: 8453,
+                  poolAddress: "0xb2cc224c1c9fee385f8ad6a55b4d94e92359dc59",
+                  observedThroughBlock: 120,
+                  sourceRegistryId: "unit-registry",
+                  maxFreshnessBlocks: 120,
+                  producerStatus: "warming" as const,
+                  producerReason: "seed-required",
+                }
+              : reserveRow(quoteRequest),
+          ),
+        }),
+      }),
+      fallback: fallbackAdapter(fallback),
+      currentBlock: 125,
+      expectedSourceRegistryId: "unit-registry",
+      diagnostics,
+    });
+
+    const [clQuote, reserveQuote] = await Promise.all([
+      adapter.quoteEdge({ edge: clEdge, amountIn: 1_000_000n }),
+      adapter.quoteEdge({ edge: reserveEdge, amountIn: 1_000_000n }),
+    ]);
+    const snapshot = diagnostics.snapshot();
+    const producerUntrustedDetail = snapshot.details.find(
+      (detail) => detail.unavailableReason === "producer-untrusted",
+    );
+
+    assert.equal(fallback.calls, 1);
+    assert.equal(clQuote.status, "quoted");
+    assert.equal(reserveQuote.status, "quoted");
+    if (clQuote.status === "quoted") {
+      assert.equal(clQuote.evidence, "fallback live quote");
+    }
+    if (reserveQuote.status === "quoted") {
+      assert.match(reserveQuote.evidence, /indexed reserve quote/);
+    }
+    assert.equal(snapshot.usedCount, 1);
+    assert.equal(snapshot.fallbackCount, 1);
+    assert.equal(snapshot.statusCounts.quoted, 1);
+    assert.equal(snapshot.statusCounts.unavailable, 1);
+    assert.equal(snapshot.unavailableReasonCounts["producer-untrusted"], 1);
+    assert.equal(snapshot.fallbackReasonCounts.unavailable_row, 1);
+    assert.equal(producerUntrustedDetail?.producerMaintenanceStatus, "warming");
+    assert.equal(producerUntrustedDetail?.producerReason, "seed-required");
   });
 
   it("falls back when compact quote metadata does not match the local pool", async () => {

--- a/src/features/fame-swap/solver/quotes/indexedQuoteApiAdapter.ts
+++ b/src/features/fame-swap/solver/quotes/indexedQuoteApiAdapter.ts
@@ -54,6 +54,8 @@ export interface FameQuoteApiEdgeDiagnostics {
   quoteKind?: FamePoolQuoteQuotedEntry["quoteKind"];
   rowStatus?: FamePoolQuoteEntry["status"];
   unavailableReason?: FamePoolQuoteUnavailableReason;
+  producerMaintenanceStatus?: FamePoolQuoteUnavailableEntry["producerStatus"];
+  producerReason?: string | null;
   fallbackReason?: FameQuoteApiFallbackReason;
   batchFailureCategory?: FameQuoteApiBatchFailureCategory;
   observedThroughBlock?: number;
@@ -78,6 +80,9 @@ export interface FameQuoteApiDiagnosticsSnapshot {
     quoted: number;
     unavailable: number;
   };
+  unavailableReasonCounts: Partial<
+    Record<FamePoolQuoteUnavailableReason, number>
+  >;
   fallbackReasonCounts: Partial<Record<FameQuoteApiFallbackReason, number>>;
   details: FameQuoteApiEdgeDiagnostics[];
   truncatedDetailCount: number;
@@ -175,6 +180,9 @@ export function createQuoteApiDiagnosticsRecorder(
   const fallbackReasonCounts: Partial<
     Record<FameQuoteApiFallbackReason, number>
   > = {};
+  const unavailableReasonCounts: Partial<
+    Record<FamePoolQuoteUnavailableReason, number>
+  > = {};
   const details: FameQuoteApiEdgeDiagnostics[] = [];
 
   function pushDetail(detail: FameQuoteApiEdgeDiagnostics): void {
@@ -230,7 +238,10 @@ export function createQuoteApiDiagnosticsRecorder(
       if (reason === "quote_api_batch_failed") batchFailureCount += 1;
       increment(fallbackReasonCounts, reason);
       if (row?.status === "quoted") statusCounts.quoted += 1;
-      if (row?.status === "unavailable") statusCounts.unavailable += 1;
+      if (row?.status === "unavailable") {
+        statusCounts.unavailable += 1;
+        increment(unavailableReasonCounts, row.reason);
+      }
       pushDetail({
         ...edgeDiagnosticsBase(request, block),
         outcome: "fallback",
@@ -238,6 +249,10 @@ export function createQuoteApiDiagnosticsRecorder(
         quoteKind: row?.status === "quoted" ? row.quoteKind : undefined,
         unavailableReason:
           row?.status === "unavailable" ? row.reason : undefined,
+        producerMaintenanceStatus:
+          row?.status === "unavailable" ? row.producerStatus : undefined,
+        producerReason:
+          row?.status === "unavailable" ? row.producerReason : undefined,
         fallbackReason: reason,
         batchFailureCategory,
         observedThroughBlock:
@@ -262,6 +277,7 @@ export function createQuoteApiDiagnosticsRecorder(
           ...(lastBatchDurationMs === undefined ? {} : { lastBatchDurationMs }),
         },
         statusCounts,
+        unavailableReasonCounts,
         fallbackReasonCounts,
         details,
         truncatedDetailCount,
@@ -455,6 +471,13 @@ function quoteResultFromClQuote(options: {
       preSwapSqrtPriceX96,
       postSwapSqrtPriceX96,
     }),
+    indexedEvidence: {
+      source: "indexed",
+      kind: "compact-quote",
+      quoteKind: options.quote.quoteKind,
+      evidenceId: options.quote.snapshotId,
+      poolId: options.quote.poolId,
+    },
   };
 }
 
@@ -509,6 +532,13 @@ function quoteResultFromReserveQuote(options: {
       method: "constant-product-reserves",
     },
     protocolEvidence: options.quote.protocolEvidence,
+    indexedEvidence: {
+      source: "indexed",
+      kind: "compact-quote",
+      quoteKind: options.quote.quoteKind,
+      evidenceId: quoteEvidenceId(options.quote),
+      poolId: options.quote.poolId,
+    },
   };
 }
 

--- a/src/features/fame-swap/solver/quotes/indexedQuoteApiAdapter.ts
+++ b/src/features/fame-swap/solver/quotes/indexedQuoteApiAdapter.ts
@@ -2,10 +2,10 @@ import { base } from "viem/chains";
 import {
   CL_REPLAY_CAPABLE_FAME_POOL_IDS,
   FAME_V4_ZORA_QUOTE_LANE_ACTIVATION,
-  FAME_V4_ZORA_REVIEWED_POOL_SHAPE,
   QUOTE_MODEL_CAPABLE_FAME_POOL_IDS,
   famePoolSupportsCompactQuote,
   fameV4ZoraQuoteLaneActivationPassed,
+  fameV4ZoraReviewedPoolManifestForPool,
   type FameV4ZoraQuoteLaneActivation,
 } from "../poolStateRegistry";
 import type {
@@ -316,7 +316,7 @@ function isReserveQuoteCapablePool(poolId: string): boolean {
 }
 
 function isV4ZoraQuoteCapablePool(poolId: string): boolean {
-  return poolId === FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId;
+  return fameV4ZoraReviewedPoolManifestForPool(poolId) !== null;
 }
 
 function requestSupportedByQuoteApi(
@@ -458,7 +458,19 @@ function v4ClQuoteValidationFailure(
   if (!isV4ZoraQuoteCapablePool(request.edge.poolId))
     return "row_kind_mismatch";
   const pool = request.edge.pool;
-  const reviewed = FAME_V4_ZORA_REVIEWED_POOL_SHAPE;
+  const manifest = fameV4ZoraReviewedPoolManifestForPool(request.edge.poolId);
+  if (manifest === null) return "row_kind_mismatch";
+  const reviewed = manifest.reviewedPoolShape;
+  const evidence = quote.reviewedPoolEvidence;
+  const provenanceMatches = manifest.provenanceRequired
+    ? quote.zoraProvenance !== undefined &&
+      quote.zoraProvenance.status === "verified" &&
+      quote.zoraProvenance.chainId === base.id &&
+      sameAddress(quote.zoraProvenance.coinAddress, reviewed.currency1) &&
+      quote.zoraProvenance.poolKey.toLowerCase() ===
+        quote.poolKey.toLowerCase() &&
+      quote.zoraProvenance.poolId.toLowerCase() === quote.poolKey.toLowerCase()
+    : quote.zoraProvenance === undefined;
   if (
     !quotedCommonFieldsMatchRequest(quote, request) ||
     pool.venue !== "uniswap-v4" ||
@@ -484,12 +496,20 @@ function v4ClQuoteValidationFailure(
     quote.poolKey.toLowerCase() !== reviewed.poolKey.toLowerCase() ||
     !sameAddress(quote.hookAddress, pool.hooks) ||
     !sameAddress(quote.hookAddress, reviewed.hooks) ||
-    quote.zoraProvenance.status !== "verified" ||
-    quote.zoraProvenance.chainId !== base.id ||
-    !sameAddress(quote.zoraProvenance.coinAddress, pool.currency1) ||
-    quote.zoraProvenance.poolKey.toLowerCase() !==
-      quote.poolKey.toLowerCase() ||
-    quote.zoraProvenance.poolId.toLowerCase() !== quote.poolKey.toLowerCase()
+    evidence.status !== "verified" ||
+    evidence.source !== "reviewed-v4-manifest" ||
+    evidence.kind !==
+      (manifest.provenanceRequired
+        ? "zora-protocol-pool"
+        : "zero-hook-static-fee") ||
+    evidence.manifestVersion !== manifest.version ||
+    evidence.poolId !== reviewed.poolId ||
+    evidence.poolKey.toLowerCase() !== reviewed.poolKey.toLowerCase() ||
+    evidence.staticFee !== reviewed.fee.toString() ||
+    !sameAddress(evidence.hookAddress, reviewed.hooks) ||
+    evidence.hookData.toLowerCase() !== reviewed.hookData.toLowerCase() ||
+    evidence.protocolFeeStatus !== "zero" ||
+    !provenanceMatches
   ) {
     return "row_metadata_mismatch";
   }
@@ -663,6 +683,13 @@ function quoteResultFromV4ClQuote(options: {
       preSwapSqrtPriceX96,
       postSwapSqrtPriceX96,
     }),
+    indexedEvidence: {
+      source: "indexed",
+      kind: "compact-quote",
+      quoteKind: options.quote.quoteKind,
+      evidenceId: options.quote.snapshotId,
+      poolId: options.quote.poolId,
+    },
   };
 }
 

--- a/src/features/fame-swap/solver/quotes/indexedQuoteApiAdapter.ts
+++ b/src/features/fame-swap/solver/quotes/indexedQuoteApiAdapter.ts
@@ -1,8 +1,12 @@
 import { base } from "viem/chains";
 import {
   CL_REPLAY_CAPABLE_FAME_POOL_IDS,
+  FAME_V4_ZORA_QUOTE_LANE_ACTIVATION,
+  FAME_V4_ZORA_REVIEWED_POOL_SHAPE,
   QUOTE_MODEL_CAPABLE_FAME_POOL_IDS,
   famePoolSupportsCompactQuote,
+  fameV4ZoraQuoteLaneActivationPassed,
+  type FameV4ZoraQuoteLaneActivation,
 } from "../poolStateRegistry";
 import type {
   FameAsyncQuoteAdapter,
@@ -21,6 +25,7 @@ import type {
   FamePoolQuoteRequestEntry,
   FamePoolQuoteUnavailableEntry,
   FamePoolQuoteUnavailableReason,
+  FameV4ClPoolQuoteQuotedEntry,
 } from "./indexedQuoteApiClient";
 
 const MAX_UINT256 = 2n ** 256n - 1n;
@@ -31,6 +36,7 @@ export type FameQuoteApiFallbackReason =
   | "quote_api_batch_failed"
   | "source_registry_mismatch"
   | "row_not_found"
+  | "row_ambiguous"
   | "unavailable_row"
   | "row_source_registry_mismatch"
   | "row_metadata_mismatch"
@@ -244,6 +250,7 @@ export function createQuoteApiDiagnosticsRecorder(
           row && "observedThroughBlock" in row
             ? row.observedThroughBlock
             : undefined,
+        evidenceId: row?.status === "quoted" ? quoteEvidenceId(row) : undefined,
       });
     },
     snapshot() {
@@ -292,8 +299,27 @@ function isReserveQuoteCapablePool(poolId: string): boolean {
   return QUOTE_MODEL_CAPABLE_FAME_POOL_IDS.some((id) => id === poolId);
 }
 
-function requestSupportedByQuoteApi(request: FameEdgeQuoteRequest): boolean {
-  if (!famePoolSupportsCompactQuote(request.edge.poolId)) return false;
+function isV4ZoraQuoteCapablePool(poolId: string): boolean {
+  return poolId === FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId;
+}
+
+function requestSupportedByQuoteApi(
+  request: FameEdgeQuoteRequest,
+  options: {
+    expectedSourceRegistryId?: string;
+    v4ZoraQuoteLaneActivation?: FameV4ZoraQuoteLaneActivation;
+  } = {},
+): boolean {
+  const v4ZoraQuoteLaneActivation =
+    options.v4ZoraQuoteLaneActivation ??
+    FAME_V4_ZORA_QUOTE_LANE_ACTIVATION;
+  if (
+    !famePoolSupportsCompactQuote(request.edge.poolId, {
+      v4ZoraQuoteLaneActivation,
+    })
+  ) {
+    return false;
+  }
   if (isClQuoteCapablePool(request.edge.poolId)) {
     return (
       request.edge.pool.venue === "aerodrome-slipstream" &&
@@ -309,6 +335,20 @@ function requestSupportedByQuoteApi(request: FameEdgeQuoteRequest): boolean {
         (request.edge.pool.venue === "aerodrome-v2" &&
           request.edge.pool.stable === false)) &&
       "pool" in request.edge.pool
+    );
+  }
+  if (isV4ZoraQuoteCapablePool(request.edge.poolId)) {
+    if (
+      !fameV4ZoraQuoteLaneActivationPassed(v4ZoraQuoteLaneActivation) ||
+      (options.expectedSourceRegistryId &&
+        v4ZoraQuoteLaneActivation.sourceRegistryId !==
+          options.expectedSourceRegistryId)
+    ) {
+      return false;
+    }
+    return (
+      request.edge.fee.status === "available" &&
+      request.edge.pool.venue === "uniswap-v4"
     );
   }
   return false;
@@ -335,22 +375,45 @@ function entryMatchesRequestIdentity(
   );
 }
 
-function quotedBaseMatchesRequest(
+function edgeToken0(request: FameEdgeQuoteRequest): `0x${string}` {
+  const pool = request.edge.pool;
+  if (pool.venue === "uniswap-v4") return pool.currency0;
+  if ("token0" in pool) return pool.token0;
+  return request.edge.tokenIn;
+}
+
+function edgeToken1(request: FameEdgeQuoteRequest): `0x${string}` {
+  const pool = request.edge.pool;
+  if (pool.venue === "uniswap-v4") return pool.currency1;
+  if ("token1" in pool) return pool.token1;
+  return request.edge.tokenOut;
+}
+
+function quotedCommonFieldsMatchRequest(
   quote: FamePoolQuoteQuotedEntry,
   request: FameEdgeQuoteRequest,
 ): boolean {
-  const pool = request.edge.pool;
   return (
     quote.poolId === request.edge.poolId &&
     quote.chainId === base.id &&
-    "pool" in pool &&
-    sameAddress(quote.poolAddress, pool.pool) &&
-    sameAddress(quote.token0, pool.token0) &&
-    sameAddress(quote.token1, pool.token1) &&
+    sameAddress(quote.token0, edgeToken0(request)) &&
+    sameAddress(quote.token1, edgeToken1(request)) &&
     sameAddress(quote.tokenIn, request.edge.tokenIn) &&
     sameAddress(quote.tokenOut, request.edge.tokenOut) &&
     quote.venueFamily === request.edge.venue &&
     quote.amountIn === request.amountIn.toString()
+  );
+}
+
+function quotedBaseMatchesRequest(
+  quote: FameClPoolQuoteQuotedEntry | FameConstantProductPoolQuoteQuotedEntry,
+  request: FameEdgeQuoteRequest,
+): boolean {
+  const pool = request.edge.pool;
+  return (
+    quotedCommonFieldsMatchRequest(quote, request) &&
+    "pool" in pool &&
+    sameAddress(quote.poolAddress, pool.pool)
   );
 }
 
@@ -366,6 +429,51 @@ function clQuoteValidationFailure(
     !("pool" in pool) ||
     quote.tickSpacing !== pool.tickSpacing ||
     quote.feeSource !== "pool-fee"
+  ) {
+    return "row_metadata_mismatch";
+  }
+  return null;
+}
+
+function v4ClQuoteValidationFailure(
+  quote: FameV4ClPoolQuoteQuotedEntry,
+  request: FameEdgeQuoteRequest,
+): FameQuoteApiFallbackReason | null {
+  if (!isV4ZoraQuoteCapablePool(request.edge.poolId))
+    return "row_kind_mismatch";
+  const pool = request.edge.pool;
+  const reviewed = FAME_V4_ZORA_REVIEWED_POOL_SHAPE;
+  if (
+    !quotedCommonFieldsMatchRequest(quote, request) ||
+    pool.venue !== "uniswap-v4" ||
+    quote.poolAddress !== null ||
+    quote.source !== "uniswap-v4-state-view" ||
+    quote.venueFamily !== "UniswapV4" ||
+    quote.poolId !== reviewed.poolId ||
+    quote.tickSpacing !== pool.tickSpacing ||
+    quote.tickSpacing !== reviewed.tickSpacing ||
+    quote.feeSource !== "v4-slot0" ||
+    quote.fee !== quote.lpFee ||
+    quote.fee !== reviewed.fee.toString() ||
+    quote.staticFee !== reviewed.fee.toString() ||
+    quote.protocolFee !== "0" ||
+    quote.protocolFeeStatus !== "zero" ||
+    quote.hookData.toLowerCase() !== "0x" ||
+    quote.hookDataStatus !== "empty" ||
+    !sameAddress(quote.poolManager, pool.poolManager) ||
+    !sameAddress(quote.poolManager, reviewed.poolManager) ||
+    !sameAddress(quote.stateViewAddress, pool.stateView) ||
+    !sameAddress(quote.stateViewAddress, reviewed.stateViewAddress) ||
+    quote.poolKey.toLowerCase() !== pool.poolId.toLowerCase() ||
+    quote.poolKey.toLowerCase() !== reviewed.poolKey.toLowerCase() ||
+    !sameAddress(quote.hookAddress, pool.hooks) ||
+    !sameAddress(quote.hookAddress, reviewed.hooks) ||
+    quote.zoraProvenance.status !== "verified" ||
+    quote.zoraProvenance.chainId !== base.id ||
+    !sameAddress(quote.zoraProvenance.coinAddress, pool.currency1) ||
+    quote.zoraProvenance.poolKey.toLowerCase() !==
+      quote.poolKey.toLowerCase() ||
+    quote.zoraProvenance.poolId.toLowerCase() !== quote.poolKey.toLowerCase()
   ) {
     return "row_metadata_mismatch";
   }
@@ -401,9 +509,34 @@ function quotedValidationFailure(
     return "row_source_registry_mismatch";
   }
   if (quote.quoteKind === "cl-quote-v1") {
+    if (quote.source === "uniswap-v4-state-view") {
+      return v4ClQuoteValidationFailure(quote, request);
+    }
+    if (quote.source !== "slipstream-pool-state") return "row_kind_mismatch";
     return clQuoteValidationFailure(quote, request);
   }
   return reserveQuoteValidationFailure(quote, request);
+}
+
+function quotedFreshnessValidationFailure(
+  response: FamePoolQuoteBatchResponse,
+  quote: FamePoolQuoteQuotedEntry,
+  currentBlock: number,
+): FameQuoteApiFallbackReason | null {
+  if (response.currentBlock !== currentBlock) {
+    return "row_metadata_mismatch";
+  }
+  if (quote.observedThroughBlock > currentBlock) {
+    return "row_metadata_mismatch";
+  }
+  const effectiveMaxFreshnessBlocks = Math.min(
+    response.effectiveMaxFreshnessBlocks,
+    quote.maxFreshnessBlocks,
+  );
+  if (currentBlock - quote.observedThroughBlock > effectiveMaxFreshnessBlocks) {
+    return "row_metadata_mismatch";
+  }
+  return null;
 }
 
 function quoteResultFromClQuote(options: {
@@ -437,6 +570,58 @@ function quoteResultFromClQuote(options: {
     capacityIn: null,
     fee: options.request.edge.fee,
     evidence: `indexed Slipstream CL quote for ${options.quote.poolId} snapshot ${options.quote.snapshotId}`,
+    context: {
+      source: "indexed",
+      chainId: options.quote.chainId,
+      currentBlock: options.response.currentBlock,
+      sourceRegistryId: options.response.sourceRegistryId,
+      effectiveMaxFreshnessBlocks: options.response.effectiveMaxFreshnessBlocks,
+      statusCounts: emptyPoolStateStatusCounts(),
+    },
+    priceImpact: concentratedLiquidityPriceImpact({
+      amountIn: options.request.amountIn,
+      amountOut,
+      tokenIn: options.request.edge.tokenIn,
+      tokenOut: options.request.edge.tokenOut,
+      token0: options.quote.token0,
+      token1: options.quote.token1,
+      preSwapSqrtPriceX96,
+      postSwapSqrtPriceX96,
+    }),
+  };
+}
+
+function quoteResultFromV4ClQuote(options: {
+  response: FamePoolQuoteBatchResponse;
+  quote: FameV4ClPoolQuoteQuotedEntry;
+  request: FameEdgeQuoteRequest;
+}): FameEdgeQuoteResult {
+  const amountOut = parsePositiveUint256Decimal(options.quote.amountOut);
+  const preSwapSqrtPriceX96 = parsePositiveUint256Decimal(
+    options.quote.sqrtPriceX96,
+  );
+  const postSwapSqrtPriceX96 = parsePositiveUint256Decimal(
+    options.quote.sqrtPriceX96After,
+  );
+  if (
+    amountOut === null ||
+    preSwapSqrtPriceX96 === null ||
+    postSwapSqrtPriceX96 === null
+  ) {
+    return {
+      status: "failed",
+      reason: "no_quote_evidence",
+      message: "Indexed quote API V4 CL row was not usable.",
+    };
+  }
+
+  return {
+    status: "quoted",
+    amountIn: options.request.amountIn,
+    amountOut,
+    capacityIn: null,
+    fee: options.request.edge.fee,
+    evidence: `indexed Uniswap V4 CL quote for ${options.quote.poolId} snapshot ${options.quote.snapshotId}`,
     context: {
       source: "indexed",
       chainId: options.quote.chainId,
@@ -518,6 +703,13 @@ function quoteResultFromQuoteApiRow(options: {
   request: FameEdgeQuoteRequest;
 }): FameEdgeQuoteResult {
   if (options.quote.quoteKind === "cl-quote-v1") {
+    if (options.quote.source === "uniswap-v4-state-view") {
+      return quoteResultFromV4ClQuote({
+        response: options.response,
+        quote: options.quote,
+        request: options.request,
+      });
+    }
     return quoteResultFromClQuote({
       response: options.response,
       quote: options.quote,
@@ -559,6 +751,7 @@ export function createIndexedQuoteApiAdapter(options: {
   currentBlock: number;
   maxFreshnessBlocks?: number;
   expectedSourceRegistryId?: string;
+  v4ZoraQuoteLaneActivation?: FameV4ZoraQuoteLaneActivation;
   diagnostics?: FameQuoteApiDiagnosticsRecorder;
   onBatchFailure?: (event: {
     category: FameQuoteApiBatchFailureCategory;
@@ -668,7 +861,12 @@ export function createIndexedQuoteApiAdapter(options: {
   return {
     quoteContext: fallback.quoteContext,
     async quoteEdge(request) {
-      if (!requestSupportedByQuoteApi(request)) {
+      if (
+        !requestSupportedByQuoteApi(request, {
+          expectedSourceRegistryId: options.expectedSourceRegistryId,
+          v4ZoraQuoteLaneActivation: options.v4ZoraQuoteLaneActivation,
+        })
+      ) {
         return fallback.quoteEdge(request);
       }
 
@@ -695,9 +893,13 @@ export function createIndexedQuoteApiAdapter(options: {
         });
       }
 
-      const row = response.quotes.find((entry) =>
+      const rows = response.quotes.filter((entry) =>
         entryMatchesRequestIdentity(entry, request),
       );
+      if (rows.length > 1) {
+        return fallbackQuote({ request, reason: "row_ambiguous" });
+      }
+      const row = rows[0];
       if (!row) {
         return fallbackQuote({ request, reason: "row_not_found" });
       }
@@ -709,7 +911,9 @@ export function createIndexedQuoteApiAdapter(options: {
         });
       }
 
-      const validationFailure = quotedValidationFailure(response, row, request);
+      const validationFailure =
+        quotedFreshnessValidationFailure(response, row, options.currentBlock) ??
+        quotedValidationFailure(response, row, request);
       if (validationFailure) {
         return fallbackQuote({
           request,

--- a/src/features/fame-swap/solver/quotes/indexedQuoteApiClient.test.ts
+++ b/src/features/fame-swap/solver/quotes/indexedQuoteApiClient.test.ts
@@ -9,7 +9,10 @@ import {
   type FameConstantProductPoolQuoteQuotedEntry,
 } from "./indexedQuoteApiClient";
 import { USDC, WETH } from "../../tokens";
-import { FAME_V4_ZORA_REVIEWED_POOL_SHAPE } from "../poolStateRegistry";
+import {
+  FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE,
+  FAME_V4_ZORA_REVIEWED_POOL_SHAPE,
+} from "../poolStateRegistry";
 
 const quotedResponse = poolQuoteFixture.response;
 const POOL_QUOTES_V1_FIXTURE_SHA256 =
@@ -87,6 +90,18 @@ const v4QuoteRow = {
   hookAddress: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.hooks,
   hookData: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.hookData,
   hookDataStatus: "empty",
+  reviewedPoolEvidence: {
+    status: "verified",
+    source: "reviewed-v4-manifest",
+    kind: "zora-protocol-pool",
+    manifestVersion: 1,
+    poolId: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId,
+    poolKey: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolKey,
+    staticFee: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.fee.toString(),
+    hookAddress: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.hooks,
+    hookData: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.hookData,
+    protocolFeeStatus: "zero",
+  },
   zoraProvenance: {
     status: "verified",
     source: "zora-factory-event",
@@ -98,6 +113,60 @@ const v4QuoteRow = {
     transactionHash:
       "0x7777777777777777777777777777777777777777777777777777777777777777",
     eventName: "CoinCreatedV4",
+  },
+} as const;
+const zoraEthV4QuoteRow = {
+  status: "quoted",
+  quoteKind: "cl-quote-v1",
+  poolId: FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.poolId,
+  chainId: 8453,
+  poolAddress: null,
+  poolKey: FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.poolKey,
+  poolManager: FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.poolManager,
+  stateViewAddress: FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.stateViewAddress,
+  token0: FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.currency0,
+  token1: FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.currency1,
+  tokenIn: FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.currency0,
+  tokenOut: FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.currency1,
+  venueFamily: "UniswapV4",
+  tickSpacing: FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.tickSpacing,
+  amountIn: "1000000",
+  amountOut: "969999",
+  sqrtPriceX96: "79228162514264337593543950336",
+  sqrtPriceX96After: "79228162514110420726332444185",
+  tick: 0,
+  liquidity: "1000000000000000000",
+  fee: FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.fee.toString(),
+  lpFee: FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.fee.toString(),
+  protocolFee: "0",
+  protocolFeeStatus: "zero",
+  staticFee: FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.fee.toString(),
+  feeSource: "v4-slot0",
+  observedThroughBlock: 120,
+  blockHash:
+    "0x4444444444444444444444444444444444444444444444444444444444444444",
+  parentHash:
+    "0x5555555555555555555555555555555555555555555555555555555555555555",
+  snapshotId: "unit-v4-zora-eth-quote",
+  stateHash:
+    "0x6666666666666666666666666666666666666666666666666666666666666666",
+  source: "uniswap-v4-state-view",
+  sourceRegistryId: quotedResponse.sourceRegistryId,
+  maxFreshnessBlocks: 120,
+  hookAddress: FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.hooks,
+  hookData: FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.hookData,
+  hookDataStatus: "empty",
+  reviewedPoolEvidence: {
+    status: "verified",
+    source: "reviewed-v4-manifest",
+    kind: "zero-hook-static-fee",
+    manifestVersion: 1,
+    poolId: FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.poolId,
+    poolKey: FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.poolKey,
+    staticFee: FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.fee.toString(),
+    hookAddress: FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.hooks,
+    hookData: FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.hookData,
+    protocolFeeStatus: "zero",
   },
 } as const;
 
@@ -195,6 +264,12 @@ describe("FAME indexed quote API client", () => {
     assert.equal(v4Row.source, "uniswap-v4-state-view");
     assert.equal(v4Row.poolAddress, null);
     assert.equal(v4Row.poolKey, FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolKey);
+    assert.equal(v4Row.reviewedPoolEvidence.kind, "zora-protocol-pool");
+    assert.equal(
+      v4Row.reviewedPoolEvidence.poolKey,
+      FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolKey,
+    );
+    assert.ok(v4Row.zoraProvenance);
     assert.equal(v4Row.zoraProvenance.poolKey, v4Row.poolKey);
     assert.equal("initializedTicks" in v4Row, false);
     assert.equal("reserve0" in parsed.quotes[2]!, false);
@@ -212,6 +287,34 @@ describe("FAME indexed quote API client", () => {
     assert.equal(unavailable.reason, "fee-model-mismatch");
     assert.equal(unavailable.producerStatus, "trusted");
     assert.equal(unavailable.producerReason, null);
+  });
+
+  it("parses no-hook ZORA/ETH V4 compact rows without provenance", () => {
+    const parsed = parseIndexedQuoteApiResponse({
+      ...quotedResponse,
+      quotes: [zoraEthV4QuoteRow],
+    });
+    const row = parsed.quotes[0];
+
+    assert.equal(row?.status, "quoted");
+    if (
+      row?.status !== "quoted" ||
+      row.quoteKind !== "cl-quote-v1" ||
+      !("poolKey" in row)
+    ) {
+      throw new Error("Expected quoted V4 CL row.");
+    }
+    assert.equal(row.poolId, FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.poolId);
+    assert.equal(row.poolKey, FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.poolKey);
+    assert.equal(row.zoraProvenance, undefined);
+    assert.equal(
+      row.reviewedPoolEvidence.kind,
+      "zero-hook-static-fee",
+    );
+    assert.equal(
+      row.reviewedPoolEvidence.staticFee,
+      FAME_V4_ZORA_ETH_REVIEWED_POOL_SHAPE.fee.toString(),
+    );
   });
 
   it("parses producer trust unavailable compact entries", () => {
@@ -256,6 +359,15 @@ describe("FAME indexed quote API client", () => {
         ...quotedResponse,
         quotes: [{ ...v4QuoteRow, poolKey: undefined }],
       }),
+    );
+
+    assert.throws(
+      () =>
+        parseIndexedQuoteApiResponse({
+          ...quotedResponse,
+          quotes: [{ ...v4QuoteRow, reviewedPoolEvidence: undefined }],
+        }),
+      /reviewedPoolEvidence/,
     );
 
     assert.throws(() =>

--- a/src/features/fame-swap/solver/quotes/indexedQuoteApiClient.test.ts
+++ b/src/features/fame-swap/solver/quotes/indexedQuoteApiClient.test.ts
@@ -9,10 +9,11 @@ import {
   type FameConstantProductPoolQuoteQuotedEntry,
 } from "./indexedQuoteApiClient";
 import { USDC, WETH } from "../../tokens";
+import { FAME_V4_ZORA_REVIEWED_POOL_SHAPE } from "../poolStateRegistry";
 
 const quotedResponse = poolQuoteFixture.response;
 const POOL_QUOTES_V1_FIXTURE_SHA256 =
-  "492e125de5f865f2ef88dd63d5965bd835c3c068d2565cfd355ef93fb28fe763";
+  "7992e76656a42471efcbdea6b11d3f39fefc873b83677653d4ea16afa772e9c1";
 const clQuoteRow = {
   status: "quoted",
   quoteKind: "cl-quote-v1",
@@ -44,6 +45,60 @@ const clQuoteRow = {
   source: "slipstream-pool-state",
   sourceRegistryId: quotedResponse.sourceRegistryId,
   maxFreshnessBlocks: 120,
+} as const;
+const v4QuoteRow = {
+  status: "quoted",
+  quoteKind: "cl-quote-v1",
+  poolId: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId,
+  chainId: 8453,
+  poolAddress: null,
+  poolKey: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolKey,
+  poolManager: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolManager,
+  stateViewAddress: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.stateViewAddress,
+  token0: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.currency0,
+  token1: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.currency1,
+  tokenIn: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.currency0,
+  tokenOut: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.currency1,
+  venueFamily: "UniswapV4",
+  tickSpacing: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.tickSpacing,
+  amountIn: "1000000",
+  amountOut: "969999",
+  sqrtPriceX96: "79228162514264337593543950336",
+  sqrtPriceX96After: "79228162514110420726332444185",
+  tick: 0,
+  liquidity: "1000000000000000000",
+  fee: "30000",
+  lpFee: "30000",
+  protocolFee: "0",
+  protocolFeeStatus: "zero",
+  staticFee: "30000",
+  feeSource: "v4-slot0",
+  observedThroughBlock: 120,
+  blockHash:
+    "0x4444444444444444444444444444444444444444444444444444444444444444",
+  parentHash:
+    "0x5555555555555555555555555555555555555555555555555555555555555555",
+  snapshotId: "unit-v4-cl-quote",
+  stateHash:
+    "0x6666666666666666666666666666666666666666666666666666666666666666",
+  source: "uniswap-v4-state-view",
+  sourceRegistryId: quotedResponse.sourceRegistryId,
+  maxFreshnessBlocks: 120,
+  hookAddress: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.hooks,
+  hookData: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.hookData,
+  hookDataStatus: "empty",
+  zoraProvenance: {
+    status: "verified",
+    source: "zora-factory-event",
+    chainId: 8453,
+    factoryAddress: "0x0000000000000000000000000000000000000003",
+    coinAddress: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.currency1,
+    poolKey: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolKey,
+    poolId: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolKey,
+    transactionHash:
+      "0x7777777777777777777777777777777777777777777777777777777777777777",
+    eventName: "CoinCreatedV4",
+  },
 } as const;
 
 describe("FAME indexed quote API client", () => {
@@ -91,24 +146,27 @@ describe("FAME indexed quote API client", () => {
     });
   });
 
-  it("parses CL, reserve, and unavailable compact entries", () => {
+  it("parses CL, V4 CL, reserve, and unavailable compact entries", () => {
     const parsed = parseIndexedQuoteApiResponse({
       ...quotedResponse,
       quotes: [
         clQuoteRow,
+        v4QuoteRow,
         quotedResponse.quotes[0],
         {
           status: "unavailable",
           requested: {
-            poolId: "slipstream-usdc-weth-100",
-            tokenIn: WETH,
-            tokenOut: USDC,
+            poolId: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId,
+            tokenIn: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.currency0,
+            tokenOut: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.currency1,
             amountIn: "1000000",
           },
-          reason: "stale-indexed-state",
-          poolId: "slipstream-usdc-weth-100",
+          reason: "fee-model-mismatch",
+          poolId: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolId,
           chainId: 8453,
-          poolAddress: "0xb2cc224c1c9fee385f8ad6a55b4d94e92359dc59",
+          poolAddress: null,
+          poolKey: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolKey,
+          stateViewAddress: FAME_V4_ZORA_REVIEWED_POOL_SHAPE.stateViewAddress,
           observedThroughBlock: 1,
           sourceRegistryId: "unit-registry",
           maxFreshnessBlocks: 120,
@@ -120,11 +178,60 @@ describe("FAME indexed quote API client", () => {
       parsed.quotes.map((quote) =>
         quote.status === "quoted" ? quote.quoteKind : quote.status,
       ),
-      ["cl-quote-v1", "constant-product-quote-v1", "unavailable"],
+      [
+        "cl-quote-v1",
+        "cl-quote-v1",
+        "constant-product-quote-v1",
+        "unavailable",
+      ],
     );
     assert.equal("initializedTicks" in parsed.quotes[0]!, false);
-    assert.equal("reserve0" in parsed.quotes[1]!, false);
-    assert.equal("reserve1" in parsed.quotes[1]!, false);
+    const v4Row = parsed.quotes[1];
+    assert.equal(v4Row?.status, "quoted");
+    assert.equal(v4Row?.quoteKind, "cl-quote-v1");
+    assert.equal(v4Row.source, "uniswap-v4-state-view");
+    assert.equal(v4Row.poolAddress, null);
+    assert.equal(v4Row.poolKey, FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolKey);
+    assert.equal(v4Row.zoraProvenance.poolKey, v4Row.poolKey);
+    assert.equal("initializedTicks" in v4Row, false);
+    assert.equal("reserve0" in parsed.quotes[2]!, false);
+    assert.equal("reserve1" in parsed.quotes[2]!, false);
+    assert.equal(parsed.quotes[3]?.status, "unavailable");
+    assert.equal(parsed.quotes[3]?.reason, "fee-model-mismatch");
+    assert.equal(
+      parsed.quotes[3]?.poolKey,
+      FAME_V4_ZORA_REVIEWED_POOL_SHAPE.poolKey,
+    );
+  });
+
+  it("rejects ambiguous V4 compact CL rows without required V4 evidence", () => {
+    assert.throws(() =>
+      parseIndexedQuoteApiResponse({
+        ...quotedResponse,
+        quotes: [{ ...v4QuoteRow, poolKey: undefined }],
+      }),
+    );
+
+    assert.throws(() =>
+      parseIndexedQuoteApiResponse({
+        ...quotedResponse,
+        quotes: [{ ...v4QuoteRow, protocolFee: "1" }],
+      }),
+    );
+
+    assert.throws(() =>
+      parseIndexedQuoteApiResponse({
+        ...quotedResponse,
+        quotes: [{ ...v4QuoteRow, staticFee: "100" }],
+      }),
+    );
+
+    assert.throws(() =>
+      parseIndexedQuoteApiResponse({
+        ...quotedResponse,
+        quotes: [{ ...v4QuoteRow, hookData: "0x01" }],
+      }),
+    );
   });
 
   it("accepts the versioned reserve fixture contract", () => {
@@ -209,7 +316,7 @@ describe("FAME indexed quote API client", () => {
     );
   });
 
-  it("rejects helper responses that loosen the requested freshness cap", async () => {
+  it("leaves row-scoped freshness to the quote adapter", async () => {
     const futureClient = createIndexedQuoteApiClient({
       endpointUrl: "https://society.example/fame/pool-quotes",
       serviceToken: "unit-token",
@@ -226,14 +333,14 @@ describe("FAME indexed quote API client", () => {
           }),
         ),
     });
-    const looseFreshnessClient = createIndexedQuoteApiClient({
+    const staleRowClient = createIndexedQuoteApiClient({
       endpointUrl: "https://society.example/fame/pool-quotes",
       serviceToken: "unit-token",
       fetchFn: async () =>
         new Response(
           JSON.stringify({
             ...quotedResponse,
-            effectiveMaxFreshnessBlocks: 120,
+            effectiveMaxFreshnessBlocks: 10,
             quotes: [
               {
                 ...quotedResponse.quotes[0],
@@ -244,14 +351,44 @@ describe("FAME indexed quote API client", () => {
           }),
         ),
     });
-    const staleRowClient = createIndexedQuoteApiClient({
+
+    const futureResponse = await futureClient.fetchQuotes({
+      currentBlock: 125,
+      quotes: [],
+    });
+    const futureRow = futureResponse.quotes[0];
+    assert.equal(futureRow?.status, "quoted");
+    assert.equal(
+      futureRow && "observedThroughBlock" in futureRow
+        ? futureRow.observedThroughBlock
+        : null,
+      126,
+    );
+
+    const staleResponse = await staleRowClient.fetchQuotes({
+      currentBlock: 125,
+      maxFreshnessBlocks: 10,
+      quotes: [],
+    });
+    const staleRow = staleResponse.quotes[0];
+    assert.equal(staleRow?.status, "quoted");
+    assert.equal(
+      staleRow && "observedThroughBlock" in staleRow
+        ? staleRow.observedThroughBlock
+        : null,
+      100,
+    );
+  });
+
+  it("rejects helper responses that loosen the requested freshness cap", async () => {
+    const looseFreshnessClient = createIndexedQuoteApiClient({
       endpointUrl: "https://society.example/fame/pool-quotes",
       serviceToken: "unit-token",
       fetchFn: async () =>
         new Response(
           JSON.stringify({
             ...quotedResponse,
-            effectiveMaxFreshnessBlocks: 10,
+            effectiveMaxFreshnessBlocks: 120,
             quotes: [
               {
                 ...quotedResponse.quotes[0],
@@ -276,29 +413,12 @@ describe("FAME indexed quote API client", () => {
 
     await assert.rejects(
       () =>
-        futureClient.fetchQuotes({
-          currentBlock: 125,
-          quotes: [],
-        }),
-      /observedThroughBlock/,
-    );
-    await assert.rejects(
-      () =>
         looseFreshnessClient.fetchQuotes({
           currentBlock: 125,
           maxFreshnessBlocks: 10,
           quotes: [],
         }),
       /effectiveMaxFreshnessBlocks/,
-    );
-    await assert.rejects(
-      () =>
-        staleRowClient.fetchQuotes({
-          currentBlock: 125,
-          maxFreshnessBlocks: 10,
-          quotes: [],
-        }),
-      /maxFreshnessBlocks/,
     );
     await assert.rejects(
       () =>

--- a/src/features/fame-swap/solver/quotes/indexedQuoteApiClient.test.ts
+++ b/src/features/fame-swap/solver/quotes/indexedQuoteApiClient.test.ts
@@ -12,7 +12,7 @@ import { USDC, WETH } from "../../tokens";
 
 const quotedResponse = poolQuoteFixture.response;
 const POOL_QUOTES_V1_FIXTURE_SHA256 =
-  "492e125de5f865f2ef88dd63d5965bd835c3c068d2565cfd355ef93fb28fe763";
+  "1167e7daf16ed8c90c01b053dce24bb08579aef88a24a1ae1a756b290c34237d";
 const clQuoteRow = {
   status: "quoted",
   quoteKind: "cl-quote-v1",
@@ -105,16 +105,19 @@ describe("FAME indexed quote API client", () => {
             tokenOut: USDC,
             amountIn: "1000000",
           },
-          reason: "stale-indexed-state",
+          reason: "producer-untrusted",
           poolId: "slipstream-usdc-weth-100",
           chainId: 8453,
           poolAddress: "0xb2cc224c1c9fee385f8ad6a55b4d94e92359dc59",
           observedThroughBlock: 1,
           sourceRegistryId: "unit-registry",
           maxFreshnessBlocks: 120,
+          producerStatus: "trusted",
+          producerReason: null,
         },
       ],
     });
+    const unavailable = parsed.quotes[2];
 
     assert.deepEqual(
       parsed.quotes.map((quote) =>
@@ -125,6 +128,13 @@ describe("FAME indexed quote API client", () => {
     assert.equal("initializedTicks" in parsed.quotes[0]!, false);
     assert.equal("reserve0" in parsed.quotes[1]!, false);
     assert.equal("reserve1" in parsed.quotes[1]!, false);
+    assert.equal(unavailable?.status, "unavailable");
+    if (unavailable?.status !== "unavailable") {
+      throw new Error("Expected unavailable producer trust row.");
+    }
+    assert.equal(unavailable.reason, "producer-untrusted");
+    assert.equal(unavailable.producerStatus, "trusted");
+    assert.equal(unavailable.producerReason, null);
   });
 
   it("accepts the versioned reserve fixture contract", () => {
@@ -158,6 +168,32 @@ describe("FAME indexed quote API client", () => {
     assert.equal(reserveRow.feeSource, "registry-fee");
     assert.equal(reserveRow.priceImpact.marketImpactBps, 3352);
     assert.equal(reserveRow.protocolEvidence.quote.value, "831");
+  });
+
+  it("documents producer-untrusted unavailable fixture examples", () => {
+    const [baselineProducerUntrusted, candidateProducerUntrusted] =
+      poolQuoteFixture.unavailableExamples;
+    const parsed = parseIndexedQuoteApiResponse({
+      ...quotedResponse,
+      quotes: [baselineProducerUntrusted, candidateProducerUntrusted],
+    });
+    const [baselineRow, candidateRow] = parsed.quotes;
+
+    assert.equal(baselineRow?.status, "unavailable");
+    if (baselineRow?.status !== "unavailable") {
+      throw new Error("Expected trusted producer-untrusted fixture example.");
+    }
+    assert.equal(baselineRow.reason, "producer-untrusted");
+    assert.equal(baselineRow.producerStatus, "trusted");
+    assert.equal(baselineRow.producerReason, null);
+    assert.equal(candidateRow?.status, "unavailable");
+    if (candidateRow?.status !== "unavailable") {
+      throw new Error("Expected candidate producer-untrusted fixture example.");
+    }
+    assert.equal(candidateRow.reason, "producer-untrusted");
+    assert.equal(candidateRow.poolId, "slipstream-basedflick-fame");
+    assert.equal(candidateRow.producerStatus, "warming");
+    assert.equal(candidateRow.producerReason, "shadow-not-promoted");
   });
 
   it("rejects non-OK and malformed responses without exposing credentials", async () => {
@@ -206,6 +242,45 @@ describe("FAME indexed quote API client", () => {
           ],
         }),
       /amountOut/,
+    );
+    assert.throws(
+      () =>
+        parseIndexedQuoteApiResponse({
+          ...quotedResponse,
+          quotes: [
+            {
+              status: "unavailable",
+              requested: {
+                poolId: "slipstream-usdc-weth-100",
+                tokenIn: WETH,
+                tokenOut: USDC,
+                amountIn: "1000000",
+              },
+              reason: "operator-sad",
+            },
+          ],
+        }),
+      /reason/,
+    );
+    assert.throws(
+      () =>
+        parseIndexedQuoteApiResponse({
+          ...quotedResponse,
+          quotes: [
+            {
+              status: "unavailable",
+              requested: {
+                poolId: "slipstream-usdc-weth-100",
+                tokenIn: WETH,
+                tokenOut: USDC,
+                amountIn: "1000000",
+              },
+              reason: "producer-untrusted",
+              producerStatus: "sleepy",
+            },
+          ],
+        }),
+      /producerStatus/,
     );
   });
 

--- a/src/features/fame-swap/solver/quotes/indexedQuoteApiClient.ts
+++ b/src/features/fame-swap/solver/quotes/indexedQuoteApiClient.ts
@@ -29,7 +29,15 @@ export type FamePoolQuoteUnavailableReason =
   | "reserve-quote-failed"
   | "malformed-replay-state"
   | "outside-indexed-tick-range"
-  | "replay-failed";
+  | "replay-failed"
+  | "producer-untrusted";
+
+export type FamePoolQuoteProducerStatus =
+  | "trusted"
+  | "warming"
+  | "drift-failed"
+  | "repairing"
+  | "event-gap";
 
 export interface FamePoolQuoteUnavailableEntry {
   status: "unavailable";
@@ -41,6 +49,8 @@ export interface FamePoolQuoteUnavailableEntry {
   observedThroughBlock?: number;
   sourceRegistryId?: string;
   maxFreshnessBlocks?: number;
+  producerStatus?: FamePoolQuoteProducerStatus;
+  producerReason?: string | null;
 }
 
 interface FamePoolQuoteQuotedEntryBase {
@@ -239,11 +249,36 @@ function parseUnavailableReason(
     reason !== "reserve-quote-failed" &&
     reason !== "malformed-replay-state" &&
     reason !== "outside-indexed-tick-range" &&
-    reason !== "replay-failed"
+    reason !== "replay-failed" &&
+    reason !== "producer-untrusted"
   ) {
     throw responseError("reason");
   }
   return reason;
+}
+
+function parseProducerStatus(
+  record: Record<string, unknown>,
+): FamePoolQuoteProducerStatus {
+  const status = stringField(record, "producerStatus");
+  if (
+    status !== "trusted" &&
+    status !== "warming" &&
+    status !== "drift-failed" &&
+    status !== "repairing" &&
+    status !== "event-gap"
+  ) {
+    throw responseError("producerStatus");
+  }
+  return status;
+}
+
+function optionalNullableStringField(
+  record: Record<string, unknown>,
+  key: string,
+): string | null {
+  if (record[key] === null) return null;
+  return stringField(record, key);
 }
 
 function parseQuotedBase(
@@ -466,6 +501,12 @@ function parseUnavailableEntry(
       : {
           maxFreshnessBlocks: safeIntegerField(record, "maxFreshnessBlocks"),
         }),
+    ...(record.producerStatus === undefined
+      ? {}
+      : { producerStatus: parseProducerStatus(record) }),
+    ...(record.producerReason === undefined
+      ? {}
+      : { producerReason: optionalNullableStringField(record, "producerReason") }),
   };
 }
 

--- a/src/features/fame-swap/solver/quotes/indexedQuoteApiClient.ts
+++ b/src/features/fame-swap/solver/quotes/indexedQuoteApiClient.ts
@@ -29,7 +29,11 @@ export type FamePoolQuoteUnavailableReason =
   | "reserve-quote-failed"
   | "malformed-replay-state"
   | "outside-indexed-tick-range"
-  | "replay-failed";
+  | "replay-failed"
+  | "missing-provenance"
+  | "v4-shape-mismatch"
+  | "fee-model-mismatch"
+  | "producer-untrusted";
 
 export interface FamePoolQuoteUnavailableEntry {
   status: "unavailable";
@@ -38,6 +42,8 @@ export interface FamePoolQuoteUnavailableEntry {
   poolId?: string;
   chainId?: number;
   poolAddress?: Address | null;
+  poolKey?: Hex | null;
+  stateViewAddress?: Address | null;
   observedThroughBlock?: number;
   sourceRegistryId?: string;
   maxFreshnessBlocks?: number;
@@ -47,7 +53,6 @@ interface FamePoolQuoteQuotedEntryBase {
   status: "quoted";
   poolId: string;
   chainId: number;
-  poolAddress: Address;
   token0: Address;
   token1: Address;
   tokenIn: Address;
@@ -60,8 +65,13 @@ interface FamePoolQuoteQuotedEntryBase {
   maxFreshnessBlocks: number;
 }
 
-export interface FameClPoolQuoteQuotedEntry
+interface FameAddressBackedPoolQuoteQuotedEntryBase
   extends FamePoolQuoteQuotedEntryBase {
+  poolAddress: Address;
+}
+
+export interface FameClPoolQuoteQuotedEntry
+  extends FameAddressBackedPoolQuoteQuotedEntryBase {
   quoteKind: "cl-quote-v1";
   tickSpacing: number;
   sqrtPriceX96: string;
@@ -77,6 +87,48 @@ export interface FameClPoolQuoteQuotedEntry
   source: "slipstream-pool-state";
 }
 
+export interface FameV4ZoraVerifiedProvenance {
+  status: "verified";
+  source: "zora-factory-event" | "zora-factory-transaction-trace";
+  chainId: 8453;
+  factoryAddress: Address;
+  coinAddress: Address;
+  poolKey: Hex;
+  poolId: Hex;
+  transactionHash: Hex;
+  eventName: string | null;
+}
+
+export interface FameV4ClPoolQuoteQuotedEntry
+  extends FamePoolQuoteQuotedEntryBase {
+  quoteKind: "cl-quote-v1";
+  poolAddress: null;
+  poolKey: Hex;
+  poolManager: Address;
+  stateViewAddress: Address;
+  venueFamily: "UniswapV4";
+  tickSpacing: number;
+  sqrtPriceX96: string;
+  sqrtPriceX96After: string;
+  tick: number;
+  liquidity: string;
+  fee: string;
+  lpFee: string;
+  protocolFee: string;
+  protocolFeeStatus: "zero";
+  staticFee: string;
+  feeSource: "v4-slot0";
+  blockHash: Hex;
+  parentHash: Hex;
+  snapshotId: string;
+  stateHash: Hex;
+  source: "uniswap-v4-state-view";
+  hookAddress: Address;
+  hookData: Hex;
+  hookDataStatus: "empty";
+  zoraProvenance: FameV4ZoraVerifiedProvenance;
+}
+
 export interface FameConstantProductQuotePriceImpact {
   preSwapPriceX18: string;
   postSwapPriceX18: string;
@@ -86,7 +138,7 @@ export interface FameConstantProductQuotePriceImpact {
 }
 
 export interface FameConstantProductPoolQuoteQuotedEntry
-  extends FamePoolQuoteQuotedEntryBase {
+  extends FameAddressBackedPoolQuoteQuotedEntryBase {
   quoteKind: "constant-product-quote-v1";
   quoteModel: "constant-product-reserves";
   quoteModelVersion: 1;
@@ -100,6 +152,7 @@ export interface FameConstantProductPoolQuoteQuotedEntry
 
 export type FamePoolQuoteQuotedEntry =
   | FameClPoolQuoteQuotedEntry
+  | FameV4ClPoolQuoteQuotedEntry
   | FameConstantProductPoolQuoteQuotedEntry;
 
 export type FamePoolQuoteEntry =
@@ -184,6 +237,14 @@ function bytes32HexField(record: Record<string, unknown>, key: string): Hex {
   return value as Hex;
 }
 
+function hexField(record: Record<string, unknown>, key: string): Hex {
+  const value = stringField(record, key);
+  if (!isHex(value, { strict: true })) {
+    throw responseError(key);
+  }
+  return value as Hex;
+}
+
 function addressField(record: Record<string, unknown>, key: string): Address {
   const value = stringField(record, key);
   if (!isAddress(value, { strict: false })) {
@@ -199,6 +260,15 @@ function optionalAddressField(
   if (record[key] === undefined) return undefined;
   if (record[key] === null) return null;
   return addressField(record, key);
+}
+
+function optionalBytes32HexField(
+  record: Record<string, unknown>,
+  key: string,
+): Hex | null | undefined {
+  if (record[key] === undefined) return undefined;
+  if (record[key] === null) return null;
+  return bytes32HexField(record, key);
 }
 
 function literalStringField<T extends string>(
@@ -239,7 +309,11 @@ function parseUnavailableReason(
     reason !== "reserve-quote-failed" &&
     reason !== "malformed-replay-state" &&
     reason !== "outside-indexed-tick-range" &&
-    reason !== "replay-failed"
+    reason !== "replay-failed" &&
+    reason !== "missing-provenance" &&
+    reason !== "v4-shape-mismatch" &&
+    reason !== "fee-model-mismatch" &&
+    reason !== "producer-untrusted"
   ) {
     throw responseError("reason");
   }
@@ -253,7 +327,6 @@ function parseQuotedBase(
     status: "quoted",
     poolId: stringField(record, "poolId"),
     chainId: safeIntegerField(record, "chainId"),
-    poolAddress: addressField(record, "poolAddress"),
     token0: addressField(record, "token0"),
     token1: addressField(record, "token1"),
     tokenIn: addressField(record, "tokenIn"),
@@ -267,6 +340,15 @@ function parseQuotedBase(
   };
 }
 
+function parseAddressBackedQuotedBase(
+  record: Record<string, unknown>,
+): FameAddressBackedPoolQuoteQuotedEntryBase {
+  return {
+    ...parseQuotedBase(record),
+    poolAddress: addressField(record, "poolAddress"),
+  };
+}
+
 function parseClQuotedEntry(
   record: Record<string, unknown>,
 ): FameClPoolQuoteQuotedEntry {
@@ -274,7 +356,7 @@ function parseClQuotedEntry(
   if (tickSpacing <= 0) throw responseError("tickSpacing");
 
   return {
-    ...parseQuotedBase(record),
+    ...parseAddressBackedQuotedBase(record),
     quoteKind: "cl-quote-v1",
     tickSpacing,
     sqrtPriceX96: decimalStringField(record, "sqrtPriceX96"),
@@ -288,6 +370,93 @@ function parseClQuotedEntry(
     snapshotId: stringField(record, "snapshotId"),
     stateHash: bytes32HexField(record, "stateHash"),
     source: literalStringField(record, "source", "slipstream-pool-state"),
+  };
+}
+
+function parseNullableString(
+  value: unknown,
+  path: string,
+): string | null {
+  if (value === null) return null;
+  if (typeof value === "string" && value.length > 0) return value;
+  throw responseError(path);
+}
+
+function parseV4ZoraProvenance(
+  value: unknown,
+): FameV4ZoraVerifiedProvenance {
+  const record = asRecord(value, "zoraProvenance");
+  const source = stringField(record, "source");
+  if (
+    source !== "zora-factory-event" &&
+    source !== "zora-factory-transaction-trace"
+  ) {
+    throw responseError("zoraProvenance.source");
+  }
+  const chainId = safeIntegerField(record, "chainId");
+  if (chainId !== 8453) throw responseError("zoraProvenance.chainId");
+  return {
+    status: literalStringField(record, "status", "verified"),
+    source,
+    chainId,
+    factoryAddress: addressField(record, "factoryAddress"),
+    coinAddress: addressField(record, "coinAddress"),
+    poolKey: bytes32HexField(record, "poolKey"),
+    poolId: bytes32HexField(record, "poolId"),
+    transactionHash: bytes32HexField(record, "transactionHash"),
+    eventName: parseNullableString(record.eventName, "zoraProvenance.eventName"),
+  };
+}
+
+function parseV4ClQuotedEntry(
+  record: Record<string, unknown>,
+): FameV4ClPoolQuoteQuotedEntry {
+  if (record.poolAddress !== null) throw responseError("poolAddress");
+
+  const fee = decimalStringField(record, "fee");
+  const lpFee = decimalStringField(record, "lpFee");
+  const protocolFee = decimalStringField(record, "protocolFee");
+  const staticFee = decimalStringField(record, "staticFee");
+  const tickSpacing = safeIntegerField(record, "tickSpacing");
+  const hookData = hexField(record, "hookData");
+  if (fee !== lpFee) throw responseError("fee");
+  if (staticFee !== fee) throw responseError("staticFee");
+  if (protocolFee !== "0") throw responseError("protocolFee");
+  if (tickSpacing <= 0) throw responseError("tickSpacing");
+  if (hookData.toLowerCase() !== "0x") throw responseError("hookData");
+
+  return {
+    ...parseQuotedBase(record),
+    quoteKind: "cl-quote-v1",
+    poolAddress: null,
+    poolKey: bytes32HexField(record, "poolKey"),
+    poolManager: addressField(record, "poolManager"),
+    stateViewAddress: addressField(record, "stateViewAddress"),
+    venueFamily: literalStringField(record, "venueFamily", "UniswapV4"),
+    tickSpacing,
+    sqrtPriceX96: decimalStringField(record, "sqrtPriceX96"),
+    sqrtPriceX96After: decimalStringField(record, "sqrtPriceX96After"),
+    tick: safeIntegerField(record, "tick"),
+    liquidity: decimalStringField(record, "liquidity"),
+    fee,
+    lpFee,
+    protocolFee,
+    protocolFeeStatus: literalStringField(
+      record,
+      "protocolFeeStatus",
+      "zero",
+    ),
+    staticFee,
+    feeSource: literalStringField(record, "feeSource", "v4-slot0"),
+    blockHash: bytes32HexField(record, "blockHash"),
+    parentHash: bytes32HexField(record, "parentHash"),
+    snapshotId: stringField(record, "snapshotId"),
+    stateHash: bytes32HexField(record, "stateHash"),
+    source: literalStringField(record, "source", "uniswap-v4-state-view"),
+    hookAddress: addressField(record, "hookAddress"),
+    hookData,
+    hookDataStatus: literalStringField(record, "hookDataStatus", "empty"),
+    zoraProvenance: parseV4ZoraProvenance(record.zoraProvenance),
   };
 }
 
@@ -405,7 +574,7 @@ function parseConstantProductQuotedEntry(
   record: Record<string, unknown>,
 ): FameConstantProductPoolQuoteQuotedEntry {
   return {
-    ...parseQuotedBase(record),
+    ...parseAddressBackedQuotedBase(record),
     quoteKind: "constant-product-quote-v1",
     quoteModel: literalStringField(
       record,
@@ -426,7 +595,12 @@ function parseQuotedEntry(
   record: Record<string, unknown>,
 ): FamePoolQuoteQuotedEntry {
   const quoteKind = stringField(record, "quoteKind");
-  if (quoteKind === "cl-quote-v1") return parseClQuotedEntry(record);
+  if (quoteKind === "cl-quote-v1") {
+    const source = stringField(record, "source");
+    if (source === "slipstream-pool-state") return parseClQuotedEntry(record);
+    if (source === "uniswap-v4-state-view") return parseV4ClQuotedEntry(record);
+    throw responseError("source");
+  }
   if (quoteKind === "constant-product-quote-v1") {
     return parseConstantProductQuotedEntry(record);
   }
@@ -450,6 +624,12 @@ function parseUnavailableEntry(
     ...(record.poolAddress === undefined
       ? {}
       : { poolAddress: optionalAddressField(record, "poolAddress") }),
+    ...(record.poolKey === undefined
+      ? {}
+      : { poolKey: optionalBytes32HexField(record, "poolKey") }),
+    ...(record.stateViewAddress === undefined
+      ? {}
+      : { stateViewAddress: optionalAddressField(record, "stateViewAddress") }),
     ...(record.observedThroughBlock === undefined
       ? {}
       : {
@@ -514,24 +694,6 @@ function validateFreshness(
     response.effectiveMaxFreshnessBlocks > request.maxFreshnessBlocks
   ) {
     throw responseError("effectiveMaxFreshnessBlocks");
-  }
-
-  for (const quote of response.quotes) {
-    if (quote.status !== "quoted") continue;
-    if (quote.observedThroughBlock > response.currentBlock) {
-      throw responseError("observedThroughBlock");
-    }
-    const effectiveFreshness = Math.min(
-      quote.maxFreshnessBlocks,
-      response.effectiveMaxFreshnessBlocks,
-      request.maxFreshnessBlocks ?? Number.MAX_SAFE_INTEGER,
-    );
-    if (
-      response.currentBlock - quote.observedThroughBlock >
-      effectiveFreshness
-    ) {
-      throw responseError("maxFreshnessBlocks");
-    }
   }
 }
 

--- a/src/features/fame-swap/solver/quotes/indexedQuoteApiClient.ts
+++ b/src/features/fame-swap/solver/quotes/indexedQuoteApiClient.ts
@@ -108,6 +108,19 @@ export interface FameV4ZoraVerifiedProvenance {
   eventName: string | null;
 }
 
+export interface FameV4ReviewedPoolEvidence {
+  status: "verified";
+  source: "reviewed-v4-manifest";
+  kind: "zero-hook-static-fee" | "zora-protocol-pool";
+  manifestVersion: number;
+  poolId: string;
+  poolKey: Hex;
+  staticFee: string;
+  hookAddress: Address;
+  hookData: Hex;
+  protocolFeeStatus: "zero";
+}
+
 export interface FameV4ClPoolQuoteQuotedEntry
   extends FamePoolQuoteQuotedEntryBase {
   quoteKind: "cl-quote-v1";
@@ -135,7 +148,8 @@ export interface FameV4ClPoolQuoteQuotedEntry
   hookAddress: Address;
   hookData: Hex;
   hookDataStatus: "empty";
-  zoraProvenance: FameV4ZoraVerifiedProvenance;
+  reviewedPoolEvidence: FameV4ReviewedPoolEvidence;
+  zoraProvenance?: FameV4ZoraVerifiedProvenance;
 }
 
 export interface FameConstantProductQuotePriceImpact {
@@ -441,6 +455,43 @@ function parseV4ZoraProvenance(
   };
 }
 
+function parseOptionalV4ZoraProvenance(
+  value: unknown,
+): FameV4ZoraVerifiedProvenance | undefined {
+  if (value === undefined) return undefined;
+  return parseV4ZoraProvenance(value);
+}
+
+function parseV4ReviewedPoolEvidence(
+  value: unknown,
+): FameV4ReviewedPoolEvidence {
+  const record = asRecord(value, "reviewedPoolEvidence");
+  const kind = stringField(record, "kind");
+  if (kind !== "zero-hook-static-fee" && kind !== "zora-protocol-pool") {
+    throw responseError("reviewedPoolEvidence.kind");
+  }
+  return {
+    status: literalStringField(record, "status", "verified"),
+    source: literalStringField(
+      record,
+      "source",
+      "reviewed-v4-manifest",
+    ),
+    kind,
+    manifestVersion: safeIntegerField(record, "manifestVersion"),
+    poolId: stringField(record, "poolId"),
+    poolKey: bytes32HexField(record, "poolKey"),
+    staticFee: decimalStringField(record, "staticFee"),
+    hookAddress: addressField(record, "hookAddress"),
+    hookData: hexField(record, "hookData"),
+    protocolFeeStatus: literalStringField(
+      record,
+      "protocolFeeStatus",
+      "zero",
+    ),
+  };
+}
+
 function parseV4ClQuotedEntry(
   record: Record<string, unknown>,
 ): FameV4ClPoolQuoteQuotedEntry {
@@ -489,7 +540,10 @@ function parseV4ClQuotedEntry(
     hookAddress: addressField(record, "hookAddress"),
     hookData,
     hookDataStatus: literalStringField(record, "hookDataStatus", "empty"),
-    zoraProvenance: parseV4ZoraProvenance(record.zoraProvenance),
+    reviewedPoolEvidence: parseV4ReviewedPoolEvidence(
+      record.reviewedPoolEvidence,
+    ),
+    zoraProvenance: parseOptionalV4ZoraProvenance(record.zoraProvenance),
   };
 }
 

--- a/src/features/fame-swap/solver/quotes/liveAdapters.ts
+++ b/src/features/fame-swap/solver/quotes/liveAdapters.ts
@@ -1,4 +1,5 @@
 import type { Address } from "viem";
+import { displaySafeDiagnosticMessage } from "../diagnostics";
 import type { FameSlipstreamPoolConfig } from "../../router/types";
 import type {
   FameAsyncQuoteAdapter,
@@ -273,21 +274,7 @@ function unavailable(message: string): FameEdgeQuoteResult {
 }
 
 function displaySafeErrorMessage(error: unknown): string {
-  const raw = error instanceof Error ? error.message : String(error);
-  const firstLine = raw
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .find(
-      (line) =>
-        line.length > 0 &&
-        !/\b(request body|calldata|approval|swap request|private key|signer|authorization|api[-_ ]?key)\b|(?:^|\s)secret(?:[-_ ]?(?:key|token))?\s*[:=]/i.test(
-          line,
-        ),
-    );
-  return (firstLine ?? "Unknown live quote error.")
-    .replace(/(?:https?|wss?):\/\/\S+/g, "[redacted-url]")
-    .replace(/\b(?:bearer|token)\s+[a-z0-9._~+/=-]+/gi, "[redacted-secret]")
-    .replace(/0x[a-fA-F0-9]{64,}/g, "[redacted-hex]");
+  return displaySafeDiagnosticMessage(error);
 }
 
 function availableEvidence(
@@ -585,9 +572,7 @@ function feeBpsFor(request: FameEdgeQuoteRequest): number | null {
   return fee.status === "available" ? fee.feeBps : null;
 }
 
-function poolGetAmountOutVenueLabel(
-  venue: "solidly" | "aerodrome-v2",
-): string {
+function poolGetAmountOutVenueLabel(venue: "solidly" | "aerodrome-v2"): string {
   return venue === "aerodrome-v2" ? "Aerodrome V2" : "Solidly";
 }
 

--- a/src/features/fame-swap/solver/quotes/rankRoutes.ts
+++ b/src/features/fame-swap/solver/quotes/rankRoutes.ts
@@ -178,6 +178,7 @@ export function quoteRouteCandidate(
       quoteContext: quote.context ?? quoteContext,
       priceImpact: quote.priceImpact,
       protocolEvidence: quote.protocolEvidence,
+      indexedEvidence: quote.indexedEvidence,
     });
   }
 

--- a/src/features/fame-swap/solver/readiness.ts
+++ b/src/features/fame-swap/solver/readiness.ts
@@ -1,4 +1,5 @@
 import type { Address } from "viem";
+import { displaySafeDiagnosticMessage } from "./diagnostics";
 import { FAME_SWAP_ARTIFACT_MANIFEST } from "../artifacts/manifest";
 import type { FameSwapConfig } from "../config";
 import { artifactIntegrityIssue } from "./integrity";
@@ -39,22 +40,7 @@ function blocked(
 }
 
 function displaySafeReadinessError(error: unknown): string {
-  const raw = error instanceof Error ? error.message : String(error);
-  return (
-    raw
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .find(
-        (line) =>
-          line.length > 0 &&
-          !/\b(request body|calldata|approval|swap request|private key|signer|authorization|api[-_ ]?key)\b|(?:^|\s)secret(?:[-_ ]?(?:key|token))?\s*[:=]/i.test(
-            line,
-          ),
-      ) ?? "Unknown router policy read error."
-  )
-    .replace(/(?:https?|wss?):\/\/\S+/g, "[redacted-url]")
-    .replace(/\b(?:bearer|token)\s+[a-z0-9._~+/=-]+/gi, "[redacted-secret]")
-    .replace(/0x[a-fA-F0-9]{64,}/g, "[redacted-hex]");
+  return displaySafeDiagnosticMessage(error);
 }
 
 export function staticReadiness(config: FameSwapConfig): FameSwapReadiness {

--- a/src/features/fame-swap/solver/types.ts
+++ b/src/features/fame-swap/solver/types.ts
@@ -66,6 +66,7 @@ export interface FameSwapQuoteRequest {
   readiness?: FameSwapReadiness;
   optimizerMode?: FameOptimizerMode;
   optimizerBudgets?: Partial<FameOptimizerBudgets>;
+  requestedRouteId?: string;
   now?: Date;
   deadlineSeconds?: bigint;
 }

--- a/src/features/fame-swap/solver/types.ts
+++ b/src/features/fame-swap/solver/types.ts
@@ -16,6 +16,7 @@ import type {
   FameOptimizerMode,
   FameOptimizerQuotePlanStats,
 } from "./optimizer/types";
+import type { FameRouteCandidate } from "./graph/routePlan";
 
 export type FameSwapQuoteStatus =
   | "ready"
@@ -66,6 +67,7 @@ export interface FameSwapQuoteRequest {
   readiness?: FameSwapReadiness;
   optimizerMode?: FameOptimizerMode;
   optimizerBudgets?: Partial<FameOptimizerBudgets>;
+  candidateFilter?: (candidate: FameRouteCandidate) => boolean;
   now?: Date;
   deadlineSeconds?: bigint;
 }

--- a/src/features/fameus/client-components/RedirectWhenConnected.tsx
+++ b/src/features/fameus/client-components/RedirectWhenConnected.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { FC, useEffect, useState } from "react";
-import { useSwitchChain, useChains, useChainId } from "wagmi";
+import { useSwitchChain, useChains } from "wagmi";
 import { useAccount } from "@/hooks/useAccount";
 import { useRouter, usePathname } from "next/navigation";
 
@@ -24,9 +24,8 @@ export const RedirectWhenConnected: FC<{
   const [targetChainId, setTargetChainId] = useState<number | undefined>(
     toChain,
   );
-  const { isConnected, address } = useAccount();
+  const { isConnected, address, chainId: connectedChainId } = useAccount();
   const chains = useChains();
-  const chainId = useChainId();
   const {
     mutateAsync: switchChainAsync,
     isSuccess,
@@ -52,14 +51,15 @@ export const RedirectWhenConnected: FC<{
       targetChainId &&
       chain &&
       !isSuccess &&
-      targetChainId !== chainId &&
+      targetChainId !== connectedChainId &&
       address
     ) {
       console.log("switching chain", targetChainId);
       switchChainAsync({ chainId: targetChainId }).then((newChain) => {
-        if (newChain) {
+        const chainName = chainIdToChainName(newChain?.id ?? targetChainId);
+        if (chainName) {
           router.replace(
-            `/${chainIdToChainName(newChain.id)}/${pathPrefix ? pathPrefix + "/" : ""}${address}${pathPostfix ? "/" + pathPostfix : ""}`,
+            `/${chainName}/${pathPrefix ? pathPrefix + "/" : ""}${address}${pathPostfix ? "/" + pathPostfix : ""}`,
           );
         }
       });
@@ -68,7 +68,7 @@ export const RedirectWhenConnected: FC<{
     targetChainId,
     chain,
     isSuccess,
-    chainId,
+    connectedChainId,
     switchChainAsync,
     router,
     pathPrefix,
@@ -78,9 +78,18 @@ export const RedirectWhenConnected: FC<{
   ]);
 
   useEffect(() => {
-    const possiblePath = `/${chainIdToChainName(chainId)}/${pathPrefix ? pathPrefix + "/" : ""}${address}${pathPostfix ? "/" + pathPostfix : ""}`;
-    if (isConnected && address && pathname !== possiblePath) {
-      console.log(`redirecting to ${possiblePath} with chainId ${chainId}`);
+    const chainName = chainIdToChainName(toChain);
+    if (!chainName) return;
+    const possiblePath = `/${chainName}/${pathPrefix ? pathPrefix + "/" : ""}${address}${pathPostfix ? "/" + pathPostfix : ""}`;
+    if (
+      isConnected &&
+      address &&
+      connectedChainId === toChain &&
+      pathname !== possiblePath
+    ) {
+      console.log(
+        `redirecting to ${possiblePath} with chainId ${connectedChainId}`,
+      );
       router.replace(possiblePath);
     }
   }, [
@@ -89,7 +98,8 @@ export const RedirectWhenConnected: FC<{
     pathname,
     pathPrefix,
     router,
-    chainId,
+    connectedChainId,
+    toChain,
     pathPostfix,
   ]);
 

--- a/src/features/naming/components/ClaimNameForm.tsx
+++ b/src/features/naming/components/ClaimNameForm.tsx
@@ -25,6 +25,7 @@ import { useAuthSession } from "@/hooks/useAuthSession";
 import { useSwitchChain, useWaitForTransactionReceipt } from "wagmi";
 import { useWriteBulkMinterMint } from "@/wagmi";
 import { encodeIdentifier, parseIdentifier } from "../utils/networkUtils";
+import { needsConnectedChainSwitch } from "@/utils/connectedChain";
 
 function getTokenImageUrl(network: NetworkType, tokenId: number): string {
   switch (network) {
@@ -78,7 +79,11 @@ export const ClaimNameForm: FC<ClaimNameFormProps> = ({ network }) => {
   );
   const [mintError, setMintError] = useState<string | null>(null);
 
-  const isWrongChain = isConnected && connectedChainId !== expectedChainId;
+  const isWrongChain = needsConnectedChainSwitch({
+    isConnected,
+    connectedChainId,
+    targetChainId: expectedChainId,
+  });
   const needsSetup = !isConnected || !token || isWrongChain;
   const isBulkMinterNetwork = network === "base-sepolia" || network === "sepolia";
 

--- a/src/features/presale/components/PresaleCard.tsx
+++ b/src/features/presale/components/PresaleCard.tsx
@@ -1,10 +1,4 @@
-import React, {
-  ChangeEventHandler,
-  FC,
-  useCallback,
-  useEffect,
-  useState,
-} from "react";
+import React, { FC, useCallback, useEffect, useState } from "react";
 import * as sentry from "@sentry/nextjs";
 import Grid2 from "@mui/material/Unstable_Grid2";
 import Card from "@mui/material/Card";
@@ -14,51 +8,45 @@ import CardActions from "@mui/material/CardActions";
 import Typography from "@mui/material/Typography";
 import { useNotifications } from "@/features/notifications/Context";
 import { fameSaleAbi, fameSaleTokenAbi } from "@/wagmi";
-import {
-  useAccount,
-  useBalance,
-  useChainId,
-  useReadContracts,
-  useWriteContract,
-} from "wagmi";
+import { useBalance, useReadContracts, useWriteContract } from "wagmi";
+import { useAccount } from "@/hooks/useAccount";
 import { useProof } from "../hooks/useProof";
 import {
   ContractFunctionExecutionError,
   formatEther,
   formatUnits,
-  parseUnits,
 } from "viem";
-import FormGroup from "@mui/material/FormGroup";
 import Button from "@mui/material/Button";
 import { WrappedLink } from "@/components/WrappedLink";
 import { Transaction, TransactionsModal } from "./TransactionsModal";
-
-import { styled } from "@mui/material/styles";
-import MuiInput from "@mui/material/Input";
 import { shortenHash } from "@/utils/hash";
 import { ThankYouCard } from "./ThankYouCard";
 import { fameSaleAddress, fameSaleTokenAddress } from "../../fame/contract";
 import { ContributionGauge } from "./ContributionGauge";
 import { useAllocation } from "@/features/claim-to-fame/hooks/useAllocation";
 import { ClaimEnoughModal } from "./ClaimEnoughModal";
+import { base, sepolia } from "viem/chains";
 
-const Input = styled(MuiInput)`
-  width: 96px;
-`;
-
-const bigIntMax = (...args: bigint[]) => args.reduce((m, e) => (e > m ? e : m));
 const bigIntMin = (...args: bigint[]) => args.reduce((m, e) => (e < m ? e : m));
 
 function formatUnit(amount: bigint) {
   return Math.floor(Number(formatUnits(amount, 18)));
 }
 
-export const PresaleCard: FC<{}> = () => {
+type PresaleNetwork = "base" | "sepolia";
+
+function getSaleChain(network: PresaleNetwork) {
+  return network === "sepolia" ? sepolia : base;
+}
+
+export const PresaleCard: FC<{ network: PresaleNetwork }> = ({ network }) => {
   const [isBuyModalOpen, setIsBuyModalOpen] = useState(false);
   const [requestBuy, setRequestBuy] = useState<bigint>(0n);
 
-  const { address, chain } = useAccount();
-  const chainId = useChainId() as 11155111 | 8453;
+  const saleChain = getSaleChain(network);
+  const saleChainId = saleChain.id;
+  const saleExplorerUrl = saleChain.blockExplorers.default.url;
+  const { address } = useAccount();
   const { proof } = useProof();
 
   const { total } = useAllocation({
@@ -69,6 +57,7 @@ export const PresaleCard: FC<{}> = () => {
 
   const { data: userBalance } = useBalance({
     address,
+    chainId: saleChainId,
   });
 
   const {
@@ -86,40 +75,47 @@ export const PresaleCard: FC<{}> = () => {
     contracts: [
       {
         abi: fameSaleAbi,
-        address: fameSaleAddress(chainId),
+        address: fameSaleAddress(saleChainId),
         functionName: "raiseRemaining",
+        chainId: saleChainId,
       },
       {
         abi: fameSaleAbi,
-        address: fameSaleAddress(chainId),
+        address: fameSaleAddress(saleChainId),
         functionName: "canProve",
         args: proof && address ? [proof, address] : undefined,
+        chainId: saleChainId,
       },
       {
         abi: fameSaleAbi,
-        address: fameSaleAddress(chainId),
+        address: fameSaleAddress(saleChainId),
         functionName: "maxBuy",
+        chainId: saleChainId,
       },
       {
         abi: fameSaleAbi,
-        address: fameSaleAddress(chainId),
+        address: fameSaleAddress(saleChainId),
         functionName: "isPaused",
+        chainId: saleChainId,
       },
       {
         abi: fameSaleTokenAbi,
-        address: fameSaleTokenAddress(chainId),
+        address: fameSaleTokenAddress(saleChainId),
         functionName: "balanceOf",
         args: address ? [address] : undefined,
+        chainId: saleChainId,
       },
       {
         abi: fameSaleAbi,
-        address: fameSaleAddress(chainId),
+        address: fameSaleAddress(saleChainId),
         functionName: "fameTotalSupply",
+        chainId: saleChainId,
       },
       {
         abi: fameSaleAbi,
-        address: fameSaleAddress(chainId),
+        address: fameSaleAddress(saleChainId),
         functionName: "maxRaise",
+        chainId: saleChainId,
       },
     ],
   });
@@ -169,7 +165,8 @@ export const PresaleCard: FC<{}> = () => {
       try {
         const result = await writeFameSaleBuy({
           abi: fameSaleAbi,
-          address: fameSaleAddress(chainId),
+          address: fameSaleAddress(saleChainId),
+          chainId: saleChainId,
           functionName: "buy",
           args: [proof],
           value: requestBuy,
@@ -182,17 +179,13 @@ export const PresaleCard: FC<{}> = () => {
         ]);
         addNotification({
           id: "buy-pending",
-          message: chain?.blockExplorers?.default.url ? (
+          message: (
             <Typography color="black">
               transaction submitted{" "}
-              <WrappedLink
-                href={`${chain?.blockExplorers?.default.url}/tx/${result}`}
-              >
+              <WrappedLink href={`${saleExplorerUrl}/tx/${result}`}>
                 {shortenHash(result, 4)}
               </WrappedLink>
             </Typography>
-          ) : (
-            "transaction submitted"
           ),
           type: "success",
           autoHideMs: 5000,
@@ -237,10 +230,10 @@ export const PresaleCard: FC<{}> = () => {
     proof,
     writeFameSaleBuyStatus,
     writeFameSaleBuy,
-    chainId,
+    saleChainId,
     requestBuy,
     addNotification,
-    chain?.blockExplorers?.default.url,
+    saleExplorerUrl,
   ]);
 
   const onCloseTransactionModal = useCallback(() => {}, []);

--- a/src/hooks/useSweepAndWrap.ts
+++ b/src/hooks/useSweepAndWrap.ts
@@ -1,7 +1,7 @@
 "use client";
 import { useCallback, useState } from "react";
 import { useAccount } from "@/hooks/useAccount";
-import { useChainId, useSwitchChain, useWriteContract } from "wagmi";
+import { useSwitchChain, useWriteContract } from "wagmi";
 import {
   WaitForTransactionReceiptErrorType,
   type WriteContractErrorType,
@@ -16,6 +16,7 @@ import { prepareSweepPayload } from "@/lib/seaport/prepareSweepPayload";
 import type { Listing } from "opensea-js";
 import { waitForTransactionReceipt } from "viem/actions";
 import { client as mainnetClient } from "@/viem/mainnet-client";
+import { needsConnectedChainSwitch } from "@/utils/connectedChain";
 
 const FEE_BPS = 250n;
 
@@ -28,9 +29,12 @@ export function useSweepAndWrap() {
 
   const { data: wrapCostData } = useReadFameLadySocietyWrapCost();
   const { mutateAsync: switchChainAsync } = useSwitchChain();
-  const { address: receiver } = useAccount();
+  const {
+    address: receiver,
+    chainId: connectedChainId,
+    isConnected,
+  } = useAccount();
   const { mutateAsync: writeContractAsync } = useWriteContract();
-  const chainId = useChainId();
 
   const submitSweep = useCallback(
     async (selectedListings: Listing[]) => {
@@ -50,6 +54,7 @@ export function useSweepAndWrap() {
           const txHash = await writeContractAsync({
             abi: saveLadyAbi,
             address: saveLadyAddress[mainnet.id],
+            chainId: mainnet.id,
             functionName: "sweepAndWrap",
             args: [
               payload.advancedOrders,
@@ -110,15 +115,20 @@ export function useSweepAndWrap() {
   );
   const executeSweep = useCallback(
     async (selectedListings: Listing[]) => {
-      if (chainId === mainnet.id) {
-        return await submitSweep(selectedListings);
-      } else {
+      if (
+        needsConnectedChainSwitch({
+          isConnected,
+          connectedChainId,
+          targetChainId: mainnet.id,
+        })
+      ) {
         return await switchChainAsync({ chainId: mainnet.id }).then(() =>
           submitSweep(selectedListings),
         );
       }
+      return await submitSweep(selectedListings);
     },
-    [submitSweep, switchChainAsync, chainId],
+    [submitSweep, switchChainAsync, connectedChainId, isConnected],
   );
 
   return {

--- a/src/routes/FamePresale.tsx
+++ b/src/routes/FamePresale.tsx
@@ -6,30 +6,32 @@ import Typography from "@mui/material/Typography";
 import { Main } from "@/layouts/Main";
 import { SiteMenu } from "@/features/appbar/components/SiteMenu";
 import { LinksMenuItems } from "@/features/appbar/components/LinksMenuItems";
-import { FC, PropsWithChildren, ReactNode, useEffect } from "react";
+import { FC, PropsWithChildren, useEffect } from "react";
 import Grid2 from "@mui/material/Unstable_Grid2";
 import { PresaleCard } from "@/features/presale/components/PresaleCard";
-import { useChainId, useSwitchChain } from "wagmi";
+import { useSwitchChain } from "wagmi";
 import { useAccount } from "@/hooks/useAccount";
 import { base, sepolia } from "viem/chains";
 import { InfoCard } from "@/features/presale/components/InfoCard";
+import { needsConnectedChainSwitch } from "@/utils/connectedChain";
 
 const Content: FC<PropsWithChildren<{ network?: "base" | "sepolia" }>> = ({
   children,
   network,
 }) => {
-  const { isConnected } = useAccount();
-  const chainId = useChainId();
+  const { isConnected, chainId: connectedChainId } = useAccount();
   const { mutate: switchChain } = useSwitchChain();
-  const correctChain =
-    isConnected &&
-    ((network === "base" && chainId === base.id) ||
-      (network === "sepolia" && chainId === sepolia.id));
+  const targetChainId = network === "sepolia" ? sepolia.id : base.id;
+  const shouldSwitchChain = needsConnectedChainSwitch({
+    isConnected,
+    connectedChainId,
+    targetChainId,
+  });
   useEffect(() => {
-    if (isConnected && !correctChain) {
-      switchChain({ chainId: network === "sepolia" ? sepolia.id : base.id });
+    if (shouldSwitchChain) {
+      switchChain({ chainId: targetChainId });
     }
-  }, [correctChain, isConnected, network, switchChain]);
+  }, [shouldSwitchChain, switchChain, targetChainId]);
   return children;
 };
 
@@ -56,7 +58,7 @@ export const FamePresale: FC<{
         <Container maxWidth="xl" sx={{ py: 2, mt: 4 }}>
           <Grid2 container spacing={2}>
             <Content network={network}>
-              <PresaleCard />
+              <PresaleCard network={network} />
               <Grid2 xs={12} md={12}>
                 <InfoCard />
               </Grid2>

--- a/src/utils/connectedChain.test.ts
+++ b/src/utils/connectedChain.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { base, mainnet } from "viem/chains";
+import { needsConnectedChainSwitch } from "./connectedChain";
+
+describe("connected wallet chain switching", () => {
+  it("requires switching when a connected wallet is on Base for a mainnet target", () => {
+    assert.equal(
+      needsConnectedChainSwitch({
+        isConnected: true,
+        connectedChainId: base.id,
+        targetChainId: mainnet.id,
+      }),
+      true,
+    );
+  });
+
+  it("does not require switching when a connected wallet is already on the target", () => {
+    assert.equal(
+      needsConnectedChainSwitch({
+        isConnected: true,
+        connectedChainId: mainnet.id,
+        targetChainId: mainnet.id,
+      }),
+      false,
+    );
+  });
+
+  it("requires switching when a connected wallet has an unsupported or unavailable chain id", () => {
+    assert.equal(
+      needsConnectedChainSwitch({
+        isConnected: true,
+        connectedChainId: undefined,
+        targetChainId: mainnet.id,
+      }),
+      true,
+    );
+
+    assert.equal(
+      needsConnectedChainSwitch({
+        isConnected: true,
+        connectedChainId: 999_999,
+        targetChainId: mainnet.id,
+      }),
+      true,
+    );
+  });
+
+  it("does not request a switch for a disconnected wallet", () => {
+    assert.equal(
+      needsConnectedChainSwitch({
+        isConnected: false,
+        connectedChainId: base.id,
+        targetChainId: mainnet.id,
+      }),
+      false,
+    );
+
+    assert.equal(
+      needsConnectedChainSwitch({
+        isConnected: false,
+        connectedChainId: undefined,
+        targetChainId: mainnet.id,
+      }),
+      false,
+    );
+  });
+});

--- a/src/utils/connectedChain.ts
+++ b/src/utils/connectedChain.ts
@@ -1,0 +1,13 @@
+export type ConnectedChainSwitchInput = {
+  isConnected: boolean;
+  connectedChainId?: number;
+  targetChainId: number;
+};
+
+export function needsConnectedChainSwitch({
+  isConnected,
+  connectedChainId,
+  targetChainId,
+}: ConnectedChainSwitchInput) {
+  return isConnected && connectedChainId !== targetChainId;
+}


### PR DESCRIPTION
## Summary

Compact quote helper traffic now stays scoped to direct FAME pools. Non-direct route dependencies remain visible for route planning and diagnostics, but they no longer advertise producer or compact quote eligibility.

This keeps the selected direct-FAME Slipstream lane eligible while forcing V4 ZORA/ETH and BASEDFLICK/ZORA dependencies back to live fallback. The quote API adapter coverage now exercises direct-FAME reserve and Slipstream rows for helper behavior, so the tests keep protecting batching, validation, and fallback without re-enabling high-activity Base pools.

## Validation

- `bun test src/features/fame-swap/solver/poolStateRegistry.test.ts src/features/fame-swap/solver/poolActivation.test.ts src/features/fame-swap/solver/quotes/indexedQuoteApiAdapter.test.ts src/features/fame-swap/solver/quotes/indexedPoolStateClient.test.ts src/features/fame-swap/solver/quotes/indexedQuoteApiClient.test.ts src/app/api/fame/swap/quote/route.test.ts`
- `yarn tsc --noEmit --pretty false --tsBuildInfoFile /private/tmp/fls-www-tsconfig.tsbuildinfo`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
