### PR TITLE
fix(fame): stabilize creator portal role checks

### DIFF
--- a/src/app/fame/creator/[address]/CreatorPortal.tsx
+++ b/src/app/fame/creator/[address]/CreatorPortal.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react";
 import { useAccount } from "@/hooks/useAccount";
 import { useRouter } from "next/navigation";
+import { isAddressEqual } from "viem";
 import { useHasCreatorRole } from "./useHasCreatorRole";
 import { TokenSelection } from "./TokenSelection";
 import { MetadataSwap } from "./MetadataSwap";
@@ -25,26 +26,67 @@ export function CreatorPortal({
   mintPool,
   artPool,
 }: CreatorPortalProps) {
-  const { address: connectedAddress } = useAccount();
+  const { address: connectedAddress, isConnecting } = useAccount();
   const router = useRouter();
   const roles = useHasCreatorRole(address);
   const [selectedTokenId, setSelectedTokenId] = useState<bigint | null>(null);
-
-  useEffect(() => {
-    // Redirect if not connected or not the correct address
-    if (!connectedAddress || connectedAddress !== address) {
-      router.push("/fame/creator");
-    }
-  }, [connectedAddress, address, router]);
-
-  // Redirect if user has no relevant roles
-  const hasAnyRole = !!(
-    roles?.isCreator ||
-    roles?.isBanisher ||
-    roles?.isArtPoolManager
+  const isConnectedAddress = Boolean(
+    connectedAddress && isAddressEqual(connectedAddress, address),
   );
 
-  if (!hasAnyRole) {
+  useEffect(() => {
+    if (isConnecting) return;
+
+    // Redirect if not connected or not the correct address
+    if (!isConnectedAddress) {
+      router.push("/fame/creator");
+    }
+  }, [isConnecting, isConnectedAddress, router]);
+
+  if (!isConnectedAddress) {
+    return null;
+  }
+
+  if (roles.isLoading || roles.isPending) {
+    return (
+      <div className="w-full pl-4 py-8">
+        <div className="max-w-4xl mx-auto">
+          <h1 className="text-4xl font-bold mb-6 text-center">
+            Checking Permissions
+          </h1>
+          <p className="text-lg text-center mb-6">
+            Verifying Creator Portal roles on Base.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (roles.isError) {
+    return (
+      <div className="w-full pl-4 py-8">
+        <div className="max-w-4xl mx-auto">
+          <h1 className="text-4xl font-bold mb-6 text-center">
+            Could Not Verify Permissions
+          </h1>
+          <p className="text-lg text-center mb-6">
+            The Creator Portal could not read this wallet&apos;s roles from the
+            CreatorMagic contract on Base.
+          </p>
+          <div className="text-center">
+            <button
+              onClick={() => void roles.refetch()}
+              className="bg-blue-500 text-white px-6 py-3 rounded-md hover:bg-blue-600"
+            >
+              Try Again
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!roles.hasAnyRole) {
     return (
       <div className="w-full pl-4 py-8">
         <div className="max-w-4xl mx-auto">

--- a/src/app/fame/creator/[address]/CreatorPortal.tsx
+++ b/src/app/fame/creator/[address]/CreatorPortal.tsx
@@ -43,6 +43,12 @@ export function CreatorPortal({
     }
   }, [isConnecting, isConnectedAddress, router]);
 
+  useEffect(() => {
+    if (!roles.isError || !roles.errorMessage) return;
+
+    console.error("Creator Portal role read failed", roles.errorMessage);
+  }, [roles.errorMessage, roles.isError]);
+
   if (!isConnectedAddress) {
     return null;
   }
@@ -73,6 +79,11 @@ export function CreatorPortal({
             We could not verify this wallet&apos;s Creator Portal permissions on
             Base. This is a read failure, not a confirmed missing-role denial.
           </p>
+          {roles.errorMessage && (
+            <p className="text-sm text-center mb-6 text-gray-400">
+              Read failure: {roles.errorMessage}
+            </p>
+          )}
           <div className="text-center">
             <button
               onClick={() => void roles.refetch()}

--- a/src/app/fame/creator/[address]/CreatorPortal.tsx
+++ b/src/app/fame/creator/[address]/CreatorPortal.tsx
@@ -67,11 +67,11 @@ export function CreatorPortal({
       <div className="w-full pl-4 py-8">
         <div className="max-w-4xl mx-auto">
           <h1 className="text-4xl font-bold mb-6 text-center">
-            Could Not Verify Permissions
+            Could Not Check Access
           </h1>
           <p className="text-lg text-center mb-6">
-            The Creator Portal could not read this wallet&apos;s roles from the
-            CreatorMagic contract on Base.
+            We could not verify this wallet&apos;s Creator Portal permissions on
+            Base. This is a read failure, not a confirmed missing-role denial.
           </p>
           <div className="text-center">
             <button

--- a/src/app/fame/creator/[address]/useHasCreatorRole.test.ts
+++ b/src/app/fame/creator/[address]/useHasCreatorRole.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { decodeCreatorPortalRoles } from "./useHasCreatorRole";
+
+describe("decodeCreatorPortalRoles", () => {
+  it("does not grant access while the role read has no data", () => {
+    assert.deepEqual(decodeCreatorPortalRoles(), {
+      isCreator: false,
+      isBanisher: false,
+      isArtPoolManager: false,
+      hasAnyRole: false,
+      raw: 0,
+    });
+  });
+
+  it("recognizes the deployed CreatorArtistMagic role bits", () => {
+    assert.deepEqual(decodeCreatorPortalRoles(2n), {
+      isCreator: true,
+      isBanisher: false,
+      isArtPoolManager: false,
+      hasAnyRole: true,
+      raw: 2,
+    });
+
+    assert.deepEqual(decodeCreatorPortalRoles(4n), {
+      isCreator: false,
+      isBanisher: true,
+      isArtPoolManager: false,
+      hasAnyRole: true,
+      raw: 4,
+    });
+
+    assert.deepEqual(decodeCreatorPortalRoles(8n), {
+      isCreator: false,
+      isBanisher: false,
+      isArtPoolManager: true,
+      hasAnyRole: true,
+      raw: 8,
+    });
+  });
+
+  it("preserves combined role masks from wallets with historical grants", () => {
+    assert.deepEqual(decodeCreatorPortalRoles(3n), {
+      isCreator: true,
+      isBanisher: false,
+      isArtPoolManager: false,
+      hasAnyRole: true,
+      raw: 3,
+    });
+  });
+});

--- a/src/app/fame/creator/[address]/useHasCreatorRole.test.ts
+++ b/src/app/fame/creator/[address]/useHasCreatorRole.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { decodeCreatorPortalRoles } from "./useHasCreatorRole";
+import {
+  decodeCreatorPortalRoles,
+  formatCreatorRoleReadError,
+} from "./useHasCreatorRole";
 
 describe("decodeCreatorPortalRoles", () => {
   it("does not grant access while the role read has no data", () => {
@@ -47,5 +50,15 @@ describe("decodeCreatorPortalRoles", () => {
       hasAnyRole: true,
       raw: 3,
     });
+  });
+
+  it("formats role read errors without leaking full RPC URLs", () => {
+    assert.equal(
+      formatCreatorRoleReadError({
+        shortMessage:
+          "HTTP request failed. URL: https://example.rpc-provider.test/v2/secret-key",
+      }),
+      "HTTP request failed. URL: https://example.rpc-provider.test/...",
+    );
   });
 });

--- a/src/app/fame/creator/[address]/useHasCreatorRole.ts
+++ b/src/app/fame/creator/[address]/useHasCreatorRole.ts
@@ -6,26 +6,53 @@ import { base } from "viem/chains";
 import { useReadContract } from "wagmi";
 
 // Role bit masks (OwnableRoles uses _ROLE_0 = 1 << 0, _ROLE_1 = 1 << 1, ...)
-const ROLE_CREATOR = 1 << 1; // _ROLE_1
-const ROLE_BANISHER = 1 << 2; // _ROLE_2
-const ROLE_ART_POOL_MANAGER = 1 << 3; // _ROLE_3
+const ROLE_CREATOR = 1n << 1n; // _ROLE_1
+const ROLE_BANISHER = 1n << 2n; // _ROLE_2
+const ROLE_ART_POOL_MANAGER = 1n << 3n; // _ROLE_3
+
+export type CreatorPortalRoles = {
+  isCreator: boolean;
+  isBanisher: boolean;
+  isArtPoolManager: boolean;
+  hasAnyRole: boolean;
+  raw: number;
+};
+
+export function decodeCreatorPortalRoles(roles?: bigint): CreatorPortalRoles {
+  const bitmask = roles ?? 0n;
+  const isCreator = (bitmask & ROLE_CREATOR) !== 0n;
+  const isBanisher = (bitmask & ROLE_BANISHER) !== 0n;
+  const isArtPoolManager = (bitmask & ROLE_ART_POOL_MANAGER) !== 0n;
+
+  return {
+    isCreator,
+    isBanisher,
+    isArtPoolManager,
+    hasAnyRole: isCreator || isBanisher || isArtPoolManager,
+    raw: Number(bitmask),
+  };
+}
 
 export function useHasCreatorRole(address?: `0x${string}`) {
   // read raw roles bitmask from contract
-  const { data: roles } = useReadContract({
+  const rolesRead = useReadContract({
+    chainId: base.id,
     address: creatorArtistMagicAddress(base.id),
     abi: creatorArtistMagicAbi,
     functionName: "rolesOf",
     args: address ? [address] : undefined,
+    query: {
+      enabled: Boolean(address),
+    },
   });
 
-  const bitmask =
-    typeof roles === "bigint" ? Number(roles) : Number(roles ?? 0);
-
   return {
-    isCreator: Boolean(bitmask & ROLE_CREATOR),
-    isBanisher: Boolean(bitmask & ROLE_BANISHER),
-    isArtPoolManager: Boolean(bitmask & ROLE_ART_POOL_MANAGER),
-    raw: bitmask,
+    ...decodeCreatorPortalRoles(rolesRead.data),
+    isLoading: rolesRead.isLoading,
+    isPending: rolesRead.isPending,
+    isError: rolesRead.isError,
+    isSuccess: rolesRead.isSuccess,
+    error: rolesRead.error,
+    refetch: rolesRead.refetch,
   };
 }

--- a/src/app/fame/creator/[address]/useHasCreatorRole.ts
+++ b/src/app/fame/creator/[address]/useHasCreatorRole.ts
@@ -33,6 +33,40 @@ export function decodeCreatorPortalRoles(roles?: bigint): CreatorPortalRoles {
   };
 }
 
+function redactUrl(rawUrl: string) {
+  try {
+    const url = new URL(rawUrl);
+    return `${url.protocol}//${url.host}/...`;
+  } catch {
+    return "[redacted url]";
+  }
+}
+
+export function formatCreatorRoleReadError(error: unknown) {
+  const maybeViemError = error as
+    | {
+        message?: unknown;
+        shortMessage?: unknown;
+      }
+    | undefined;
+  const message =
+    typeof maybeViemError?.shortMessage === "string"
+      ? maybeViemError.shortMessage
+      : typeof maybeViemError?.message === "string"
+        ? maybeViemError.message
+        : typeof error === "string"
+          ? error
+          : undefined;
+
+  if (!message) return undefined;
+
+  return message
+    .replace(/https?:\/\/[^\s)]+/g, redactUrl)
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 280);
+}
+
 export function useHasCreatorRole(address?: `0x${string}`) {
   // read raw roles bitmask from contract
   const rolesRead = useReadContract({
@@ -53,6 +87,7 @@ export function useHasCreatorRole(address?: `0x${string}`) {
     isError: rolesRead.isError,
     isSuccess: rolesRead.isSuccess,
     error: rolesRead.error,
+    errorMessage: formatCreatorRoleReadError(rolesRead.error),
     refetch: rolesRead.refetch,
   };
 }

--- a/src/app/fame/creator/page.tsx
+++ b/src/app/fame/creator/page.tsx
@@ -6,7 +6,6 @@ import { useAccount } from "@/hooks/useAccount";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { useHasCreatorRole } from "./[address]/useHasCreatorRole";
-import { base } from "viem/chains";
 
 const videoWipeUrl = "/videos/wipe-1.mp4";
 
@@ -16,10 +15,10 @@ export default function CreatorPage() {
   const roles = useHasCreatorRole(address);
 
   useEffect(() => {
-    if (isConnected && address) {
+    if (isConnected && address && roles.isSuccess && roles.hasAnyRole) {
       router.push(`/fame/creator/${address}`);
     }
-  }, [isConnected, address, router]);
+  }, [isConnected, address, roles.isSuccess, roles.hasAnyRole, router]);
 
   return (
     <>

--- a/src/context/wagmiConfig.ts
+++ b/src/context/wagmiConfig.ts
@@ -9,6 +9,7 @@ import {
 } from "wagmi/chains";
 import { Chain, Transport } from "viem";
 import { parseRpcUrls } from "@/viem/rpcUrls";
+import { baseRpcUrls } from "@/viem/baseRpcUrls";
 
 const sepoliaRpcUrls = parseRpcUrls(
   process.env.NEXT_PUBLIC_SEPOLIA_RPC_JSON,
@@ -52,11 +53,13 @@ export const sepoliaOnly = {
 export const baseSepoliaOnly = {
   chains: [base, sepolia],
   transports: {
-    [base.id]: fallback([
-      http(process.env.NEXT_PUBLIC_BASE_RPC_URL_1!, {
-        batch: true,
-      }),
-    ]),
+    [base.id]: fallback(
+      baseRpcUrls().map((rpc) =>
+        http(rpc, {
+          batch: true,
+        }),
+      ),
+    ),
     [sepolia.id]: fallback(
       sepoliaRpcUrls.map((rpc) => http(rpc, { batch: true })),
     ),

--- a/src/service/tokenHolderList.ts
+++ b/src/service/tokenHolderList.ts
@@ -10,30 +10,24 @@ import {
   http,
 } from "viem";
 import { base } from "viem/chains";
+import { baseRpcUrls } from "@/viem/baseRpcUrls";
 
 const REVALIDATE_INTERVAL = 60 * 60;
 
 export const client = createPublicClient({
-  transport: fallback([
-    http(process.env.NEXT_PUBLIC_BASE_RPC_URL_1, {
-      batch: true,
-      retryCount: 10,
-      fetchOptions: {
-        next: {
-          revalidate: REVALIDATE_INTERVAL,
+  transport: fallback(
+    baseRpcUrls().map((rpc) =>
+      http(rpc, {
+        batch: true,
+        retryCount: 10,
+        fetchOptions: {
+          next: {
+            revalidate: REVALIDATE_INTERVAL,
+          },
         },
-      },
-    }),
-    // http(process.env.NEXT_PUBLIC_BASE_RPC_URL_2, {
-    //   batch: true,
-    //   retryCount: 10,
-    //   fetchOptions: {
-    //     next: {
-    //       revalidate: REVALIDATE_INTERVAL,
-    //     },
-    //   },
-    // }),
-  ]),
+      }),
+    ),
+  ),
   chain: base,
 });
 

--- a/src/viem/base-client.ts
+++ b/src/viem/base-client.ts
@@ -8,19 +8,24 @@ import {
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { base } from "viem/chains";
+import { baseRpcUrls } from "./baseRpcUrls";
+
+const baseRpcTransportConfig = {
+  batch: true,
+  retryCount: 10,
+  fetchOptions: {
+    next: {
+      revalidate: 60,
+    },
+  },
+} satisfies HttpTransportConfig;
+
+function createBaseRpcTransports() {
+  return baseRpcUrls().map((rpc) => http(rpc, baseRpcTransportConfig));
+}
 
 export const client = createPublicClient({
-  transport: fallback([
-    http(process.env.NEXT_PUBLIC_BASE_RPC_URL_1, {
-      batch: true,
-      retryCount: 10,
-      fetchOptions: {
-        next: {
-          revalidate: 60,
-        },
-      },
-    }),
-  ]),
+  transport: fallback(createBaseRpcTransports()),
   chain: base,
   batch: {
     multicall: true,
@@ -28,17 +33,7 @@ export const client = createPublicClient({
 });
 
 export const walletClient = createWalletClient({
-  transport: fallback([
-    http(process.env.NEXT_PUBLIC_BASE_RPC_URL_1, {
-      batch: true,
-      retryCount: 10,
-      fetchOptions: {
-        next: {
-          revalidate: 60,
-        },
-      },
-    }),
-  ]),
+  transport: fallback(createBaseRpcTransports()),
   chain: base,
 });
 

--- a/src/viem/baseRpcUrls.test.ts
+++ b/src/viem/baseRpcUrls.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { baseRpcUrls } from "./baseRpcUrls";
+
+const originalBaseRpcUrl1 = process.env.NEXT_PUBLIC_BASE_RPC_URL_1;
+const originalBaseRpcUrl2 = process.env.NEXT_PUBLIC_BASE_RPC_URL_2;
+
+function restoreEnv(name: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+afterEach(() => {
+  restoreEnv("NEXT_PUBLIC_BASE_RPC_URL_1", originalBaseRpcUrl1);
+  restoreEnv("NEXT_PUBLIC_BASE_RPC_URL_2", originalBaseRpcUrl2);
+});
+
+describe("baseRpcUrls", () => {
+  it("keeps configured Base RPC URLs ahead of the public fallback", () => {
+    process.env.NEXT_PUBLIC_BASE_RPC_URL_1 = "https://primary.example";
+    process.env.NEXT_PUBLIC_BASE_RPC_URL_2 = "https://secondary.example";
+
+    assert.deepEqual(baseRpcUrls(), [
+      "https://primary.example",
+      "https://secondary.example",
+      "https://mainnet.base.org",
+    ]);
+  });
+
+  it("deduplicates the public Base fallback", () => {
+    process.env.NEXT_PUBLIC_BASE_RPC_URL_1 = "https://mainnet.base.org";
+    delete process.env.NEXT_PUBLIC_BASE_RPC_URL_2;
+
+    assert.deepEqual(baseRpcUrls(), ["https://mainnet.base.org"]);
+  });
+});

--- a/src/viem/baseRpcUrls.ts
+++ b/src/viem/baseRpcUrls.ts
@@ -1,0 +1,11 @@
+const PUBLIC_BASE_RPC_URL = "https://mainnet.base.org";
+
+export function baseRpcUrls() {
+  const urls = [
+    process.env.NEXT_PUBLIC_BASE_RPC_URL_1,
+    process.env.NEXT_PUBLIC_BASE_RPC_URL_2,
+    PUBLIC_BASE_RPC_URL,
+  ].filter((url): url is string => Boolean(url));
+
+  return [...new Set(urls)];
+}


### PR DESCRIPTION
## Summary

Creator wallets no longer get shown Access Denied just because the CreatorMagic role read has not resolved or failed transiently. The Creator Portal now waits while Base roles are being checked, shows a retryable verification error if the contract read fails, and only denies access after a successful read proves the wallet lacks creator/admin roles.

Root cause found during debugging: the deployed Base RPC transport was pinned to a single `lb.drpc.org` endpoint that currently returns HTTP 403 / `User balance exceeded`. The wallet and contract state are fine: a live Base read returns `rolesOf(0xF11C...3324) = 3`. The app now keeps configured Base RPCs first but adds `https://mainnet.base.org` as a public fallback for browser wagmi reads and server Base read clients.

The role lookup is pinned to Base to match the CreatorMagic address, and the landing page waits for a successful role read before auto-routing connected wallets into the address portal. Role bit decoding is now covered for the deployed CREATOR/BANISHER/ART_POOL_MANAGER masks, including the historical combined `3n` grant.

## Test Plan

- `bun test 'src/app/fame/creator/[address]/useHasCreatorRole.test.ts' src/viem/baseRpcUrls.test.ts`
- `yarn eslint 'src/app/fame/creator/[address]/useHasCreatorRole.ts' 'src/app/fame/creator/[address]/useHasCreatorRole.test.ts' 'src/app/fame/creator/[address]/CreatorPortal.tsx' src/context/wagmiConfig.ts src/viem/base-client.ts src/viem/baseRpcUrls.ts src/viem/baseRpcUrls.test.ts src/service/tokenHolderList.ts`
- `yarn tsc --noEmit --pretty false`
- live smoke: viem fallback with the exhausted production dRPC endpoint first and `mainnet.base.org` second returns `rolesOf = 3`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
