### PR TITLE
feat(fame): sponsor creator metadata uploads

### DIFF
--- a/src/app/api/fame/creator/metadata/route.test.ts
+++ b/src/app/api/fame/creator/metadata/route.test.ts
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { NextRequest } from "next/server";
+import { handleCreatorMetadataUpload } from "./route";
+import type { IrysSponsoredUploader } from "@/service/irys_sponsored_upload";
+
+const CREATOR = "0x0000000000000000000000000000000000000001" as const;
+const OTHER = "0x0000000000000000000000000000000000000002" as const;
+
+function makeRequest(opts: {
+  address?: string;
+  tokenId?: string;
+  mode?: string;
+  image?: File | string;
+}) {
+  const formData = new FormData();
+  if (opts.address !== undefined) formData.set("address", opts.address);
+  if (opts.tokenId !== undefined) formData.set("tokenId", opts.tokenId);
+  if (opts.mode !== undefined) formData.set("mode", opts.mode);
+  if (opts.image !== undefined) formData.set("image", opts.image);
+
+  return new NextRequest("http://localhost/api/fame/creator/metadata", {
+    method: "POST",
+    body: formData,
+  });
+}
+
+function imageFile(type = "image/png", name = "creator.png") {
+  return new File(["image-bytes"], name, { type });
+}
+
+function deps(opts: {
+  sessionAddress?: `0x${string}` | null;
+  roles?: bigint;
+  uploads?: Array<{ content: string | Uint8Array; tags: unknown }>;
+}) {
+  const uploads = opts.uploads ?? [];
+  const uploader: IrysSponsoredUploader = {
+    getPrice: async () => 1n,
+    getBalance: async () => 10n,
+    fund: async () => undefined,
+    upload: async (content, uploadOpts) => {
+      uploads.push({ content, tags: uploadOpts.tags });
+      return { id: uploads.length === 1 ? "image-tx" : "metadata-tx" };
+    },
+  };
+
+  return {
+    getSession: () =>
+      opts.sessionAddress === null
+        ? null
+        : {
+            address: opts.sessionAddress ?? CREATOR,
+            chainId: 8453,
+            expiresAt: Date.now() + 60_000,
+          },
+    readRoles: async () => opts.roles ?? 0n,
+    createUploader: async () => uploader,
+    getMaxFundAmount: async () => 100n,
+  };
+}
+
+describe("/api/fame/creator/metadata", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const response = await handleCreatorMetadataUpload(
+      makeRequest({
+        address: CREATOR,
+        tokenId: "123",
+        mode: "update",
+        image: imageFile(),
+      }),
+      deps({ sessionAddress: null }),
+    );
+
+    assert.equal(response.status, 401);
+  });
+
+  it("returns 403 when the session address does not match the request address", async () => {
+    const response = await handleCreatorMetadataUpload(
+      makeRequest({
+        address: OTHER,
+        tokenId: "123",
+        mode: "update",
+        image: imageFile(),
+      }),
+      deps({ sessionAddress: CREATOR, roles: 2n }),
+    );
+
+    assert.equal(response.status, 403);
+  });
+
+  it("returns 400 when the image is missing or unsupported", async () => {
+    const missing = await handleCreatorMetadataUpload(
+      makeRequest({
+        address: CREATOR,
+        tokenId: "123",
+        mode: "update",
+      }),
+      deps({ roles: 2n }),
+    );
+    assert.equal(missing.status, 400);
+
+    const unsupported = await handleCreatorMetadataUpload(
+      makeRequest({
+        address: CREATOR,
+        tokenId: "123",
+        mode: "update",
+        image: imageFile("text/plain", "creator.txt"),
+      }),
+      deps({ roles: 2n }),
+    );
+    assert.equal(unsupported.status, 400);
+  });
+
+  it("allows art pool managers to sponsor art-pool metadata", async () => {
+    const response = await handleCreatorMetadataUpload(
+      makeRequest({
+        address: CREATOR,
+        tokenId: "123",
+        mode: "art",
+        image: imageFile(),
+      }),
+      deps({ roles: 8n }),
+    );
+
+    assert.equal(response.status, 200);
+  });
+
+  it("rejects wallets without the required mode role", async () => {
+    const response = await handleCreatorMetadataUpload(
+      makeRequest({
+        address: CREATOR,
+        tokenId: "123",
+        mode: "update",
+        image: imageFile(),
+      }),
+      deps({ roles: 0n }),
+    );
+
+    assert.equal(response.status, 403);
+  });
+
+  it("uploads the image, then generated metadata, and returns both gateway URIs", async () => {
+    const uploads: Array<{ content: string | Uint8Array; tags: unknown }> = [];
+    const response = await handleCreatorMetadataUpload(
+      makeRequest({
+        address: CREATOR,
+        tokenId: "123",
+        mode: "update",
+        image: imageFile(),
+      }),
+      deps({ roles: 2n, uploads }),
+    );
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      imageUri: "https://gateway.irys.xyz/image-tx",
+      metadataUri: "https://gateway.irys.xyz/metadata-tx",
+    });
+    assert.equal(uploads.length, 2);
+    assert.ok(uploads[0].content instanceof Uint8Array);
+    assert.equal(
+      JSON.parse(uploads[1].content as string).image,
+      "https://gateway.irys.xyz/image-tx",
+    );
+  });
+});

--- a/src/app/api/fame/creator/metadata/route.test.ts
+++ b/src/app/api/fame/creator/metadata/route.test.ts
@@ -141,7 +141,7 @@ describe("/api/fame/creator/metadata", () => {
   });
 
   it("uploads the image, then generated metadata, and returns both gateway URIs", async () => {
-    const uploads: Array<{ content: string | Uint8Array; tags: unknown }> = [];
+    const uploads: Array<{ content: Buffer; tags: unknown }> = [];
     const response = await handleCreatorMetadataUpload(
       makeRequest({
         address: CREATOR,
@@ -158,9 +158,10 @@ describe("/api/fame/creator/metadata", () => {
       metadataUri: "https://gateway.irys.xyz/metadata-tx",
     });
     assert.equal(uploads.length, 2);
-    assert.ok(uploads[0].content instanceof Uint8Array);
+    assert.ok(Buffer.isBuffer(uploads[0].content));
+    assert.ok(Buffer.isBuffer(uploads[1].content));
     assert.equal(
-      JSON.parse(uploads[1].content as string).image,
+      JSON.parse(uploads[1].content.toString("utf-8")).image,
       "https://gateway.irys.xyz/image-tx",
     );
   });

--- a/src/app/api/fame/creator/metadata/route.ts
+++ b/src/app/api/fame/creator/metadata/route.ts
@@ -1,0 +1,203 @@
+import * as sentry from "@sentry/nextjs";
+import { NextRequest, NextResponse } from "next/server";
+import { getSession, type SessionData } from "@/app/siwe/session-utils";
+import { creatorArtistMagicAddress } from "@/features/fame/contract";
+import {
+  canUploadCreatorMetadata,
+  createCreatorMetadataJson,
+  decodeCreatorPortalRoles,
+  isCreatorMetadataUploadMode,
+} from "@/features/fame/creatorMetadata";
+import { client as basePublicClient } from "@/viem/base-client";
+import { creatorArtistMagicAbi } from "@/wagmi";
+import { buildNodeIrysUploader } from "@/service/irys_backend_client_node";
+import {
+  ensureIrysBalance,
+  type IrysSponsoredUploader,
+  uploadToIrys,
+} from "@/service/irys_sponsored_upload";
+import { getBalance, readContract } from "viem/actions";
+import {
+  isAddress,
+  isAddressEqual,
+  keccak256,
+  type Address,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { base } from "viem/chains";
+
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+const SUPPORTED_IMAGE_TYPES = new Set([
+  "image/gif",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+]);
+
+type CreatorMetadataUploadDeps = {
+  getSession: (request: NextRequest) => SessionData | null;
+  readRoles: (address: Address) => Promise<bigint>;
+  createUploader: () => Promise<IrysSponsoredUploader>;
+  getMaxFundAmount: () => Promise<bigint>;
+};
+
+function jsonError(message: string, status: number) {
+  return NextResponse.json({ error: message }, { status });
+}
+
+function sanitizeFilename(filename: string) {
+  const sanitized = filename.replace(/[^a-zA-Z0-9._-]/g, "-").slice(0, 80);
+  return sanitized || "creator-image";
+}
+
+function contentLength(bytes: Uint8Array | string) {
+  return typeof bytes === "string"
+    ? new TextEncoder().encode(bytes).length
+    : bytes.byteLength;
+}
+
+function contentHash(bytes: Uint8Array | string) {
+  return keccak256(
+    typeof bytes === "string" ? new TextEncoder().encode(bytes) : bytes,
+  ).slice(2);
+}
+
+async function defaultGetMaxFundAmount() {
+  const privateKey = process.env.METADATA_PRIVATE_KEY;
+  if (!privateKey) {
+    throw new Error("METADATA_PRIVATE_KEY not configured");
+  }
+  const account = privateKeyToAccount(privateKey as `0x${string}`);
+  const accountBalance = await getBalance(basePublicClient, {
+    address: account.address,
+  });
+  const estimatedGas = 21000n * 20n;
+  return accountBalance > estimatedGas ? accountBalance - estimatedGas : 0n;
+}
+
+async function defaultCreateUploader() {
+  const privateKey = process.env.METADATA_PRIVATE_KEY;
+  if (!privateKey) {
+    throw new Error("METADATA_PRIVATE_KEY not configured");
+  }
+  return buildNodeIrysUploader({
+    privateKey: privateKey as `0x${string}`,
+  }) as Promise<IrysSponsoredUploader>;
+}
+
+const defaultDeps: CreatorMetadataUploadDeps = {
+  getSession,
+  readRoles: async (address) =>
+    readContract(basePublicClient, {
+      address: creatorArtistMagicAddress(base.id),
+      abi: creatorArtistMagicAbi,
+      functionName: "rolesOf",
+      args: [address],
+    }),
+  createUploader: defaultCreateUploader,
+  getMaxFundAmount: defaultGetMaxFundAmount,
+};
+
+export async function handleCreatorMetadataUpload(
+  request: NextRequest,
+  deps: CreatorMetadataUploadDeps = defaultDeps,
+) {
+  const session = deps.getSession(request);
+  if (!session) {
+    return jsonError("Unauthorized", 401);
+  }
+
+  const formData = await request.formData();
+  const address = formData.get("address");
+  const tokenIdRaw = formData.get("tokenId");
+  const mode = formData.get("mode");
+  const image = formData.get("image");
+
+  if (typeof address !== "string" || !isAddress(address)) {
+    return jsonError("Invalid address", 400);
+  }
+  if (!isAddressEqual(address, session.address)) {
+    return jsonError("Unauthorized", 403);
+  }
+  if (typeof tokenIdRaw !== "string" || !/^\d+$/.test(tokenIdRaw)) {
+    return jsonError("Invalid tokenId", 400);
+  }
+  const tokenId = Number(tokenIdRaw);
+  if (!Number.isSafeInteger(tokenId)) {
+    return jsonError("Invalid tokenId", 400);
+  }
+  if (!isCreatorMetadataUploadMode(mode)) {
+    return jsonError("Invalid mode", 400);
+  }
+  if (!(image instanceof File)) {
+    return jsonError("Missing image", 400);
+  }
+  if (!SUPPORTED_IMAGE_TYPES.has(image.type)) {
+    return jsonError("Unsupported image type", 400);
+  }
+  if (image.size <= 0 || image.size > MAX_IMAGE_BYTES) {
+    return jsonError("Invalid image size", 400);
+  }
+
+  const roles = decodeCreatorPortalRoles(await deps.readRoles(address));
+  if (!canUploadCreatorMetadata(roles, mode)) {
+    return jsonError("Forbidden", 403);
+  }
+
+  const imageBytes = new Uint8Array(await image.arrayBuffer());
+  const uploader = await deps.createUploader();
+
+  await ensureIrysBalance({
+    uploader,
+    bytes: imageBytes.byteLength,
+    maxFundAmount: await deps.getMaxFundAmount(),
+    logContext: { address, tokenId, kind: "creator-image" },
+  });
+  const imageUri = await uploadToIrys({
+    uploader,
+    content: imageBytes,
+    tags: [
+      { name: "Content-Type", value: image.type },
+      { name: "Content-Length", value: String(imageBytes.byteLength) },
+      {
+        name: "Content-Disposition",
+        value: `attachment; filename="${sanitizeFilename(image.name)}"`,
+      },
+      { name: "Content-Hash", value: contentHash(imageBytes) },
+    ],
+  });
+
+  const metadataContent = createCreatorMetadataJson(tokenId, imageUri);
+  const metadataBytes = contentLength(metadataContent);
+  await ensureIrysBalance({
+    uploader,
+    bytes: metadataBytes,
+    maxFundAmount: await deps.getMaxFundAmount(),
+    logContext: { address, tokenId, kind: "creator-metadata" },
+  });
+  const metadataUri = await uploadToIrys({
+    uploader,
+    content: metadataContent,
+    tags: [
+      { name: "Content-Type", value: "application/json" },
+      { name: "Content-Length", value: String(metadataBytes) },
+      {
+        name: "Content-Disposition",
+        value: `attachment; filename="fame-creator-${tokenId}.json"`,
+      },
+      { name: "Content-Hash", value: contentHash(metadataContent) },
+    ],
+  });
+
+  return NextResponse.json({ imageUri, metadataUri });
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    return await handleCreatorMetadataUpload(request);
+  } catch (error) {
+    console.error(error);
+    sentry.captureException(error);
+    return jsonError("Internal server error", 500);
+  }
+}

--- a/src/app/fame/creator/[address]/CreatorPortal.tsx
+++ b/src/app/fame/creator/[address]/CreatorPortal.tsx
@@ -135,6 +135,7 @@ export function CreatorPortal({
           />
         ) : (
           <MetadataSwap
+            address={address}
             selectedTokenId={Number(selectedTokenId)}
             burnPool={burnPool}
             nextArtPoolIndex={nextArtPoolIndex}

--- a/src/app/fame/creator/[address]/MetadataSwap.tsx
+++ b/src/app/fame/creator/[address]/MetadataSwap.tsx
@@ -1,14 +1,15 @@
 "use client";
-import { useState, useCallback } from "react";
+import { useState } from "react";
 import { useSwapMetadata } from "./useSwapMetadata";
 import { base } from "viem/chains";
 import { TransactionsModal, Transaction } from "@/components/TransactionsModal";
 import { SwapModeGrid } from "./SwapModeGrid";
 import { TokenPoolGrid } from "./TokenPoolGrid";
 import { SwapMode } from "./SwapModeToken";
-import MetadataIrysUploader from "@/components/MetadataIrysUploader";
+import { SponsoredCreatorMetadataUploader } from "./SponsoredCreatorMetadataUploader";
 
 interface MetadataSwapProps {
+  address: `0x${string}`;
   selectedTokenId: number;
   burnPool: Array<{ tokenId: number; uri: string }>;
   nextArtPoolIndex: number;
@@ -25,6 +26,7 @@ interface MetadataSwapProps {
 }
 
 export function MetadataSwap({
+  address,
   selectedTokenId,
   burnPool,
   nextArtPoolIndex,
@@ -59,17 +61,6 @@ export function MetadataSwap({
   const [showUploaderFor, setShowUploaderFor] = useState<
     null | "art" | "end" | "update"
   >(null);
-
-  const defaultTemplate = useCallback(
-    (imageUrl: string) =>
-      JSON.stringify({
-        name: `FAME Society #${selectedTokenId}`,
-        image: imageUrl,
-        description:
-          "Experience the innovative $FAME token from the Fame Lady Society, a DN404 project seamlessly integrating ERC20 and ERC721 standards. Each $FAME token is part of a revolutionary system where owning multiples of 1 million $FAME automatically mints a rare and exclusive Society NFT to your wallet. These NFTs, backed by 1 million $FAME tokens each, merge the worlds of liquidity and ownership, offering both stability and exclusivity.\n\nWhen you hold a Society NFT, you're not just an owner; you're part of a vibrant, empowering community dedicated to transparency, community governance, and women's empowerment in Web3. Selling any portion of the associated 1 million $FAME will cause the NFT to vanish, reflecting the unique balance of value and rarity within the Fame Lady Society ecosystem.\n\nThe Fame Lady Society, born from the pioneering all-female generative PFP project, continues to push boundaries by promoting true decentralization and sustainability. Fame Lady Society's mission is to transform Web3 into 'webWE,' ensuring every member has a voice in shaping the future. Join us in this exciting journey and redefine how NFTs and tokens can be traded and gamified.",
-      }),
-    [selectedTokenId],
-  );
 
   const handleSubmit = async () => {
     if (!swapMode) return;
@@ -219,10 +210,12 @@ export function MetadataSwap({
                   </button>
                   {showUploaderFor === "art" && (
                     <div className="mt-3">
-                      <MetadataIrysUploader
-                        template={defaultTemplate}
-                        onComplete={(txid) => {
-                          setArtPoolUrl(`https://gateway.irys.xyz/${txid}`);
+                      <SponsoredCreatorMetadataUploader
+                        address={address}
+                        tokenId={selectedTokenId}
+                        mode="art"
+                        onComplete={(metadataUri) => {
+                          setArtPoolUrl(metadataUri);
                           setShowUploaderFor(null);
                         }}
                       />
@@ -255,10 +248,12 @@ export function MetadataSwap({
                   </button>
                   {showUploaderFor === "end" && (
                     <div className="mt-3">
-                      <MetadataIrysUploader
-                        template={defaultTemplate}
-                        onComplete={(uri) => {
-                          setEndOfMintUrl(uri);
+                      <SponsoredCreatorMetadataUploader
+                        address={address}
+                        tokenId={selectedTokenId}
+                        mode="end"
+                        onComplete={(metadataUri) => {
+                          setEndOfMintUrl(metadataUri);
                           setShowUploaderFor(null);
                         }}
                       />
@@ -291,10 +286,12 @@ export function MetadataSwap({
                   </button>
                   {showUploaderFor === "update" && (
                     <div className="mt-3">
-                      <MetadataIrysUploader
-                        template={defaultTemplate}
-                        onComplete={(txid) => {
-                          setUpdateMetadataUrl(txid);
+                      <SponsoredCreatorMetadataUploader
+                        address={address}
+                        tokenId={selectedTokenId}
+                        mode="update"
+                        onComplete={(metadataUri) => {
+                          setUpdateMetadataUrl(metadataUri);
                           setShowUploaderFor(null);
                         }}
                       />

--- a/src/app/fame/creator/[address]/SponsoredCreatorMetadataUploader.tsx
+++ b/src/app/fame/creator/[address]/SponsoredCreatorMetadataUploader.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useId, useState } from "react";
+import { withAuthHeaders } from "@/utils/authToken";
+import type { CreatorMetadataUploadMode } from "@/features/fame/creatorMetadata";
+import { useSIWE } from "connectkit";
+
+type SponsoredCreatorMetadataUploaderProps = {
+  address: `0x${string}`;
+  tokenId: number;
+  mode: CreatorMetadataUploadMode;
+  onComplete: (metadataUri: string) => void;
+};
+
+type UploadState = "idle" | "uploading" | "done" | "error";
+
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+const SUPPORTED_IMAGE_TYPES = new Set([
+  "image/gif",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+]);
+
+export function SponsoredCreatorMetadataUploader({
+  address,
+  tokenId,
+  mode,
+  onComplete,
+}: SponsoredCreatorMetadataUploaderProps) {
+  const inputId = useId();
+  const { isSignedIn, signIn } = useSIWE();
+  const [file, setFile] = useState<File | null>(null);
+  const [state, setState] = useState<UploadState>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [imageUri, setImageUri] = useState<string | null>(null);
+  const [metadataUri, setMetadataUri] = useState<string | null>(null);
+
+  const isUploading = state === "uploading";
+
+  const handleUpload = async () => {
+    if (!file || isUploading) return;
+    if (!isSignedIn) {
+      setState("error");
+      setError("Sign in with Ethereum before uploading metadata.");
+      return;
+    }
+
+    if (!SUPPORTED_IMAGE_TYPES.has(file.type)) {
+      setState("error");
+      setError("Choose a PNG, JPG, GIF, or WebP image.");
+      return;
+    }
+    if (file.size <= 0 || file.size > MAX_IMAGE_BYTES) {
+      setState("error");
+      setError("Choose an image smaller than 10 MB.");
+      return;
+    }
+
+    setState("uploading");
+    setError(null);
+    setImageUri(null);
+    setMetadataUri(null);
+
+    try {
+      const formData = new FormData();
+      formData.set("address", address);
+      formData.set("tokenId", String(tokenId));
+      formData.set("mode", mode);
+      formData.set("image", file);
+
+      const response = await fetch("/api/fame/creator/metadata", {
+        method: "POST",
+        headers: withAuthHeaders(),
+        body: formData,
+      });
+
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(
+          `Sponsored upload failed: ${response.status} ${text}`,
+        );
+      }
+
+      const data = (await response.json()) as {
+        imageUri: string;
+        metadataUri: string;
+      };
+
+      setImageUri(data.imageUri);
+      setMetadataUri(data.metadataUri);
+      setState("done");
+      onComplete(data.metadataUri);
+    } catch (err) {
+      setState("error");
+      setError(err instanceof Error ? err.message : "Sponsored upload failed");
+    }
+  };
+
+  return (
+    <div className="rounded-md border border-gray-200 bg-white/60 p-3">
+      <div className="space-y-3">
+        <div>
+          <label htmlFor={inputId} className="block text-sm font-medium mb-2">
+            Image for generated metadata
+          </label>
+          <input
+            id={inputId}
+            type="file"
+            accept="image/png,image/jpeg,image/gif,image/webp"
+            disabled={isUploading}
+            onChange={(event) => {
+              setFile(event.currentTarget.files?.[0] ?? null);
+              setState("idle");
+              setError(null);
+              setImageUri(null);
+              setMetadataUri(null);
+            }}
+            className="block w-full text-sm text-gray-700 file:mr-3 file:rounded file:border-0 file:bg-indigo-600 file:px-3 file:py-2 file:text-sm file:font-medium file:text-white hover:file:bg-indigo-700 disabled:opacity-60"
+          />
+        </div>
+
+        <div className="flex items-center gap-3">
+          {!isSignedIn && (
+            <button
+              type="button"
+              onClick={() => signIn?.()}
+              disabled={isUploading}
+              className="rounded bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
+            >
+              Sign in
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={handleUpload}
+            disabled={!file || isUploading || !isSignedIn}
+            className="rounded bg-green-600 px-3 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
+          >
+            {isUploading ? "Uploading..." : "Generate metadata URI"}
+          </button>
+          <span className="text-sm text-gray-600">
+            {state === "idle" &&
+              (isSignedIn
+                ? "Backend sponsors image and metadata upload."
+                : "Sign in to upload generated metadata.")}
+            {state === "uploading" && "Uploading image, then metadata."}
+            {state === "done" && "Metadata URI ready."}
+            {state === "error" && "Upload failed."}
+          </span>
+        </div>
+
+        {error && (
+          <p className="rounded border border-red-200 bg-red-50 p-2 text-sm text-red-700">
+            {error}
+          </p>
+        )}
+
+        {imageUri && (
+          <div className="text-sm">
+            <div className="text-xs text-gray-500">Image URI</div>
+            <div className="break-words text-gray-800">{imageUri}</div>
+          </div>
+        )}
+        {metadataUri && (
+          <div className="text-sm">
+            <div className="text-xs text-gray-500">Metadata URI</div>
+            <div className="break-words text-gray-800">{metadataUri}</div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/fame/creator/[address]/useHasCreatorRole.ts
+++ b/src/app/fame/creator/[address]/useHasCreatorRole.ts
@@ -1,37 +1,16 @@
 "use client";
 
 import { creatorArtistMagicAddress } from "@/features/fame/contract";
+import {
+  decodeCreatorPortalRoles,
+  type CreatorPortalRoles,
+} from "@/features/fame/creatorMetadata";
 import { creatorArtistMagicAbi } from "@/wagmi";
 import { base } from "viem/chains";
 import { useReadContract } from "wagmi";
 
-// Role bit masks (OwnableRoles uses _ROLE_0 = 1 << 0, _ROLE_1 = 1 << 1, ...)
-const ROLE_CREATOR = 1n << 1n; // _ROLE_1
-const ROLE_BANISHER = 1n << 2n; // _ROLE_2
-const ROLE_ART_POOL_MANAGER = 1n << 3n; // _ROLE_3
-
-export type CreatorPortalRoles = {
-  isCreator: boolean;
-  isBanisher: boolean;
-  isArtPoolManager: boolean;
-  hasAnyRole: boolean;
-  raw: number;
-};
-
-export function decodeCreatorPortalRoles(roles?: bigint): CreatorPortalRoles {
-  const bitmask = roles ?? 0n;
-  const isCreator = (bitmask & ROLE_CREATOR) !== 0n;
-  const isBanisher = (bitmask & ROLE_BANISHER) !== 0n;
-  const isArtPoolManager = (bitmask & ROLE_ART_POOL_MANAGER) !== 0n;
-
-  return {
-    isCreator,
-    isBanisher,
-    isArtPoolManager,
-    hasAnyRole: isCreator || isBanisher || isArtPoolManager,
-    raw: Number(bitmask),
-  };
-}
+export { decodeCreatorPortalRoles };
+export type { CreatorPortalRoles };
 
 function redactUrl(rawUrl: string) {
   try {

--- a/src/app/fame/creator/layout.tsx
+++ b/src/app/fame/creator/layout.tsx
@@ -5,5 +5,5 @@ export default function CreatorLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return <DefaultProvider base>{children}</DefaultProvider>;
+  return <DefaultProvider base siwe>{children}</DefaultProvider>;
 }

--- a/src/features/fame/creatorMetadata.ts
+++ b/src/features/fame/creatorMetadata.ts
@@ -1,0 +1,59 @@
+export type CreatorMetadataUploadMode = "art" | "end" | "update";
+
+export type CreatorPortalRoles = {
+  isCreator: boolean;
+  isBanisher: boolean;
+  isArtPoolManager: boolean;
+  hasAnyRole: boolean;
+  raw: number;
+};
+
+const ROLE_CREATOR = 1n << 1n;
+const ROLE_BANISHER = 1n << 2n;
+const ROLE_ART_POOL_MANAGER = 1n << 3n;
+
+export const CREATOR_METADATA_UPLOAD_MODES = ["art", "end", "update"] as const;
+
+export function isCreatorMetadataUploadMode(
+  mode: unknown,
+): mode is CreatorMetadataUploadMode {
+  return mode === "art" || mode === "end" || mode === "update";
+}
+
+export function decodeCreatorPortalRoles(roles?: bigint): CreatorPortalRoles {
+  const bitmask = roles ?? 0n;
+  const isCreator = (bitmask & ROLE_CREATOR) !== 0n;
+  const isBanisher = (bitmask & ROLE_BANISHER) !== 0n;
+  const isArtPoolManager = (bitmask & ROLE_ART_POOL_MANAGER) !== 0n;
+
+  return {
+    isCreator,
+    isBanisher,
+    isArtPoolManager,
+    hasAnyRole: isCreator || isBanisher || isArtPoolManager,
+    raw: Number(bitmask),
+  };
+}
+
+export function canUploadCreatorMetadata(
+  roles: CreatorPortalRoles,
+  mode: CreatorMetadataUploadMode,
+) {
+  switch (mode) {
+    case "art":
+      return roles.isCreator || roles.isArtPoolManager;
+    case "end":
+      return roles.isCreator || roles.isBanisher;
+    case "update":
+      return roles.isCreator;
+  }
+}
+
+export function createCreatorMetadataJson(tokenId: number, imageUrl: string) {
+  return JSON.stringify({
+    name: `FAME Society #${tokenId}`,
+    image: imageUrl,
+    description:
+      "Experience the innovative $FAME token from the Fame Lady Society, a DN404 project seamlessly integrating ERC20 and ERC721 standards. Each $FAME token is part of a revolutionary system where owning multiples of 1 million $FAME automatically mints a rare and exclusive Society NFT to your wallet. These NFTs, backed by 1 million $FAME tokens each, merge the worlds of liquidity and ownership, offering both stability and exclusivity.\n\nWhen you hold a Society NFT, you're not just an owner; you're part of a vibrant, empowering community dedicated to transparency, community governance, and women's empowerment in Web3. Selling any portion of the associated 1 million $FAME will cause the NFT to vanish, reflecting the unique balance of value and rarity within the Fame Lady Society ecosystem.\n\nThe Fame Lady Society, born from the pioneering all-female generative PFP project, continues to push boundaries by promoting true decentralization and sustainability. Fame Lady Society's mission is to transform Web3 into 'webWE,' ensuring every member has a voice in shaping the future. Join us in this exciting journey and redefine how NFTs and tokens can be traded and gamified.",
+  });
+}

--- a/src/service/irys_sponsored_upload.test.ts
+++ b/src/service/irys_sponsored_upload.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  computeBufferedIrysPrice,
+  ensureIrysBalance,
+  type IrysSponsoredUploader,
+} from "./irys_sponsored_upload";
+
+function fakeUploader(opts: {
+  price: bigint;
+  balances: bigint[];
+  onFund?: (amount: bigint) => void;
+}): IrysSponsoredUploader {
+  const balances = [...opts.balances];
+  return {
+    getPrice: async () => opts.price,
+    getBalance: async () => balances.shift() ?? balances.at(-1) ?? 0n,
+    fund: async (amount) => opts.onFund?.(amount),
+    upload: async () => ({ id: "txid" }),
+  };
+}
+
+describe("irys sponsored upload helpers", () => {
+  it("computes a 10% buffered price", () => {
+    assert.equal(computeBufferedIrysPrice(1000n), 1100n);
+  });
+
+  it("does not fund when the uploader has enough loaded balance", async () => {
+    let funded = 0n;
+    const result = await ensureIrysBalance({
+      uploader: fakeUploader({
+        price: 1000n,
+        balances: [1200n],
+        onFund: (amount) => {
+          funded += amount;
+        },
+      }),
+      bytes: 123,
+      maxFundAmount: 2000n,
+    });
+
+    assert.equal(funded, 0n);
+    assert.equal(result.loadedBalance, 1200n);
+  });
+
+  it("funds only the required buffered amount", async () => {
+    let funded = 0n;
+    const result = await ensureIrysBalance({
+      uploader: fakeUploader({
+        price: 1000n,
+        balances: [500n, 1100n],
+        onFund: (amount) => {
+          funded += amount;
+        },
+      }),
+      bytes: 123,
+      maxFundAmount: 2000n,
+    });
+
+    assert.equal(funded, 600n);
+    assert.equal(result.funded, 600n);
+    assert.equal(result.loadedBalance, 1100n);
+  });
+
+  it("does not partially fund when sponsor balance is below the required amount", async () => {
+    let funded = 0n;
+
+    await assert.rejects(
+      ensureIrysBalance({
+        uploader: fakeUploader({
+          price: 1000n,
+          balances: [500n],
+          onFund: (amount) => {
+            funded += amount;
+          },
+        }),
+        bytes: 123,
+        maxFundAmount: 599n,
+      }),
+      /Insufficient sponsor balance/,
+    );
+
+    assert.equal(funded, 0n);
+  });
+});

--- a/src/service/irys_sponsored_upload.ts
+++ b/src/service/irys_sponsored_upload.ts
@@ -10,7 +10,7 @@ export type IrysSponsoredUploader = {
   getBalance: () => Promise<unknown>;
   fund: (amount: bigint) => Promise<unknown>;
   upload: (
-    content: string | Uint8Array,
+    content: Buffer,
     opts: { tags: IrysUploadTag[] },
   ) => Promise<{ id?: string } | undefined>;
 };
@@ -79,7 +79,11 @@ export async function uploadToIrys(opts: {
   content: string | Uint8Array;
   tags: IrysUploadTag[];
 }) {
-  const result = await opts.uploader.upload(opts.content, { tags: opts.tags });
+  const uploadContent =
+    typeof opts.content === "string"
+      ? Buffer.from(opts.content)
+      : Buffer.from(opts.content);
+  const result = await opts.uploader.upload(uploadContent, { tags: opts.tags });
   const txid = result?.id;
   if (!txid) {
     throw new Error("Upload failed: no transaction ID returned");

--- a/src/service/irys_sponsored_upload.ts
+++ b/src/service/irys_sponsored_upload.ts
@@ -1,0 +1,88 @@
+import { formatEther } from "viem";
+
+export type IrysUploadTag = {
+  name: string;
+  value: string;
+};
+
+export type IrysSponsoredUploader = {
+  getPrice: (bytes: number) => Promise<unknown>;
+  getBalance: () => Promise<unknown>;
+  fund: (amount: bigint) => Promise<unknown>;
+  upload: (
+    content: string | Uint8Array,
+    opts: { tags: IrysUploadTag[] },
+  ) => Promise<{ id?: string } | undefined>;
+};
+
+export function toBigIntAmount(value: unknown): bigint {
+  if (typeof value === "bigint") return value;
+  if (typeof value === "number") return BigInt(value);
+  if (typeof value === "string") return BigInt(value);
+  const maybeString = value as { toString?: () => string } | null | undefined;
+  return BigInt(maybeString?.toString?.() ?? 0);
+}
+
+export function computeBufferedIrysPrice(price: bigint) {
+  return (price * 110n) / 100n;
+}
+
+export async function ensureIrysBalance(opts: {
+  uploader: IrysSponsoredUploader;
+  bytes: number;
+  maxFundAmount: bigint;
+  logContext?: Record<string, unknown>;
+}) {
+  const priceRaw = await opts.uploader.getPrice(opts.bytes);
+  const price = toBigIntAmount(priceRaw);
+  const bufferedPrice = computeBufferedIrysPrice(price);
+
+  const balanceRaw = await opts.uploader.getBalance();
+  let loadedBalance = toBigIntAmount(balanceRaw);
+  if (loadedBalance >= bufferedPrice) {
+    return { bufferedPrice, loadedBalance, funded: 0n };
+  }
+
+  const requiredAmount = bufferedPrice - loadedBalance;
+  if (opts.maxFundAmount < requiredAmount) {
+    throw new Error(
+      `Insufficient sponsor balance to fund Irys upload. Need ${formatEther(requiredAmount)} ETH.`,
+    );
+  }
+
+  const fundAmount = requiredAmount;
+  await opts.uploader.fund(fundAmount);
+  const refreshedBalance = toBigIntAmount(await opts.uploader.getBalance());
+  loadedBalance =
+    refreshedBalance > loadedBalance ? refreshedBalance : loadedBalance;
+
+  if (loadedBalance < bufferedPrice) {
+    throw new Error("Irys funding did not load enough balance for upload");
+  }
+
+  if (opts.logContext) {
+    console.log(
+      "[irys] sponsored funding complete",
+      JSON.stringify({
+        ...opts.logContext,
+        loaded: formatEther(loadedBalance),
+        funded: formatEther(fundAmount),
+      }),
+    );
+  }
+
+  return { bufferedPrice, loadedBalance, funded: fundAmount };
+}
+
+export async function uploadToIrys(opts: {
+  uploader: IrysSponsoredUploader;
+  content: string | Uint8Array;
+  tags: IrysUploadTag[];
+}) {
+  const result = await opts.uploader.upload(opts.content, { tags: opts.tags });
+  const txid = result?.id;
+  if (!txid) {
+    throw new Error("Upload failed: no transaction ID returned");
+  }
+  return `https://gateway.irys.xyz/${txid}`;
+}


### PR DESCRIPTION
## Summary

FAME Creator Portal users can now generate metadata from an image without personally funding Irys uploads. The creator flow signs users in with SIWE, verifies CreatorArtistMagic roles again on the server, uploads both the image and generated metadata through the sponsored backend path, and returns a final metadata gateway URI for the existing creator contract writes.

## What changed

- Added a SIWE-protected `/api/fame/creator/metadata` route that validates the requested creator address, mode-specific CreatorArtistMagic permissions, image type/size, and sponsored Irys upload funding before returning `{ imageUri, metadataUri }`.
- Replaced the creator metadata swap image uploader with a focused sponsored upload control that includes a sign-in CTA when SIWE is missing and always fills swap fields with the final metadata URI.
- Moved creator role decoding and generated metadata construction into shared helpers so the client gate and server authorization use the same role bitmask and metadata shape.
- Added reusable sponsored Irys funding/upload helpers with focused tests for buffered pricing, no-op funding, required funding, and sponsor-balance failure behavior.

## Validation

- `bun test src/service/irys_sponsored_upload.test.ts 'src/app/fame/creator/[address]/useHasCreatorRole.test.ts' src/app/api/fame/creator/metadata/route.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `yarn lint`

`yarn lint` still reports the existing unrelated warnings in `src/app/[network]/profile/image/[tokenId]/route.tsx`.

## Post-Deploy Monitoring & Validation

- Watch application logs for `/api/fame/creator/metadata`, `[irys] sponsored funding complete`, `creator-image`, and `creator-metadata`.
- Watch Sentry for exceptions from `src/app/api/fame/creator/metadata/route.ts`, especially Irys funding/upload failures, missing `METADATA_PRIVATE_KEY`, and Base role-read failures.
- Healthy signal: creator wallets with the correct role can sign in, upload a PNG/JPG/GIF/WebP under 10 MB, receive `https://gateway.irys.xyz/...` image and metadata URIs, and proceed to the existing CreatorArtistMagic transaction.
- Failure signals: elevated 500s on the creator metadata route, valid creator wallets receiving unexpected 403s, repeated sponsor-balance errors, or metadata fields being populated with raw transaction ids instead of gateway URIs.
- Validation window: first creator upload after deploy plus 24 hours of route/Sentry log monitoring. Owner: FLS web deploy operator.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
